### PR TITLE
Remove Reddit link

### DIFF
--- a/main.md
+++ b/main.md
@@ -21,8 +21,8 @@ navmode: navbar
         <p><a href="#learn">Learn more</a>, or <a href="/docs">jump to the technical docs</a>.  And subscribe to our newsletter:</p>
         <email dataPath="/submit" submit="Get updates"></email>
         <p class="social">
-        You can also find us on:
-        <a href="https://github.com/urbit/urbit">GitHub</a>,&#32;&#32; <a href="https://reddit.com/r/urbit">Reddit</a>, and <a href="https://twitter.com/urbit_">Twitter</a>.
+        You can also find us on
+        <a href="https://github.com/urbit/urbit">GitHub</a>&#32;&#32; and <a href="https://twitter.com/urbit_">Twitter</a>.
         </p>        
     </div>
 </div>


### PR DESCRIPTION
We should be directing people to `:fora` now.