### PR TITLE
Re-enable stream

### DIFF
--- a/main/stream.md
+++ b/main/stream.md
@@ -8,11 +8,22 @@ navclass: urbit
 navhome: /
 ---
 
-# Stream
+# Live from `~marzod`
 
-_**Update: `~2017.12.7` continuity breach:**_
+This is a live feed from `urbit-meta`, running on `~marzod`, one of `2^16` Urbit stars.  We use `urbit-meta` to chat, coordinate and build Urbit.
 
-Stream is temporarily disabled. We're fixing a bug with new web Talk. 
+To try running an Urbit, head to [the install docs](https://urbit.org/docs/using/install/) to get set up.
 
-We'll post to Fora when it's back up. Thanks!
+*Be warned: this chat gateway can be pretty slow when traffic spikes.*
 
+<div class="mini-module talk-stream">
+<script src="/~/at/=home=/web/lib/js/urb.js" />
+<script src="https://cdn.rawgit.com/seatgeek/react-infinite/0.8.0/dist/react-infinite.js" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.11.2/moment-with-locales.js" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.1/moment-timezone.js" />
+<script src="/=home=/web/talk/main.js" />
+<link href="/=home=/web/talk/main.css" rel="stylesheet" />
+<talk chrono="reverse" station="stream" audience-lock default-glyph="=">
+  <load />
+</talk>
+</div>


### PR DESCRIPTION
Includes a few tiny changes compared to the original stream.md, namely:

- Say `urbit-meta` as the channel name, instead of `/urbit-meta`.
- Link to the install docs instead of the urbit/urbit repo that tells you to go to the install docs.
- Relay station is now `stream` instead of `home`, as facilitated by urbit/arvo#494 and urbit/arvo-ops-branches#1.