### PR TITLE
fixes inconsistent language

### DIFF
--- a/static-site/primer.hoon
+++ b/static-site/primer.hoon
@@ -492,7 +492,7 @@
           ;>
             Arvo is a general-purpose computer that runs as a virtual machine. You can think of it as an overlay OS; it treats Unix the way Unix treats the BIOS.
 
-            Its behavior is completely defined by a frozen transition function called Nock that goes from `[event, current-state]` to `[actions, next-state]`. An event might be a keypress, an HTTP request, or a UDP message from another Arvo. An effect might be a command to the Unix terminal, an HTTP response, or another UDP message to another Arvo.
+            Its behavior is completely defined by a frozen transition function called Nock that goes from `[event, current-state]` to `[effects, next-state]`. An event might be a keypress, an HTTP request, or a UDP message from another Arvo. An effect might be a command to the Unix terminal, an HTTP response, or another UDP message to another Arvo.
 
             Arvo consists of the following stack of components, from the bottom up.
 


### PR DESCRIPTION
We use both "effects" and "actions" to describe the same thing. This change keeps it consistent.