### PR TITLE
adds introduction material

### DIFF
--- a/static-site/docs.udon
+++ b/static-site/docs.udon
@@ -1,13 +1,55 @@
-:-  :~  navhome/'/docs/'
-        navuptwo/'true'
-        next/'true'
-        sort/'1'
-        title/'Technical overview'
-    ==
-;>
+1 :-  :~  navhome/'/docs/'
+2         navuptwo/'true'
+3         next/'true'
+4         sort/'1'
+5         title/'Introduction'
+6     ==
+7 ;>
 
 # Docs
 
-Welcome to the documentation for the Urbit project, including the Azimuth identity layer, the Arvo operating system, and the Hoon programming language. This documentation is maintained by [Tlon](https://tlon.io) in a public [Github repository](https://github.com/urbit/docs). Issues and contributions are welcome.
+Welcome to the documentation for the Urbit project, including the Azimuth identity layer, the Arvo operating system, and the Hoon programming language. This documentation is maintained by [Tlon](https://tlon.io) in a public [GitHub repository](https://github.com/urbit/docs). Issues and contributions are welcome.
 
-Please make your way to the [Introduction](docs/introduction) for an overview of the docs.
+The documentation is organized into four high-level sections. Read on to get acquainted.
+
+## [Getting Started](/docs/getting-started)
+
+If you'd like to install Arvo, get an Azimuth point, and/or get on the Urbit network, you'll find guides here. Dive in, and don't be afraid to [ask for help](mailto:support@urbit.org)!
+
+The three pages below are meant to be followed in order.
+
+- The [Bridge section](/docs/getting-started/azimuth) is the first step. It tells you how to access your Azimuth identity using our client.
+- The [guide to installing Urbit](/docs/getting-started/installing-urbit) is the second step. It tells you how to get our software on your machine.
+- The [guide to booting a ship](/docs/getting-started/booting-a-ship) is the third and final step. It walks you through using what you did in the previous steps to get onto the Arvo network.
+
+In addition to those primary pages, the documents below are helpful but optional for using Urbit.
+
+- [Creating a Development Ship](/docs/getting-started/creating-a-development-ship), a walkthrough for creating an unnetworked a a platform for coding.
+- [Operating a Star](/docs/getting-started/creating-a-development-ship)
+
+## [Concepts](/docs/concepts)
+
+If you're looking for a high-level introduction to the Urbit project and its components, start here.
+
+- [Arvo vs. Azimuth](/docs/introduction/arvo-vs-azimuth), a quick explanation of the two parallel systems that compose Urbit.
+- [Technical Overview](/docs/introduction/technical-overview), a more in-depth description of the entire Urbit stack.
+- [Contributing](/docs/introduction/contributing), a guide to getting involved with the Urbit project.
+- [Community Tutorials](/docs/introduction/community-tutorials), a collection of unofficial but useful Urbit learning resources.
+- [Source Code](/docs/introduction/source-code-overview), an explanation of Urbit's constituent GitHub repos.
+- [Galaxies, Stars, and Planets](/docs/introduction/galaxies-stars-and-planets), an explanation of the Urbit address-space hierarchy.
+
+## [Learn](/docs/learn)
+
+If you're interested in contributing to the project, building applications, or understanding the system technically, take a look at our tutorials and explanations of the Urbit components.
+
+- [The Hoon Tutorial](/docs/learn/arvo/hoon), for our programming language. To learn the system, start here.
+- [The Arvo section](/docs/learn/arvo), for the internals of Arvo, the Urbit operating system.
+
+## [Reference](/docs/reference)
+
+If you're a developer looking for Arvo reference documentation, this section is for you.
+
+- [The Glossary](/docs/reference/glossary) will help if you're confused by all the new jargon.
+- [The Cheat Sheet](/docs/reference/cheat-sheet) is a compact document for looking up Hoon expressions.
+- [The Hoon Expressions](/docs/reference/hoon-expressions) section contains more comprehensive reference material for Hoon expressions.
+- [The Standard Library](/docs/reference/library) section documents the Hoon standard library.

--- a/static-site/docs.udon
+++ b/static-site/docs.udon
@@ -24,7 +24,7 @@ The three pages below are meant to be followed in order.
 
 In addition to those primary pages, the documents below are helpful but optional for using Urbit.
 
-- [Creating a Development Ship](/docs/getting-started/creating-a-development-ship), a walkthrough for creating an unnetworked a a platform for coding.
+- [Creating a Development Ship](/docs/getting-started/creating-a-development-ship), a walkthrough for creating a walkthrough for creating a disposable ship, disconnected from the Arvo network, for hacking on Urbit, developing applications, and learning.
 - [Operating a Star](/docs/getting-started/creating-a-development-ship)
 
 ## [Concepts](/docs/concepts)
@@ -35,21 +35,21 @@ If you're looking for a high-level introduction to the Urbit project and its com
 - [Technical Overview](/docs/introduction/technical-overview), a more in-depth description of the entire Urbit stack.
 - [Contributing](/docs/introduction/contributing), a guide to getting involved with the Urbit project.
 - [Community Tutorials](/docs/introduction/community-tutorials), a collection of unofficial but useful Urbit learning resources.
-- [Source Code](/docs/introduction/source-code-overview), an explanation of Urbit's constituent GitHub repos.
-- [Galaxies, Stars, and Planets](/docs/introduction/galaxies-stars-and-planets), an explanation of the Urbit address-space hierarchy.
+- [Source Code](/docs/introduction/source-code-overview), an explanation of Urbit's constituent GitHub repositories.
+- [Galaxies, Stars, and Planets](/docs/introduction/galaxies-stars-and-planets), an explanation of the Azimuth address-space hierarchy.
 
 ## [Learn](/docs/learn)
 
-If you're interested in contributing to the project, building applications, or understanding the system technically, take a look at our tutorials and explanations of the Urbit components.
+If you're interested in contributing to the project, building applications, or understanding the system technically, take a look at our tutorials and explanations of Urbit's components.
 
-- [The Hoon Tutorial](/docs/learn/arvo/hoon), for our programming language. To learn the system, start here.
-- [The Arvo section](/docs/learn/arvo), for the internals of Arvo, the Urbit operating system.
+- [The Hoon Tutorial](/docs/learn/hoon), for our programming language. To learn the system, start here.
+- [The Arvo section](/docs/learn/arvo), for the internals of Arvo, Urbit's operating system.
 
 ## [Reference](/docs/reference)
 
 If you're a developer looking for Arvo reference documentation, this section is for you.
 
-- [The Glossary](/docs/reference/glossary) will help if you're confused by all the new jargon.
-- [The Cheat Sheet](/docs/reference/cheat-sheet) is a compact document for looking up Hoon expressions.
-- [The Hoon Expressions](/docs/reference/hoon-expressions) section contains more comprehensive reference material for Hoon expressions.
-- [The Standard Library](/docs/reference/library) section documents the Hoon standard library.
+- The [Glossary](/docs/reference/glossary) will help if you're confused by all the new jargon.
+- The [Cheat Sheet](/docs/reference/cheat-sheet) is a compact document for looking up Hoon expressions.
+- The [Hoon Expressions](/docs/reference/hoon-expressions) section contains more comprehensive reference material for Hoon expressions.
+- The [Standard Library](/docs/reference/library) section documents the Hoon standard library.

--- a/static-site/docs.udon
+++ b/static-site/docs.udon
@@ -10,7 +10,7 @@
 
 Welcome to the documentation for the Urbit project, including the Azimuth identity layer, the Arvo operating system, and the Hoon programming language. This documentation is maintained by [Tlon](https://tlon.io) in a public [GitHub repository](https://github.com/urbit/docs). Issues and contributions are welcome.
 
-The documentation is organized into four high-level sections. Read on to get acquainted.
+The documentation is organized into five high-level sections. Read on to get acquainted.
 
 ## [Getting Started](/docs/getting-started)
 
@@ -27,23 +27,38 @@ In addition to those primary pages, the documents below are helpful but optional
 - [Creating a Development Ship](/docs/getting-started/creating-a-development-ship), a walkthrough for creating a walkthrough for creating a disposable ship, disconnected from the Arvo network, for hacking on Urbit, developing applications, and learning.
 - [Operating a Star](/docs/getting-started/creating-a-development-ship)
 
+## [Using](/docs/using)
+
+Here live guides that are helpful for everyday users.
+
+- [Admin and Operation](/using/admin) is a guide to the basic commands used to interact with your ship.
+- [Messaging](/using/messaging) tells you how to use Talk, our chat system.
+- [Shell](/using/shell) is a guide to using Dojo, our command-line interface.
+- [Introduction to the Filesystem](/using/filesystem) explains the basics of using use Clay, our revision-control filesystem.
+- [Source Layout](/using/layout) walks you through the various directories of the Arvo operating system.
+- [Sail](/using/sail) is a guide to Sail: Hoon markup that's used to build web pages with XML.
+- [Udon](/using/udon) is a guide to Udon, which is our take on Markdown.
+- [Generators](/using/generators) will explain how to use the "generator," a kind of file that's the easiest way to run Hoon programs.
+
 ## [Concepts](/docs/concepts)
 
 If you're looking for a high-level introduction to the Urbit project and its components, start here.
 
-- [Arvo vs. Azimuth](/docs/introduction/arvo-vs-azimuth), a quick explanation of the two parallel systems that compose Urbit.
-- [Technical Overview](/docs/introduction/technical-overview), a more in-depth description of the entire Urbit stack.
-- [Contributing](/docs/introduction/contributing), a guide to getting involved with the Urbit project.
-- [Community Tutorials](/docs/introduction/community-tutorials), a collection of unofficial but useful Urbit learning resources.
-- [Source Code](/docs/introduction/source-code-overview), an explanation of Urbit's constituent GitHub repositories.
-- [Galaxies, Stars, and Planets](/docs/introduction/galaxies-stars-and-planets), an explanation of the Azimuth address-space hierarchy.
+- [Arvo vs. Azimuth](/docs/concepts/arvo-vs-azimuth), a quick explanation of the two parallel systems that compose Urbit.
+- [Technical Overview](/docs/concepts/technical-overview), a more in-depth description of the entire Urbit stack.
+- [Contributing](/docs/concepts/contributing), a guide to getting involved with the Urbit project.
+- [Community Tutorials](/docs/concepts/community-tutorials), a collection of unofficial but useful Urbit learning resources.
+- [Source Code](/docs/concepts/source-code-overview), an explanation of Urbit's constituent GitHub repositories.
+- [Galaxies, Stars, and Planets](/docs/concepts/galaxies-stars-and-planets), an explanation of the Azimuth address-space hierarchy.
 
 ## [Learn](/docs/learn)
 
 If you're interested in contributing to the project, building applications, or understanding the system technically, take a look at our tutorials and explanations of Urbit's components.
 
-- [The Hoon Tutorial](/docs/learn/hoon), for our programming language. To learn the system, start here.
-- [The Arvo section](/docs/learn/arvo), for the internals of Arvo, Urbit's operating system.
+- The [Hoon section](/docs/learn/hoon), for resources on learning our programming language. To understand the system, start here.
+- The [Arvo section](/docs/learn/arvo), for the internals of Arvo, Urbit's operating system.
+- The [Nock section](/docs/learn/nock), for learning Nock, Urbit's low-level language.
+- The [Vere section](/docs/learn/vere), for learning about Vere, the virtual machine that runs on Unix.
 
 ## [Reference](/docs/reference)
 


### PR DESCRIPTION
urbit.org/docs site no longer redirects to urbit.org/docs/introduction (because that's now "concepts.udon"), so I tweaked the contents and moved them here.