### PR TITLE
~rovnys-ricfer instead of ~rovnys-ricfur

### DIFF
--- a/content/posts/2019-5-17-update.md
+++ b/content/posts/2019-5-17-update.md
@@ -9,7 +9,7 @@ posts = ["Updates"]
 
 ![](https://media.urbit.org/site/posts/updates/~2019.5.17-update-1.png)
 
-**Ted** `~rovnys-ricfur` and **Philip** `~wicdev-wisryt` continued work on new `%ames` in the [aloe](https://github.com/urbit/arvo/tree/aloe) branch, **Elliot** `~littel-ponnys` has been designing a new, multi-process Arvo, known as "nuevo," and implementing primitives for ring signatures in Arvo, **Joe** `~master-morzod` finalized cc-release and started toward finishing new `%eyre`, ongoing in the [lighter-than-eyre](https://github.com/urbit/urbit/tree/lighter-than-eyre) branch, and **Mark** `~palfun-foslup` pushed [Bridge v1.4.1](https://github.com/urbit/bridge/releases).
+**Ted** `~rovnys-ricfer` and **Philip** `~wicdev-wisryt` continued work on new `%ames` in the [aloe](https://github.com/urbit/arvo/tree/aloe) branch, **Elliot** `~littel-ponnys` has been designing a new, multi-process Arvo, known as "nuevo," and implementing primitives for ring signatures in Arvo, **Joe** `~master-morzod` finalized cc-release and started toward finishing new `%eyre`, ongoing in the [lighter-than-eyre](https://github.com/urbit/urbit/tree/lighter-than-eyre) branch, and **Mark** `~palfun-foslup` pushed [Bridge v1.4.1](https://github.com/urbit/bridge/releases).
 
 In other news, the **Interface Team** started a [Twitter account](https://twitter.com/urbitwip) to share work in progress, there's been lively discussion on [urbit-dev](https://groups.google.com/a/urbit.org/forum/#!forum/dev), and we published [a roadmap](https://urbit.org/posts/2019-5-roadmap/).
 


### PR DESCRIPTION
Because ~rovnys-ricfur is a valid `@p`, @belisarius222 might want his contributions to be associated with his real identity