### PR TITLE
Minor improvements to the grants post

### DIFF
--- a/content/posts/urbit-grants-and-mid-2019-gifts.md
+++ b/content/posts/urbit-grants-and-mid-2019-gifts.md
@@ -37,8 +37,6 @@ As always, we much prefer to talk about working code as opposed to unfinished wo
 
 Making the process of rewarding contributors is something we’ve thought a lot about over the past few months. We’ve come up with a system that we like, and are hoping to put it up later this summer. It’s probably not perfect, but it’s a step in the right direction. We’ll be able to properly engage in a grant proposal process, post bounties as well as reward people directly with prizes.
 
-Again, we prefer to talk about working code instead of future potential — so there’s not much more to say. We’ll say much more later this summer and look forward to hearing your feedback. 
-
 Please [subscribe to our newsletter](http://eepurl.com/b7x7hj) to make sure you receive future announcements.
 
 – **Galen** `~ravmel-ropdyl` & **Alex** `~mignyt-mogseb`

--- a/content/posts/urbit-grants-and-mid-2019-gifts.md
+++ b/content/posts/urbit-grants-and-mid-2019-gifts.md
@@ -27,7 +27,7 @@ That is, our winners from the past nine months:
 - John `~dirwex-dosrev` [@jfranklin9000](https://github.com/jfranklin9000)
 - Assaf `~rophex-hashes` [@asssaf](https://github.com/asssaf)
 
-**Pyry** has been a [regular contributor](https://github.com/urbit/bridge/graphs/contributors) to Bridge over the past few months, **John** has been consistently picking up [changes all over the place](https://github.com/jfranklin9000), and **Assaf** found a [security issue](https://github.com/urbit/urbit-key-generation/issues/55) with our hierarchical wallet. 
+**Pyry** has been a [regular contributor](https://github.com/urbit/bridge/pulls?utf8=%E2%9C%93&q=author%3Apkova) to Bridge over the past few months, **John** has been consistently picking up changes [all](https://github.com/urbit/urbit/pulls?utf8=%E2%9C%93&q=author%3Ajfranklin9000) [over](https://github.com/urbit/arvo/pulls?utf8=%E2%9C%93&q=author%3Ajfranklin9000) [the place](https://github.com/urbit/docs/pulls?utf8=%E2%9C%93&q=author%3Ajfranklin9000), and **Assaf** found a [security issue](https://github.com/urbit/urbit-key-generation/issues/55) with our hierarchical wallet. 
 
 Thanks to all of you for helping bring Urbit to life. We don’t make it nearly easy enough to contribute, but all of you clawed your way in and made the system better. Thank you!
 

--- a/content/posts/urbit-grants-and-mid-2019-gifts.md
+++ b/content/posts/urbit-grants-and-mid-2019-gifts.md
@@ -19,7 +19,7 @@ That is, our winners from the past nine months:
 - Ben `~mirfet-hocbyt` [@bencalder](https://github.com/bencalder)
 - Max `~ladres-forfex` [@max19](https://github.com/max19)
 
-**~mirfet-hocbyt** discovered the bug in our @p rendering algorithm, nicknamed “the @pocalypse” around the office, and led to a few nights of lost sleep. It was a fantastic find, which was then resolved by **Max** with one of the greatest GitHub comments of all time: “[curious if this works](https://github.com/urbit/arvo/issues/1105#issuecomment-472585937).”
+**Ben** discovered the bug in our @p rendering algorithm, nicknamed “the @pocalypse” around the office, and led to a few nights of lost sleep. It was a fantastic find, which was then resolved by **Max** with one of the greatest GitHub comments of all time: “[curious if this works](https://github.com/urbit/arvo/issues/1105#issuecomment-472585937).”
 
 **Bronze: 1 star**
 

--- a/content/posts/urbit-grants-and-mid-2019-gifts.md
+++ b/content/posts/urbit-grants-and-mid-2019-gifts.md
@@ -37,7 +37,7 @@ As always, we much prefer to talk about working code as opposed to unfinished wo
 
 Making the process of rewarding contributors is something we’ve thought a lot about over the past few months. We’ve come up with a system that we like, and are hoping to put it up later this summer. It’s probably not perfect, but it’s a step in the right direction. We’ll be able to properly engage in a grant proposal process, post bounties as well as reward people directly with prizes.
 
-As always, we prefer to talk about working code instead of future potential — so there’s not much more to say. We’ll say much more later this summer and look forward to hearing your feedback. 
+Again, we prefer to talk about working code instead of future potential — so there’s not much more to say. We’ll say much more later this summer and look forward to hearing your feedback. 
 
 Please [subscribe to our newsletter](http://eepurl.com/b7x7hj) to make sure you receive future announcements.
 


### PR DESCRIPTION
Does what is says in the commit messages.

For the contributions, I think it's better to link to the lists of their PRs, since that's more permanent, and more interesting/useful to look at than just their profile/some graphs.