### PR TITLE
Adding page titles to all templates (#99)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,7 @@
     <meta name="author" content="{{ config.extra.author.name }}">
     <link rel="icon" type="image/png" href="/images/favicon.ico" />
     <link rel="alternative" type="application/rss+xml" title="Urbit RSS" href="/rss.xml" />
-    <title>{{ config.title }}</title>
+    <title>{% block title %}{% endblock title %} - {{ config.title }}</title>
     <!-- stylesheets -->
     <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
     <style type="text/css">

--- a/templates/doc.html
+++ b/templates/doc.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-
+{% block title %} {{ page.title }} {% endblock title %}
 {% block content %}
 <!-- header -->
 {% include "partials/navigation.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-
+{% block title %} {{ section.title }} {% endblock title %}
 {% block content %}
 <div class="wrapper">
   <div class="container">

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-
+{% block title %} {{ page.title }} {% endblock title %}
 {% block content %}
 <!-- header -->
 {% include "partials/navigation.html" %}

--- a/templates/posts/list.html
+++ b/templates/posts/list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-
+{% block title %} Posts {% endblock title %}
 {% block content %}
 <!-- header -->
 {% include "partials/navigation.html" %}

--- a/templates/posts/single.html
+++ b/templates/posts/single.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-
+{% block title %} {{ term.name }} {% endblock title %}
 {% block content %}
 <!-- header -->
 {% include "partials/navigation.html" %}

--- a/templates/primer.html
+++ b/templates/primer.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="{{ config.description }}">
   <meta name="author" content="{{ config.extra.author.name }}">
-  <title>{{ config.title }}</title>
+  <title>Primer - {{ config.title }}</title>
   <!-- stylesheets -->
   <link rel="stylesheet" href="{{ config.base_url }}/styles.css" >
   <link rel="stylesheet" href="{{ config.base_url }}/primer.css" >

--- a/templates/sections/docs.html
+++ b/templates/sections/docs.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-
+{% block title %} {{ section.title }} {% endblock title %}
 {% block content %}
 <!-- header -->
 {% include "partials/navigation.html" %}

--- a/templates/sections/docs/chapters.html
+++ b/templates/sections/docs/chapters.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-
+{% block title %} {{ section.title }} {% endblock title %}
 {% block content %}
 <!-- header -->
 {% include "partials/navigation.html" %}


### PR DESCRIPTION
Addresses #99 by adding page titles to all templates — subbing in "section" and "page" variables where necessary in child templates and adding a block in the parent template. It appears to function correctly in my own testing.

Additionally the format is, for example, `Docs - Urbit`, to be as readable as possible. It can be changed if there's a preference for the styling of the title breadcrumb, of course.