### PR TITLE
Add proper iOS docs scroll behaviour

### DIFF
--- a/sass/_responsive.scss
+++ b/sass/_responsive.scss
@@ -42,6 +42,7 @@
     .header {
       &__navigation {
         overflow-y: scroll;
+        -webkit-overflow-scrolling: touch;
       }
     }
   }
@@ -57,6 +58,7 @@
       padding: 0 (4rem / 4);
       background: white;
       overflow-y: scroll;
+      -webkit-overflow-scrolling: touch;
     }
     .content-nav {
       display: block;


### PR DESCRIPTION
Addresses urbit/operators.urbit.org#45 by adding `-webkit-overflow-scrolling: touch;` to the responsive navigation's SCSS.