### PR TITLE
Night mode site theme

### DIFF
--- a/sass/_night.scss
+++ b/sass/_night.scss
@@ -1,0 +1,16 @@
+@media screen and (prefers-color-scheme: dark) {
+    body.bg-white {
+        background: #000000;
+        color: #fff;
+        a {
+            color: #fff;
+        }
+    }
+    .bg-black {
+        background: #fff;
+        color: #000000;
+    }
+    .header__nav-icon:before, .header__nav-icon:after {
+        background: #fff;
+    }
+}

--- a/sass/styles.scss
+++ b/sass/styles.scss
@@ -1,3 +1,4 @@
 // custom
 @import "main";
 @import "responsive";
+@import "night"


### PR DESCRIPTION
Using the [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) media query, adds SCSS to check if the browser or OS prefers night mode. If so, it replaces the site with a white-on-black theme. See pictured:

<img width="1718" alt="Screen Shot 2019-07-02 at 2 36 39 AM" src="https://user-images.githubusercontent.com/20846414/60489762-1e000280-9c73-11e9-8de7-f9f46aecbc95.png">

How pleasant!

## The good

- Prefers-color-scheme is supported in Chrome, Firefox, and Safari (so most people). The others will just get the site as usual. Progressive enhancement, etc.

## The bad

- This implementation really isn't scalable if the site is going to change in a drastic way in future. It's simple, hardcoded and repeats values from the base theme in new locations (violating DRY), and even worse, overwrites classes like `bg-white` and `bg-black`. This would get confusing quickly. 

A better implementation would be having both versions of the site reassigning $background and $text variables, but it involves dancing with indigo; alternatively, outside of SCSS, adding and replacing our bg classes using JS (which is totally possible — just seems unwieldy in comparison, less seamless).

Because of the 'bad' section I understand if this PR should just be closed — and, after all, it was a quick experiment — but in any case the deploy preview should let you see the potential upsides, too. Let me know what you think.