### PR TITLE
Disabling URL encoding of permalinks in RSS feed

### DIFF
--- a/templates/rss.xml
+++ b/templates/rss.xml
@@ -2,7 +2,7 @@
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
         <title>{{ config.title }}</title>
-        <link>{{ config.base_url | urlencode | safe }}</link>
+        <link>{{ config.base_url | safe }}</link>
         <description>{{ config.description }}</description>
         <generator>Zola</generator>
         <language>{{ config.default_language }}</language>

--- a/templates/rss.xml
+++ b/templates/rss.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+        <title>{{ config.title }}</title>
+        <link>{{ config.base_url | urlencode | safe }}</link>
+        <description>{{ config.description }}</description>
+        <generator>Zola</generator>
+        <language>{{ config.default_language }}</language>
+        <atom:link href="{{ feed_url | safe }}" rel="self" type="application/rss+xml"/>
+        <lastBuildDate>{{ last_build_date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
+        {% for page in pages %}
+            <item>
+                <title>{{ page.title }}</title>
+                <pubDate>{{ page.date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
+                <link>{{ page.permalink | safe }}</link>
+                <guid>{{ page.permalink | safe }}</guid>
+                <description>{% if page.summary %}{{ page.summary }}{% else %}{{ page.content }}{% endif %}</description>
+            </item>
+        {% endfor %}
+    </channel>
+</rss>


### PR DESCRIPTION
The Zola base RSS template encodes permalinks. However, I can't see other RSS feeds doing this. Check for example [Stack Overflow](https://stackoverflow.com/feeds/tag/url)'s in comparison to [ours](https://urbit.org/rss.xml) right now.

This PR creates a base template that's the same but removes the encoding.

Before:

<img width="788" alt="image" src="https://user-images.githubusercontent.com/20846414/60615392-01f88000-9d9d-11e9-8ade-98933f76e8eb.png">

After:

<img width="789" alt="image" src="https://user-images.githubusercontent.com/20846414/60615464-2ce2d400-9d9d-11e9-9e60-501e79c2908b.png">

Except, you know, it's not going to be localhost.