### PR TITLE
Fix rendering of gaps in markdown inline code backticks

### DIFF
--- a/sass/indigo.scss
+++ b/sass/indigo.scss
@@ -52,6 +52,9 @@ samp {
   font-family: monospace, monospace;
   font-size: 1em;
 }
+code {
+  white-space: pre;
+}
 small {
   font-size: 80%;
 }


### PR DESCRIPTION
While studying https://urbit.org/docs/learn/hoon/hoon-tutorial/list-of-numbers/
I noticed that gaps aren't rendered properly in inline code markdown
(search for `.=  end  count` on that page).
```
"inline `gap  gap  gap` code"
```
is rendered as "inline `gap  gap  gap` code" (the gaps are turned into aces)
Block code renders fine.

https://github.com/Python-Markdown/markdown/issues/321
explains it (see @waylan's second post) and I sledge
hammered the fix into `sass/indigo.scss`.  Maybe there
is a more targeted fix.

Is this the right repository for this or should I PR
the indigo repository?
