### PR TITLE
Align search icon in middle of bar

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -241,6 +241,7 @@ iframe {
   }
   &__search-icon {
      -webkit-transform: rotate(-45deg);
+     vertical-align: bottom;
   }
 }
 


### PR DESCRIPTION
Addressing a concern @msutherl had about the search icon's vertical position by adding a one-line to the search icon's CSS.

<img width="248" alt="image" src="https://user-images.githubusercontent.com/20846414/61586811-779c7400-ab31-11e9-9a8e-a3b0340e3e45.png">
