### PR TITLE
Prevent page refresh when using 'enter' key in search bar

### DIFF
--- a/static/scripts.js
+++ b/static/scripts.js
@@ -261,7 +261,9 @@ function initSearch() {
 
   // Don't refresh the page on enter
   searchInput.addEventListener('keydown', function(event){
-    if (event.keyCode === 13) {
+    var key = event.key || event.keyCode;
+
+    if (key === 13 || key === "Enter") {
       event.preventDefault();
       return false;
     }

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -28,7 +28,6 @@ function initHotKeys() {
       // ESC to close search window
       if (key === 'Escape' || key === 'Esc' || key === 27) {
         document.body.classList.remove('has-active-search-window');
-        console.log('esc');
       }
 
       // / to close toggle window
@@ -193,7 +192,6 @@ function formatSearchResultTitle(item) {
 }
 
 function formatSearchResultItem(item, terms) {
-  console.log(item);
   var li = document.createElement("li");
   var createA = document.createElement("a");
   li.appendChild(createA);

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -259,6 +259,14 @@ function initSearch() {
     })
   }
 
+  // Don't refresh the page on enter
+  searchInput.addEventListener('keydown', function(event){
+    if (event.keyCode === 13) {
+      event.preventDefault();
+      return false;
+    }
+  })
+
 
   searchInput.addEventListener("keyup", debounce(function() {
     inputReset.style.display="block";


### PR DESCRIPTION
Fixes #149.

Unrelated -- all the search functions still have `console.log` in the code -- should this be removed? I can do that in another PR if necessary, it just makes the console a bit messy and if I had to guess was for development purposes.