### PR TITLE
Docs navigation scrolls to current article on load

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -76,6 +76,11 @@ iframe {
     font-size: inherit;
     line-height: inherit;
   }
+  li a:focus {
+      outline: 0;
+      border: none;
+      -moz-outline-style: none;
+  }
 }
 
 .content-nav-icon {

--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -76,11 +76,6 @@ iframe {
     font-size: inherit;
     line-height: inherit;
   }
-  li a:focus {
-      outline: 0;
-      border: none;
-      -moz-outline-style: none;
-  }
 }
 
 .content-nav-icon {

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -334,7 +334,7 @@ if (document.readyState === "complete" ||
 let docsNavScroll = function() {
   let docsNav = document.querySelectorAll("ul.content-nav__index a")
   for (let link in docsNav) {
-    if (docsNav[link].href === window.location.href) {
+    if (window.location.href.includes(docsNav[link].href)) {
       docsNav[link].focus()
     }
   }

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -335,7 +335,7 @@ let docsNavScroll = function() {
   let docsNav = document.querySelectorAll("ul.content-nav__index a")
   for (let link in docsNav) {
     if (window.location.href.includes(docsNav[link].href)) {
-      docsNav[link].focus()
+      docsNav[link].scrollIntoView()
     }
   }
 }

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -329,3 +329,15 @@ if (document.readyState === "complete" ||
     initHotKeys();
   });
 }
+
+// Scroll to current document in nav list.
+let docsNavScroll = function() {
+  let docsNav = document.querySelectorAll("ul.content-nav__index a")
+  for (let link in docsNav) {
+    if (docsNav[link].href === window.location.href) {
+      docsNav[link].focus()
+    }
+  }
+}
+
+if (window.location.href.includes("docs")) docsNavScroll();


### PR DESCRIPTION
Fixes #28. If the window location has "docs", then it gets all the links in the nav list, checks if it matches the location of the current page, and if so, ~~focuses the link, which automatically~~ scrolls the container to where your place was.

~~It works! It's pretty good. But it's not perfect.~~

## Oddities and anomalies of the implementation

~~- Chrome focuses the link in the centre of the container. Firefox places the focused link at the bottom of the container.~~
- The scrollbar shows for about a second or less when it scrolls to the link location.
- It doesn't scroll down on mobile. I'm trying to think of an implementation that would scroll on mobile, but I can't off the top of my head.

## Tradeoffs of the implementation

~~- Because this uses `focus()` instead of grabbing the `scrollHeight` of the element and then changing the `scrollTop` of the navigation, I had to remove the outline on focused elements in the SCSS. This just means if you use keyboard navigation (no mouse), you won't be able to tell the currently outlined link on urbit.org. Less accessible, essentially.~~

Let me know what you think. ~~I'd be happy to give it another go, now that I've found one way to do it.~~

Redid the implementation, it's much better now.