### PR TITLE
use white-space: pre-wrap; instead of pre; for code tags

### DIFF
--- a/sass/indigo.scss
+++ b/sass/indigo.scss
@@ -53,7 +53,7 @@ samp {
   font-size: 1em;
 }
 code {
-  white-space: pre;
+  white-space: pre-wrap;
 }
 small {
   font-size: 80%;


### PR DESCRIPTION
---

`white-space: pre;`

---

<img width="828" alt="white-space-pre" src="https://user-images.githubusercontent.com/15039850/62456020-28635f80-b73d-11e9-93ad-d4d870448258.png">

---

`white-space: pre-wrap;`

---

<img width="686" alt="white-space-pre-wrap" src="https://user-images.githubusercontent.com/15039850/62456024-29948c80-b73d-11e9-9785-c9db42dd275d.png">

---
