### PR TITLE
Add support for tooltips in documentation

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -363,6 +363,10 @@ iframe {
   }
 }
 
+.tippy-tooltip {
+  border-radius: 0px;
+}
+
 /*
  * styling
  */

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -342,5 +342,11 @@ let docsNavScroll = function() {
 
 if (window.location.href.includes("docs")) {
   docsNavScroll();
-  tippy('.tooltip')
+  tippy('.tooltip', {
+    content(reference) {
+      const title = reference.getAttribute('title')
+      reference.removeAttribute('title')
+      return title
+    }
+  })
 }

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -347,6 +347,8 @@ if (window.location.href.includes("docs")) {
       const title = reference.getAttribute('title')
       reference.removeAttribute('title')
       return title
-    }
+    },
+    animateFill: false,
+    animation: 'fade'
   })
 }

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -340,4 +340,7 @@ let docsNavScroll = function() {
   }
 }
 
-if (window.location.href.includes("docs")) docsNavScroll();
+if (window.location.href.includes("docs")) {
+  docsNavScroll();
+  tippy('.tooltip')
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -35,6 +35,8 @@
     {% if config.build_search_index %}
       <script type="text/javascript" src="{{ get_url(path="elasticlunr.min.js") | safe }}"></script>
       <script type="text/javascript" src="{{ get_url(path="search_index.en.js") | safe }}"></script>
+      <script src="https://unpkg.com/popper.js@1"></script>
+      <script src="https://unpkg.com/tippy.js@4"></script>
     {% endif %}
     <script src="{{ config.base_url }}/scripts.js"></script>
   </body>


### PR DESCRIPTION
Adds the [tippy.js](https://atomiks.github.io/tippyjs/) library to the site base template.

If an element has the `tooltip` class and a `title` attribute, produces a tooltip above it. 

Currently I am working on adding tooltip content to literally everything on the standard library page, so that will be incoming to the docs repository, separately.

For a video of what it looks like see [here](https://drive.google.com/file/d/1pk8cdAaKeuoWn0neAtVulttI4HQrI3Xb/view?usp=sharing).
