### PR TITLE
Formalising RSS link in base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,7 @@
     <meta name="description" content="{{ config.description }}">
     <meta name="author" content="{{ config.extra.author.name }}">
     <link rel="icon" type="image/png" href="/images/favicon.ico" />
-    <link rel="alternative" type="application/rss+xml" title="Urbit RSS" href="/rss.xml" />
+    <link rel="alternative" type="application/rss+xml" title="RSS" href="{{ config.base_url }}/rss.xml" />
     <title>{% block title %}{% endblock title %} - {{ config.title }}</title>
     <!-- stylesheets -->
     <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Changes RSS link from a relative link to a full path and matches the titling of other sites with RSS feeds (simply titling it "RSS", since the feed itself is what gives readers the title of the feed).