### PR TITLE
Remove content nav toggle on non-doc/post content

### DIFF
--- a/sass/_responsive.scss
+++ b/sass/_responsive.scss
@@ -19,6 +19,9 @@
   }
   .content-nav-icon {
     display: block;
+    &.none {
+      display: none;
+    }
   }
   .content, .content-spacer {
     flex-basis: 90%;

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -7,6 +7,16 @@ if (toggleMainNav !== null) {
 }
 
 var toggleContentNav = document.getElementById('js-content-nav-toggle');
+
+// Only show the content nav for docs or posts
+let navEnabledSections = ['docs', 'posts']
+let showNav = false
+for (let section of navEnabledSections) {
+  window.location.href.includes(section) ? showNav = true : null
+}
+showNav ? null : toggleContentNav.classList.add('none')
+
+
 if (toggleContentNav !== null) {
   toggleContentNav.onclick = function() {
     document.body.classList.toggle('has-active-content-nav');


### PR DESCRIPTION
FAQ and Hoon School pages on mobile have the content nav toggle showing, which toggles you to ... a blank page, because they have no content navigation. 

Either I could create a new base template for root directory pages without that toggle, or I can route it in the JS to just hide the toggle on pages that aren't docs or posts. This seems more scalable, because fewer *entire new sections* will be added to the site, but more root directory pages are probably doing to arrive.

This PR does the latter.