### PR TITLE
Slugging double digit mm/dd updates

### DIFF
--- a/content/posts/2017-11-14-update.md
+++ b/content/posts/2017-11-14-update.md
@@ -3,6 +3,7 @@ title = "~2017.11.14 Update"
 date = 2017-11-14
 author = "Curtis Yarvin + Galen Wolfe-Pauly"
 description = "As usual, we're guilty of wanting to write code more than prose."
+slug = "2017-11-14-update"
 [taxonomies]
 posts = ["Updates"]
 +++

--- a/content/posts/2017-12-16-update.md
+++ b/content/posts/2017-12-16-update.md
@@ -3,6 +3,7 @@ title = "~2017.12.16 Update"
 date = 2017-12-16
 author = "~rovnys-ricfer"
 description = "A short update from the Tlon team for the week of ~2017.12.16."
+slug = "2017-12-16-update"
 [taxonomies]
 posts = ["Updates"]
 +++

--- a/content/posts/2018-10-12-update.md
+++ b/content/posts/2018-10-12-update.md
@@ -3,6 +3,7 @@ title = "~2018.10.12 Update"
 date = 2018-10-12
 author = "~lodleb-ritrul"
 description = "A short update from the Tlon team for the week of ~2018.10.12."
+slug = "2018-10-12-update"
 [taxonomies]
 posts = ["Updates"]
 +++

--- a/content/posts/2018-10-24-update.md
+++ b/content/posts/2018-10-24-update.md
@@ -3,6 +3,7 @@ title = "~2018.10.24 Update"
 date = 2018-10-24
 author = "~lodleb-ritrul"
 description = "A short update from the Tlon team for the week of ~2018.10.24."
+slug = "2018-10-24-update"
 [taxonomies]
 posts = ["Updates"]
 +++

--- a/content/posts/2018-11-20-update.md
+++ b/content/posts/2018-11-20-update.md
@@ -3,6 +3,7 @@ title = "~2018.11.20 Update"
 date = 2018-11-20
 author = "~lodleb-ritrul"
 description = "A short update from the Tlon team for the week of ~2018.11.20."
+slug = "2018-11-20-update"
 [taxonomies]
 posts = ["Updates"]
 +++

--- a/content/posts/2018-12-18-update.md
+++ b/content/posts/2018-12-18-update.md
@@ -3,6 +3,7 @@ title = "~2018.12.18 Update"
 date = 2018-12-18
 author = "~lodleb-ritrul"
 description = "A short update from the Tlon team for the week of ~2018.12.18."
+slug = "2018-12-18-update"
 [taxonomies]
 posts = ["Updates"]
 +++


### PR DESCRIPTION
Closes #107. Double digit update posts ("2017/11/22" et al) would all redirect to /posts/update. 

They get accurate, individuated slugs now.