### PR TITLE
Additional primer header padding on mobile resolutions

### DIFF
--- a/sass/primer.scss
+++ b/sass/primer.scss
@@ -13548,6 +13548,7 @@ must add span in markup to display icon
 
 /*Responsive Variables */
 /*Responsive Spacing */
+
 @media only screen and (max-width: 480px) {
   .sm-m-0 {
     margin: (0rem / 4); }
@@ -16750,6 +16751,14 @@ must add span in markup to display icon
     padding-top: (99rem / 4);
     padding-bottom: (99rem / 4); } }
 
+  @media only screen and (max-width: 330px) {
+  .xs-mb-10 {
+    margin-bottom: (10rem / 4);
+  }
+  .xs-mb-28 {
+    margin-bottom: (28rem / 4);
+  }
+}
 /*Responsive Typography */
 /** Responsive for Mobile **/
 @media only screen and (max-width: 480px) {

--- a/templates/primer.html
+++ b/templates/primer.html
@@ -108,7 +108,7 @@
                     <div class="col-md-9 col-md-offset-1 mb-10">
                         <h1 class="h1-large white">Table of Contents</h1></div>
                 </div>
-                <div class="row mb-8">
+                <div class="row mb-8 xs-mb-28 sm-mb-18">
                     <div class="col-md-12">
                         <a class="row sm-h2 h1 h1-large h-font white text-decoration-none" href="#what-urbit-is-for">
                             <div class="col-sm-1 col-md-1 col-md-offset-1 center dlig">(1)</div>
@@ -116,7 +116,7 @@
                         </a>
                     </div>
                 </div>
-                <div class="row mb-8">
+                <div class="row mb-8 sm-mb-18">
                     <div class="col-md-12">
                         <a class="row sm-h2 h1 h1-large h-font white text-decoration-none" href="#what-arvo-is">
                             <div class="col-sm-1 col-md-1 col-md-offset-1 center dlig">(2)</div>
@@ -124,7 +124,7 @@
                         </a>
                     </div>
                 </div>
-                <div class="row mb-8">
+                <div class="row mb-8 sm-mb-18">
                     <div class="col-md-12">
                         <a class="row sm-h2 h1 h1-large h-font white text-decoration-none" href="#what-azimuth-is">
                             <div class="col-sm-1 col-md-1 col-md-offset-1 center dlig">(3)</div>
@@ -161,7 +161,7 @@
                 </div>
                 <div class="row menu-toggle">
                     <div class="col-sm-9 col-md-8 col-lg-12 col-sm-offset-2 col-md-offset-1 col-lg-offset-0 white">
-                        <div class="row mb-4">
+                        <div class="row sm-mb-10 mb-4">
                             <div class="col-md-10 col-md-offset-1">
                                 <a class="row h2 h-font white text-decoration-none" href="#what-urbit-is-for">
                                     <div class="col-sm-1 col-md-1 col-md-offset-1 center dlig">(1)</div>
@@ -169,7 +169,7 @@
                                 </a>
                             </div>
                         </div>
-                        <div class="row mb-4">
+                        <div class="row mb-4 xs-mb-10">
                             <div class="col-md-10 col-md-offset-1">
                                 <a class="row h2 h-font white text-decoration-none" href="#what-arvo-is">
                                     <div class="col-sm-1 col-md-1 col-md-offset-1 center dlig">(2)</div>
@@ -177,7 +177,7 @@
                                 </a>
                             </div>
                         </div>
-                        <div class="row mb-4">
+                        <div class="row mb-4 sm-mb-10">
                             <div class="col-md-10 col-md-offset-1">
                                 <a class="row h2 h-font white text-decoration-none" href="#what-azimuth-is">
                                     <div class="col-sm-1 col-md-1 col-md-offset-1 center dlig">(3)</div>
@@ -193,7 +193,7 @@
                                 </a>
                             </div>
                         </div>
-                        <div class="row mb-4">
+                        <div class="row mb-4 sm-mb-10">
                             <div class="col-md-10 col-md-offset-1">
                                 <a class="row h2 h-font white text-decoration-none" href="#azimuth-distribution">
                                     <div class="col-sm-1 col-md-1 col-md-offset-1 center dlig">(5)</div>
@@ -262,7 +262,7 @@
             </footer>
         </nav>
         <div class="primer-container mb-5">
-            <div id="what-urbit-is-for" class="row sm-pt-20 sm-pb-20 pt-40 pb-40">
+            <div id="what-urbit-is-for" class="row sm-pt-20 sm-pb-28 pt-40 pb-40">
                 <div class="fixed" style="top:2.5rem;left:1rem">
                     <div class="col-sm-1 menu-toggle"><img class="w-8 h-8" src="../assets/menu-open.svg" /></div>
                 </div>
@@ -584,7 +584,7 @@
                     </div>
                 </div>
             </div>
-            <div id="what-azimuth-is" class="primer-container sm-pt-20 sm-pb-20 pt-40 pb-40">
+            <div id="what-azimuth-is" class="primer-container sm-pt-20 sm-pb-40 pt-40 pb-40">
                 <div class="row">
                     <div class="col-sm-12">
                         <div class="row sm-h2 h1 h1-large h-font">


### PR DESCRIPTION
Current primer on mobile devices has [some overlapping issues](https://cdn.discordapp.com/attachments/593489855057756196/617747385069731863/image0.png). This PR ensures that it does not, for several different mobile viewports.

I don't know how this was introduced, but there's various padding and spacing issues on both iPhone SE (320px) and iPhone 8 (< 480px) devices, so I also had to write some ad hoc margin-bottom classes for the former target, since it has line breaks on some headers that the latter target doesn't have.

Adds responsive margin and padding to the table of contents; to the main menu; and finally to several headers in sections, which had, for example, YouTube videos and animated graphics cutting off the last halves of headers entire.

