### PR TITLE
Next click tracking

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -109,7 +109,7 @@ a[href*="//"]:not([href*="{{config.base_url | safe}}"])::after {
             <div id="mce-success-response" class="response" style="display:none"></div>
           </div>
           <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_972a03db9e0c6c25bb58de8c8_be143888d2" tabindex="-1" value=""></div>
-          <button id="mc-embedded-subscribe" class="bg-white mb4 justify-between black w-100 tl" style="font-family: 'Inter UI', san-serif; padding: 16px; -webkit-appearance: none;" type="submit" name="subscribe">
+          <button id="mc-embedded-subscribe" class="bg-white mb4 justify-between black w-100 tl" style="font-family: 'Inter UI', san-serif; padding: 16px; -webkit-appearance: none;" type="submit" name="subscribe" onclick="_paq.push(['trackEvent', 'Mailing List', 'Subscribe'])">
             <span class="text-500">Subscribe</span> <span class="fr pr1">-></span>
           </button>
         </div>


### PR DESCRIPTION
This should add event tracking to the mailing list subscribe button per https://matomo.org/docs/event-tracking/#tracking-events.

@matildepark there are other ways to implement this, i.e. add to every button with the right 'name' from `scripts.js` – let me know if you think there's a cleaner way to do this for now.