### PR TITLE
Simplify essay and UU grid

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -189,10 +189,6 @@ body.essay {
         display: block;
         // margin: 0 auto;
     }
-    article > *:not(figure):not(picture) {
-        grid-area: auto / 4 / auto / 10;
-        @extend .measure-wide;
-    }
 }
 
 // components

--- a/sass/_responsive.scss
+++ b/sass/_responsive.scss
@@ -11,15 +11,6 @@
     }
 }
 
-// scaling below desktop
-@media all and (max-width: 60em) {
-    body.essay {
-        article > *:not(figure):not(picture) {
-            grid-area: auto / 1 / auto / 12;
-        }
-    }
-}
-
 // custom L breakpoint classes
 @media screen and (min-width: 46.875em) and (max-width: 60em) {
     .white-l { 

--- a/templates/doc.html
+++ b/templates/doc.html
@@ -5,7 +5,7 @@
 <!-- header -->
 <!-- content -->
 {% include "partials/navigation-docs.html" %}
-<article class="mt4 mb6 c1-12 c5-10-md c4-10-lg">
+<article class="mt4 mb6 full c5-10-md c4-10-lg">
   <!-- header -->
   <h1>{{ page.title }}</h1>
   <!-- body -->

--- a/templates/essays/post.html
+++ b/templates/essays/post.html
@@ -25,25 +25,25 @@
 
   {% include "partials/navigation-search.html" %}
 </nav>
-<section class="full c4-12-lg">
-<h1 class="mb2 mt4 fw6">{{ page.title }}</h1>
-{% if page.extra.author %}
-<span class="dib" rel="author"> {{ page.extra.author }}
-  {% if page.extra.ship %}
-  <address class="dib fw4 ml2 mono">{{ page.extra.ship }}</address>
-{% endif %}
-</span>
-{% if page.date %}
-  <time class="mono db mv2 gray0 f5">{{page.date | date(format="~%Y.%-m.%-d") }}</time>
-{% endif %}
-{% endif %}
-{% if page.extra.readtime %}
-<span class="dib mono {% if page.date %} ml2{% endif %} gray2 f5">{{ page.reading_time }}m read</span>
-{% endif %}
-</section>
 
-<article class="mb4 full grid12">
+<article class="mb4 measure-wide full c4-12-lg">
+    <h1 class="mb2 mt4 fw6">{{ page.title }}</h1>
+    {% if page.extra.author %}
+    <span class="dib" rel="author"> {{ page.extra.author }}
+      {% if page.extra.ship %}
+      <address class="dib fw4 ml2 mono">{{ page.extra.ship }}</address>
+    {% endif %}
+    </span>
+    {% if page.date %}
+      <time class="mono db gray0 f5">{{page.date | date(format="~%Y.%-m.%-d") }}</time>
+    {% endif %}
+    {% endif %}
+    {% if page.extra.readtime %}
+    <span class="dib mono {% if page.date %} ml2{% endif %} gray2 f5">{{ page.reading_time }}m read</span>
+    {% endif %}
+
   {{ page.content | safe }}
+
   {% include "partials/pagination.html" %}
 </article>
 {% endblock content %}

--- a/templates/sections/docs.html
+++ b/templates/sections/docs.html
@@ -5,7 +5,7 @@
 <!-- header -->
 <!-- content -->
 {% include "partials/navigation-docs.html" %}
-<article class="mt4 mb6 c1-12 c5-10-md c4-10-lg">
+<article class="mt4 mb6 full c5-10-md c4-10-lg">
   <!-- header -->
   <h1>{{ section.title }}</h1>
   <!-- body -->

--- a/templates/sections/docs/chapters.html
+++ b/templates/sections/docs/chapters.html
@@ -4,7 +4,7 @@
 <!-- header -->
 <!-- content -->
 {% include "partials/navigation-docs.html" %}
-<article class="mt4 mb6 c1-12 c5-10-md c4-10-lg">
+<article class="mt4 mb6 full c5-10-md c4-10-lg">
 <!-- header -->
 <h1>{{ section.title }}</h1>
 <!-- body -->

--- a/templates/shortcodes/full.html
+++ b/templates/shortcodes/full.html
@@ -1,3 +1,0 @@
-<figure class="full full-bleed">
-  <img src="{{url}}"/>
-</figure>

--- a/templates/shortcodes/oversize.html
+++ b/templates/shortcodes/oversize.html
@@ -1,3 +1,0 @@
-<figure class="c1-12 mt4 mb4 c3-11-lg">
-  <img src="{{url}}"/>
-</figure>

--- a/templates/understanding-urbit/post.html
+++ b/templates/understanding-urbit/post.html
@@ -34,22 +34,23 @@
     {% endif %}
   {% endfor %}
 </nav>
-  <h1 class="mb4 full mt4 c4-12-lg">{{ page.title }}</h1>
+
+  <article class="mb4 full c4-12-lg measure-wide">
+      <h1 class="mb4 mt4">{{ page.title }}</h1>
   {% if page.extra.author %}
-  <span class="dib full c4-12-lg" rel="author"> {{ page.extra.author }}
+  <span class="dib" rel="author"> {{ page.extra.author }}
     {% if page.extra.ship %}
     <address class="dib fw4 ml2 mono">{{ page.extra.ship }}</address>
   {% endif %}
   </span>
   {% if page.date %}
-    <time class="mono full c4-12-lg db mv2 gray0 f5">{{page.date | date(format="~%Y.%-m.%-d") }}</time>
+    <time class="mono db mv0 gray0 f5">{{page.date | date(format="~%Y.%-m.%-d") }}</time>
   {% endif %}
 {% endif %}
   {% if page.extra.readtime %}
-  <span class="dib mono full c4-12-lg{% if page.date %} ml2{% endif %} gray2 f5">{{ page.reading_time }}m read</span>
+  <span class="dib mono{% if page.date %} ml2{% endif %} gray2 f5">{{ page.reading_time }}m read</span>
   {% endif %}
-
-  <article class="mb4 full grid12">
+  
     {{ page.content | safe }}
 
     {% include "partials/pagination.html" %}


### PR DESCRIPTION
This PR essentially brings these templates closer to my original implementation. When @urcades and I were adding image components that would be *full page* or *oversized compared to content* I had to make the grid a bit more complex to handle that possibility, adding a subgrid and some weird CSS selectors. Sorry!

Since we aren't using those components, this makes the CSS and templates much simpler. I also brought the docs templates to use the full grid on mobile in addition. I believe this closes #247.