### PR TITLE
Feature: Docs template tweaks, adds automated "next up" pagination

### DIFF
--- a/templates/doc.html
+++ b/templates/doc.html
@@ -12,7 +12,7 @@
 <!-- header -->
 <!-- content -->
 {% include "partials/navigation-docs.html" %}
-<article class="mt4 mb6 full c4-12-lg">
+<article class="mt4 mb6 full c4-12-lg measure-wide">
   <!-- header -->
   <h1>{{ page.title }}</h1>
   <!-- body -->

--- a/templates/doc.html
+++ b/templates/doc.html
@@ -12,7 +12,7 @@
 <!-- header -->
 <!-- content -->
 {% include "partials/navigation-docs.html" %}
-<article class="mt4 mb6 full c5-10-md c4-10-lg">
+<article class="mt4 mb6 full c4-12-lg">
   <!-- header -->
   <h1>{{ page.title }}</h1>
   <!-- body -->

--- a/templates/doc.html
+++ b/templates/doc.html
@@ -17,5 +17,7 @@
   <h1>{{ page.title }}</h1>
   <!-- body -->
     {{ page.content | safe }}
+
+    {% include "partials/pagination-docs.html" %}
 </article>
 {% endblock content %}

--- a/templates/partials/navigation-docs.html
+++ b/templates/partials/navigation-docs.html
@@ -1,6 +1,6 @@
 <!-- First nav is desktop-specific. Second nav is dropdown version for mobile. -->
 {% block content %}
-<nav class="bg-gray5 dn db-l db-xl pt4 full-left no-break docs pr4">
+<nav class="bg-gray5 dn db-xl pt4 full-left no-break docs pr4">
     <a class="gray3" href="{{config.base_url}}">Urbit</a>
   <span class="gray3"> / </span>
   <a href="{{config.base_url}}/docs/">
@@ -76,7 +76,7 @@
   </ul>
 </nav>
 
-<nav class="dn-l mobile dn-xl db pt4 no-break docs full">
+<nav class="mobile dn-xl db pt4 no-break docs full">
     <a class="gray3" href="{{config.base_url}}">Urbit</a>
   <span class="gray3"> / </span>
   <a href="{{config.base_url}}/docs/">

--- a/templates/partials/pagination-docs.html
+++ b/templates/partials/pagination-docs.html
@@ -1,0 +1,10 @@
+<footer class="relative mt4">
+    {% if page.heavier %}
+    <nav class="previous absolute right-1 t-right">
+    <a class="bb-0" href="{{page.heavier.permalink}}">
+    <p class="mb0 f5">Next up:</p>
+    <p class="mt0 mb0 fw6 f5">{{page.heavier.title}}</p>
+    </a>
+    </nav>
+    {% endif %}
+</footer>

--- a/templates/sections/docs.html
+++ b/templates/sections/docs.html
@@ -12,7 +12,7 @@
 <!-- header -->
 <!-- content -->
 {% include "partials/navigation-docs.html" %}
-<article class="mt4 mb6 full c4-12-lg">
+<article class="mt4 mb6 full c4-12-lg measure-wide">
   <!-- header -->
   <h1>{{ section.title }}</h1>
   <!-- body -->

--- a/templates/sections/docs.html
+++ b/templates/sections/docs.html
@@ -12,7 +12,7 @@
 <!-- header -->
 <!-- content -->
 {% include "partials/navigation-docs.html" %}
-<article class="mt4 mb6 full c5-10-md c4-10-lg">
+<article class="mt4 mb6 full c4-12-lg">
   <!-- header -->
   <h1>{{ section.title }}</h1>
   <!-- body -->

--- a/templates/sections/docs/chapters.html
+++ b/templates/sections/docs/chapters.html
@@ -11,7 +11,7 @@
 <!-- header -->
 <!-- content -->
 {% include "partials/navigation-docs.html" %}
-<article class="mt4 mb6 full c5-10-md c4-10-lg">
+<article class="mt4 mb6 full c4-12-lg">
 <!-- header -->
 <h1>{{ section.title }}</h1>
 <!-- body -->

--- a/templates/sections/docs/chapters.html
+++ b/templates/sections/docs/chapters.html
@@ -11,7 +11,7 @@
 <!-- header -->
 <!-- content -->
 {% include "partials/navigation-docs.html" %}
-<article class="mt4 mb6 full c4-12-lg">
+<article class="mt4 mb6 full c4-12-lg measure-wide">
 <!-- header -->
 <h1>{{ section.title }}</h1>
 <!-- body -->


### PR DESCRIPTION
This PR adds "next up" pagination for all non-chapter, non-section pages.

It also amends the docs template — it was too narrow on iPad, and wasn't overall very responsive, so it now defaults to single-column on iPad resolution; uses more of the grid by default; and adds `measure-wide` to match the rest of the site.

To be deployed alongside [docs/672](https://github.com/urbit/docs/pull/672).

![image](https://user-images.githubusercontent.com/20846414/67327388-b34a2f80-f4cc-11e9-8945-fb72129ff2b1.png)
