### PR TITLE
Chore: Tweak CSS styles for Windows users

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -275,7 +275,7 @@ nav.previous, nav.next {
     background: transparent;
     span#search-icon {
       display: inline-block;
-      transform: translate(-7px, 2px) rotate(-45deg);
+      transform: translate(-4px, 2px) rotate(-45deg);
     }
     span.search-slash {
       font-size: 0.75em;
@@ -591,6 +591,6 @@ hr {
 }
 
 // hide webkit scrollbars on windows, etc
-::-webkit-scrollbar {
+nav::-webkit-scrollbar {
     display: none;
 }


### PR DESCRIPTION
- Nudge search icon to prevent cutting it off. Closes #232.
- Being more specific with hiding the scrollbar on Windows Chrome, etc. — only applying it to `nav`, since that's where we don't like seeing random scrollbars. Closes #254.