### PR TITLE
Add gray background to inline code

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -408,6 +408,10 @@ code, .code, .mono {
     font-family: "Source Code Pro", monospace;
 }
 
+code {
+    @extend .bg-gray5, .pa1;
+}
+
     // code in headers
 h1 code, h2 code, h3 code, h4 code {
     @extend .red3;


### PR DESCRIPTION
Adds `.bg-gray5` to inline code blocks, while not adding them to dates and times and non-code monospace use. This matches the background color already in use on bigger code blocks. 

This PR also includes a docs update while we're at it.

Closes #253.