### PR TITLE
Tweak h2 margin selector

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -482,7 +482,7 @@ body.docs article {
 }
 
 body.page-indiced {
-    h2:not(:first-of-type) {
+    h2:not(:first-child) {
         margin: 2rem 0 1.5rem 0;
     }
     h3 {


### PR DESCRIPTION
This PR amends the page-with-sidebar-component template (`page_indiced.html`) selector for `h2` elements to better target which `h2` elements to apply our margins to. 

Previously, it used `:first-of-type`, so that when pages have an `h2` as their header, they are level with the navigation, but the `h2` elements that follow have ample margins to separate content. 

However, some pages don't use an `h2` as the title (such as when appending the title to the sidebar — which gets its navigation from all `h2` and `h3` elements — is not desired behaviour, which necessitates then not using the `hidetitle` parameter in the template). 

This would lead to situations where the first `h2` in the page content didn't have any margin. The most obvious example is "Core development" vs. "Application development" on [using/develop](https://urbit.org/using/develop).

Basically, we don't want to remove margins from the first `h2` on the page. We want to only remove margins from the `h2` that exists _as the `<article>` element's first child_. So this substitutes `:first-child` in and fixes the issue.