### PR TITLE
add lh-copy to docs nav

### DIFF
--- a/templates/partials/navigation-docs.html
+++ b/templates/partials/navigation-docs.html
@@ -9,7 +9,7 @@
   <button id="js-search-window-toggle" class="mt2 mb4 dn db-m db-l db-xl" type="button"  style="outline:none">
     <span id="search-icon" class="f3 gray3">⚲</span><span class="ml3 gray2">Search</span>
   </button>
-  <ul>
+  <ul class="lh-copy">
   {% block menu %}
     {% set index = get_section(path="docs/_index.md") %}
     {% for s in index.subsections %}

--- a/templates/partials/pagination-docs.html
+++ b/templates/partials/pagination-docs.html
@@ -1,6 +1,6 @@
 <footer class="relative mt4">
     {% if page.heavier %}
-    <nav class="previous absolute right-1 t-right">
+    <nav class="previous absolute lh-copy right-1 t-right">
     <a class="bb-0" href="{{page.heavier.permalink}}">
     <p class="mb0 f5">Next up:</p>
     <p class="mt0 mb0 fw6 f5">{{page.heavier.title}}</p>


### PR DESCRIPTION
The /docs navigation sidebar has some weird spacing because multi-line titles are spaced differently than each element's `margin-top`. Giving the nav list `.lh-copy` spaces things evenly.