### PR TITLE
add cta + bridge info

### DIFF
--- a/content/understanding-urbit/project-history.md
+++ b/content/understanding-urbit/project-history.md
@@ -39,7 +39,7 @@ At the beginning, Urbit was just a few people with the right combination of imag
 
 ## Future updates
 
-Urbit is young, but developing quickly. If you've just finished our Understanding Urbit series and want to stay connected with the project, we recommend starting with our mailing list. 
+Urbit is young, but developing quickly. If you've just finished our Understanding Urbit series and want to stay connected with the project, we recommend starting with our mailing list.
 
 Enter your email below to get regular updates on the project.
 
@@ -71,4 +71,6 @@ novalidate>
     </button>
     </div>
 </div>
+
+You can also follow us on [Twitter](https://twitter.com/urbit) or [GitHub](https://github.com/urbit).
 </form>

--- a/content/understanding-urbit/project-history.md
+++ b/content/understanding-urbit/project-history.md
@@ -29,10 +29,46 @@ Urbit OS isn’t just an interface — it’s a complete system. You should also
 
 At the beginning, Urbit was just a few people with the right combination of imagination and discipline to try to rebuild computing. Now it's a community of thousands of address space holders, dozens of open source developers, at least two independent companies ([Tlon](https://tlon.io) — which works mostly on kernel development and interface design, and [urbit.live](https://urbit.live) — which is building services on the platform), and who knows how many fans.
 
-**History**
+## History
 
 <img class="mv5 w-100" src="https://media.urbit.org/site/understanding-urbit/project-history/project-history-05.svg">
 
-**Roadmap**
+## Roadmap
 
 <img class="mv5 w-100" src="https://media.urbit.org/site/understanding-urbit/project-history/project-history-06.svg">
+
+## Future updates
+
+Urbit is young, but developing quickly. If you've just finished our Understanding Urbit series and want to stay connected with the project, we recommend starting with our mailing list. 
+
+Enter your email below to get regular updates on the project.
+
+<iframe name="nothing" style="display:none;"></iframe>
+<form
+action="https://urbit.us11.list-manage.com/subscribe/post?u=972a03db9e0c6c25bb58de8c8&amp;amp;id=be143888d2"
+method="post"
+id="mc-embedded-subscribe-form"
+name="mc-embedded-subscribe-form"
+class="validate form"
+target="_blank"
+novalidate>
+<div class="input-group" id="mc_embed_signup_scroll">
+    <div class="mc-field-group w-100 relative">
+    <input
+        class="bg-white black b--black ba pa3 w-100 mb2 br0 wk-appearance-none"
+        type="email"
+        name="EMAIL"
+        id="mce-EMAIL"
+        placeholder="your@email.com"/>
+    <button
+        id="mc-embedded-subscribe"
+        class="dib bn absolute bg-transparent"
+        style="font-family: 'Inter UI', san-serif; right: 3px; top: 15px; -webkit-appearance: none;"
+        type="submit"
+        name="subscribe"
+        onclick="_paq.push(['trackEvent', 'Mailing List', 'Subscribe'])">
+        <span class="fr pr1">-></span>
+    </button>
+    </div>
+</div>
+</form>

--- a/content/using/install.md
+++ b/content/using/install.md
@@ -6,7 +6,7 @@ template = "page_indiced.html"
 aliases = ["/docs/getting-started/"]
 +++
 
-Urbit is not yet ready for everyday users -- but if you're technically inclined or generally intrepid, feel free to try it out. It's a good place to explore.
+Urbit is not yet ready for everyday users — but if you're technically inclined or generally intrepid, feel free to try it out. It's a good place to explore.
 
 In order to get going on the network, you'll need an [Urbit ID](#id). To try the live network out with a disposable identity, you can always [create a comet](@/using/operations/creating-a-comet.md).
 
@@ -19,7 +19,11 @@ While Tlon does not currently sell or distribute Urbit IDs, there are still a fe
 - Getting an invitation from a friend
 - Purchasing an Urbit ID from a third party, such as [urbit.live](https://urbit.live) or [OpenSea](https://opensea.io).
 
-Tlon occasionally selects candidates to distribute invitations, and users operating galaxies and stars can spawn and distribute a finite number of stars and planets, respectively.
+Tlon occasionally selects candidates to distribute invitations, and users operating galaxies and stars can spawn and distribute a finite number of stars and planets, respectively. 
+
+## Using your Urbit ID
+
+If you have an Urbit ID, you'll use [Bridge](https://bridge.urbit.org) to get your ship's keyfile before you can [boot your ship](#booting-your-ship). For more information on how to use Bridge, see [Using Bridge](@/using/operations/using-bridge.md). 
 
 ## Install Urbit {#urbit}
 
@@ -75,7 +79,7 @@ Urbit wants to map 2GB of memory when it boots up. It won’t necessarily use al
 
 Digital Ocean has a post on adding swap [here](https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-16-04). For Amazon there’s a StackOverflow thread [here](https://stackoverflow.com/questions/17173972/how-do-you-add-swap-to-an-ec2-instance).
 
-## Booting your ship
+## Booting your ship {#booting-your-ship}
 
 Now the rubber meets the road. You'll be booting your ship with the keyfile that you [downloaded from Bridge](@/using/operations/using-bridge.md).
 
@@ -96,13 +100,13 @@ Type `cd` in your terminal to return to your home directory. If you want to stor
 Run the command below, except with `sampel-palnet` replaced by the name of your
 Urbit identity, and `path/to/my-planet.key` replaced with the path to your keyfile:
 
-```
+```sh
 ./urbit -w sampel-palnet -k path/to/my-planet.key
 ```
 
 Or, if you'd prefer to copy your key in, you can run:
 
-```
+```sh
 ./urbit -w sampel-palnet -G rAnDoMkEy
 ```
 


### PR DESCRIPTION
Adds a mailing list CTA to the bottom of the last Understanding Urbit post (previously had nowhere we wanted readers to go or do once finished the series).

Adds Bridge information and "what to do once you have an urbit ID" to Install + Setup above the binary instructions, since that information was missing. Bridge is a common outlink from the site, but it's presently buried a bit deep in the site, and it isn't in the footer, so people are looking for it somewhere. 

(We discussed putting it on the front page alongside "Docs" and "Install" but it feels more natural as a small part of "Install".)