### PR TITLE
Feature: Documentation navigation auto-scrolls to latest open navigation drawer

### DIFF
--- a/static/scripts.js
+++ b/static/scripts.js
@@ -325,7 +325,16 @@ if (document.readyState === "complete" ||
   });
 }
 
+// Scroll to current document in nav list.
+let docsNavScroll = function() {
+  let docsDetails = document.querySelectorAll("nav ul details")  
+  for (let details in docsDetails) {
+    if (docsDetails[details].open) docsDetails[details].scrollIntoView()
+    }
+}
+
 if (window.location.href.includes("docs")) {
+  // tooltip behaviour for standard library page
   tippy('.tooltip', {
     content(reference) {
       const title = reference.getAttribute('title')
@@ -336,6 +345,8 @@ if (window.location.href.includes("docs")) {
     animation: 'fade'
   })
 
+  // on mobile, dropdown selections go to the option
+
   let docsSelect = document.getElementById('docsSelect');
   let goTo = function() {
     let url = docsSelect.options[docsSelect.selectedIndex].value;
@@ -345,6 +356,8 @@ if (window.location.href.includes("docs")) {
   }
 
   docsSelect.addEventListener('change', goTo);
+  // docs autoscroll to current page
+  docsNavScroll();
 }
 
 // same-page navigation on-scroll behaviour


### PR DESCRIPTION
This was something I PR'd into the last incarnation of the site, but the functionality's changed a bit. 

Links no longer have a `scrollHeight`, but the drawers do, so this just scrolls the latest open drawer into view on page load. Only really noticeable when using the Hoon tutorials or standard library (and really, only needed there, too, since most drawers are tucked out of the way, otherwise). Just some polish.

(I'm doing docs PRs because I'm using them and hitting annoyances, heh.)