### PR TITLE
page_indiced template: fix ipad layout

### DIFF
--- a/templates/page_indiced.html
+++ b/templates/page_indiced.html
@@ -22,7 +22,7 @@
 <!-- content -->
 {%- set lowercasetitle = page.title | lower | split(pat=" ") | join(sep="-") -%}
 {% if section or lowercasetitle == page.components[0] %}
-<nav class="mt4 pb4 fixed-xl full fourth-1-md fourth-1-lg page-indiced mb3 mb0-m mb0-l mb0-xl">
+<nav class="mt4 pb4 fixed-xl full fourth-1-lg page-indiced mb3 mb0-m mb0-l mb0-xl">
   <a class="gray3" href="/">Urbit</a>
   <span class="gray3"> / </span>
   <a href="/{{ page.components[0] }}">
@@ -32,7 +32,7 @@
   {% include "partials/navigation-search.html" %}
 
 {% else %}
-<nav class="mt4 fixed-xl full fourth-1-md fourth-1-lg page-indiced mb3 mb0-m mb0-l mb0-xl">
+<nav class="mt4 fixed-xl full fourth-1-lg page-indiced mb3 mb0-m mb0-l mb0-xl">
   <a class="gray3" href="/">Urbit</a>
   <span class="gray3"> / </span>
   <a href="/{{ page.components[0] }}{% if page.components[2] %}/{{ page.components[1] }}{% endif %}">
@@ -58,7 +58,7 @@
 {% endif %}
 {% endfor %}
 </nav>
-        <article class="mt4 mb6 c1-12 c5-10-md c4-10-lg">
+        <article class="mt4 mb6 c1-12 c4-10-lg measure-wide">
             {% if page.extra.hidetitle %} {% else %}<h1>{{ page.title }}</h1>{% endif %}
           {% if page.extra.author %}
           <span class="mt2 dib" rel="author"> {{ page.extra.author }} </span>


### PR DESCRIPTION
Presently our "page content as a sidebar" (Developer's Guide, FAQ, etc.) template doesn't have some of the features in our other templates and defaults to a super narrow template on iPad that isn't very flattering or useable. 

This just brings it to parity with the other templates.