### PR TITLE
docs: center dropdown on mobile

### DIFF
--- a/templates/partials/navigation-docs.html
+++ b/templates/partials/navigation-docs.html
@@ -82,7 +82,7 @@
   <a href="{{config.base_url}}/docs/">
   Documentation
   </a>
-  <select class="db mt4 pa2 b--black ba br0 mw4 f6 fw5" id="docsSelect" style="text-align-last: center;">
+  <select class="db mt4 pa2 b--black ba br0 mw4 f6 fw5" id="docsSelect" style="text-indent: 0.725rem;">
     <option>Navigation ↓</option>
     {% set index = get_section(path="docs/_index.md") %}
     {% for s in index.subsections %}


### PR DESCRIPTION
Centers the dropdown for navigation on mobile. It's a gross, hard-coded way to do it, but it's really bugging me, and I didn't want to use JS to do it — pure CSS solutions work on everything but Safari, so iOS users would always see the weird left-aligned one.