### PR TITLE
index: sentence casing and old code cleanup

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-<!--External links are differentiated on home page.-->
 {% block templatestyles %}
 
 {% endblock templatestyles %}
@@ -36,8 +35,6 @@
     class="w-100 ma0 h-100" frameborder="0" allow="autoplay;fullscreen" allowfullscreen="" style="
   "></iframe> -->
 </section>
-
-<!-- <nav class="full-bleed full grid12"> -->
 
 <section class="full c2-7-md c3-7-lg mt6">
   <p class="lh-copy mt1 mb4">
@@ -80,7 +77,7 @@
 </section>
 
 <section class="full c7-12-md c7-11-lg mt6">
-  <h1 class="mb3">Learn More</h1>
+  <h1 class="mb3">Learn more</h1>
   <p class="lh-copy mt1">We share ongoing project developments, discuss technical considerations, and update our public roadmap as often as possible. You can follow along here.</p>
   <ul class="list">
     <li class="mt3">
@@ -102,7 +99,7 @@
 </section>
 
 <section class="full c2-7-md c3-7-lg mv6">
-  <h1 class="mb3">Follow Us</h1>
+  <h1 class="mb3">Follow us</h1>
   <p class="lh-copy mt1 mb4">Urbit is actively being built, explored, and experimented with.
     To follow our progress you can:
   </p>
@@ -126,7 +123,7 @@
 <section
   class="full c7-12-md c7-11-lg mb6 mt6-xl mt6-l mt6-m"
   id="newsletter-subscribe-top">
-  <h1 class="mb3">Stay Up to Date</h1>
+  <h1 class="mb3">Stay up to date</h1>
   <p class="lh-copy mt1 mb3">
     We send regular updates about our project. Enter your email to get them.
   </p>
@@ -161,7 +158,5 @@
   </form>
 </section>
 
-  <!-- </nav> -->
-<!-- </article> -->
 {% include "partials/footer.html" %}
 {% endblock content %}


### PR DESCRIPTION
Amending the headers on index.html to match site's capitalisation pattern (@collinscorrina and I used sentence case in all content passes). Removing some commented out old code for the previous template, to help clean it up.