### PR TITLE
Add posts' leading image as Twitter card image

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ author = "Matilde Park"
 <!-- Ship: The author's ship. Used on post directory pages. -->
 ship = "~haddef-sigwen"
 
+<!-- Image: The URL to the article's main image. Used on Twitter cards and link previews to the site. -->
+image = "https://media.urbit.org/site/posts/updates/~2019.11.06-update.jpg"
+
 <!-- hidetitle: For non-post pages on the site, the title is automatically inserted as an <h1> at the top. If the title of the page is already displayed in the nav (this occurs in root content pages, like /governance, /privacy), then this just removes that <h1>. -->
 hidetitle = "true"
 

--- a/content/blog/2019-10-3-roadmap.md
+++ b/content/blog/2019-10-3-roadmap.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/2019-10-3-roadmap", "/posts/2019-10-3-roadmap"]
 [extra]
 author = "Galen Wolfe-Pauly"
 ship = "~ravmel-ropdyl"
+image = "https://media.urbit.org/site/posts/essays/2019-10-3-roadmap.jpg"
 +++
 
 ![](https://media.urbit.org/site/posts/essays/2019-10-3-roadmap.jpg)

--- a/content/blog/2019-5-roadmap.md
+++ b/content/blog/2019-5-roadmap.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/2019-5-roadmap", "/posts/2019-5-roadmap"]
 [extra]
 author = "Galen Wolfe-Pauly"
 ship = "~ravmel-ropdyl"
+image = "https://media.urbit.org/site/posts/essays/2019-5-roadmap-1.png"
 +++
 
 ![](https://media.urbit.org/site/posts/essays/2019-5-roadmap-1.png)

--- a/content/blog/a-founders-farewell.md
+++ b/content/blog/a-founders-farewell.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/a-founders-farewell", "/posts/a-founders-farewell"]
 [extra]
 author = "Curtis Yarvin"
 ship = "~sorreg-namtyv"
+image = "https://storage.googleapis.com/media.urbit.org/site/farewell.png"
 +++
 
 ![Curtis Yarvin portrait](https://storage.googleapis.com/media.urbit.org/site/farewell.png)

--- a/content/blog/an-urbit-overview.md
+++ b/content/blog/an-urbit-overview.md
@@ -6,7 +6,9 @@ aliases = ["/posts/essays/an-urbit-overview", "/posts/an-urbit-overview"]
 [extra]
 author = "Galen Wolfe-Pauly"
 ship = "~ravmel-ropdyl"
+image = "https://media.urbit.org/site/blog-0.jpg"
 +++
+
 ![](https://media.urbit.org/site/blog-0.jpg)
 
 ## What Urbit is

--- a/content/blog/azimuth-as-multipass.md
+++ b/content/blog/azimuth-as-multipass.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/azimuth-as-multipass/", "/posts/azimuth-as-multipass"]
 [extra]
 author = "Galen Wolfe-Pauly"
 ship = "~ravmel-ropdyl"
+image = "https://media.urbit.org/site/posts/essays/azimuth-as-multipass-1.png"
 +++
 
 ![](https://media.urbit.org/site/posts/essays/azimuth-as-multipass-1.png)

--- a/content/blog/azimuth-security-bounty-program.md
+++ b/content/blog/azimuth-security-bounty-program.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/azimuth-security-bounty-program", "/posts/azimuth-secu
 [extra]
 author = "Anthony Arroyo"
 ship = "~poldec-tonteg"
+image = "https://media.urbit.org/site/posts/essays/azimuth-security-bounty-program-1.jpg"
 +++
 
 ![](https://media.urbit.org/site/posts/essays/azimuth-security-bounty-program-1.jpg)

--- a/content/blog/beliefs-and-principles.md
+++ b/content/blog/beliefs-and-principles.md
@@ -6,7 +6,9 @@ aliases = ["/posts/essays/beliefs-and-principles", "/posts/beliefs-and-principle
 [extra]
 author = "Curtis Yarvin + Galen Wolfe-Pauly"
 ship = "~sorreg-namtyv + ~ravmel-ropdyl"
+image = "https://media.urbit.org/site/blog-2.jpg"
 +++
+
 ![](https://media.urbit.org/site/blog-2.jpg)
 
 ## Beliefs

--- a/content/blog/common-objections-to-urbit.md
+++ b/content/blog/common-objections-to-urbit.md
@@ -6,7 +6,9 @@ aliases = ["/posts/essays/common-objections-to-urbit", "/posts/common-objections
 [extra]
 author = "Curtis Yarvin"
 ship = "~sorreg-namtyv"
+image ="https://media.urbit.org/site/blog-9.jpg"
 +++
+
 ![](https://media.urbit.org/site/blog-9.jpg)
 
 We love crowdsourced criticism.  We've heard a lot of great

--- a/content/blog/interim-constitution.md
+++ b/content/blog/interim-constitution.md
@@ -6,7 +6,9 @@ aliases = ["/posts/essays/interim-constitution", "/posts/interim-constitution"]
 [extra]
 author = "Tlon"
 ship = ""
+image = "https://media.urbit.org/site/blog-7.jpg"
 +++
+
 ![](https://media.urbit.org/site/blog-7.jpg)
 
 ## Declaration of purpose

--- a/content/blog/landscape-a-portrait.md
+++ b/content/blog/landscape-a-portrait.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/landscape-a-portrait/", "/posts/landscape-a-portrait"]
 [extra]
 author = "Matilde Park"
 ship = "~haddef-sigwen"
+image = "https://media.urbit.org/site/posts/essays/landscape-a-portrait-1.png"
 +++
 
 ![](https://media.urbit.org/site/posts/essays/landscape-a-portrait-1.png)

--- a/content/blog/magic.md
+++ b/content/blog/magic.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/magic", "/posts/magic"]
 [extra]
 author = "Curtis Yarvin"
 ship = "~sorreg-namtyv"
+image = "https://media.urbit.org/site/blog-7.jpg"
 +++
 ![](https://media.urbit.org/site/blog-7.jpg)
 

--- a/content/blog/the-100-year-computer.md
+++ b/content/blog/the-100-year-computer.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/the-100-year-computer/", "/posts/the-100-year-computer
 [extra]
 author = "Galen Wolfe-Pauly"
 ship = "~ravmel-ropdyl"
+image = "https://media.urbit.org/site/posts/essays/100-year-computer-1.png"
 +++
 
 ![](https://media.urbit.org/site/posts/essays/100-year-computer-1.png)

--- a/content/blog/the-state-of-landscape.md
+++ b/content/blog/the-state-of-landscape.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/the-state-of-landscape", "/posts/the-state-of-landscap
 [extra]
 author = "Galen Wolfe-Pauly"
 ship = "~ravmel-ropdyl"
+image = "https://media.urbit.org/site/posts/essays/the-state-of-landscape-1.png"
 +++
 
 ![](https://media.urbit.org/site/posts/essays/the-state-of-landscape-1.png)

--- a/content/blog/the-urbit-address-space.md
+++ b/content/blog/the-urbit-address-space.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/the-urbit-address-space", "/posts/the-urbit-address-sp
 [extra]
 author = "Galen Wolfe-Pauly + Curtis Yarvin"
 ship = "~ravmel-ropdyl + ~sorreg-namtyv"
+image = "https://media.urbit.org/site/blog-3.jpg"
 +++
 ![](https://media.urbit.org/site/blog-3.jpg)
 

--- a/content/blog/urbit-and-the-blockchain.md
+++ b/content/blog/urbit-and-the-blockchain.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/urbit-and-the-blockchain", "/posts/urbit-and-the-block
 [extra]
 author = "Curtis Yarvin"
 ship = "~sorreg-namtyv"
+image = "https://media.urbit.org/site/blog-1.jpg"
 +++
 ![](https://media.urbit.org/site/blog-1.jpg)
 

--- a/content/blog/urbit-grants-and-mid-2019-gifts.md
+++ b/content/blog/urbit-grants-and-mid-2019-gifts.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/urbit-grants-and-mid-2019-gifts", "/posts/urbit-grants
 [extra]
 author = "Galen Wolfe-Pauly + Alex Matzner"
 ship = "~ravmel-ropdyl + ~mignyt-mogseb"
+image = "https://media.urbit.org/site/posts/essays/urbit-grants-and-mid-2019-gifts-1.jpg"
 +++
 
 ![](https://media.urbit.org/site/posts/essays/urbit-grants-and-mid-2019-gifts-1.jpg)

--- a/content/blog/what-is-urbit-for.md
+++ b/content/blog/what-is-urbit-for.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/what-is-urbit-for", "/posts/what-is-urbit-for"]
 [extra]
 author = "Galen Wolfe-Pauly"
 ship = "~ravmel-ropdyl"
+image = "https://media.urbit.org/site/blog-1.jpg"
 +++
 ![](https://media.urbit.org/site/blog-1.jpg)
 

--- a/content/blog/why-urbit-probably-does-not-need-a-blockchain.md
+++ b/content/blog/why-urbit-probably-does-not-need-a-blockchain.md
@@ -6,6 +6,7 @@ aliases = ["/posts/essays/why-urbit-probably-does-not-need-a-blockchain/", "/pos
 [extra]
 author = "Curtis Yarvin"
 ship = "~sorreg-namtyv"
+image = "https://media.urbit.org/site/blog-1.jpg"
 +++
 ![](https://media.urbit.org/site/blog-1.jpg)
 

--- a/content/understanding-urbit/network-and-os.md
+++ b/content/understanding-urbit/network-and-os.md
@@ -6,6 +6,7 @@ weight = 5
 flatten_pagination = "true"
 hide_next_title = "true"
 hide_previous_title = "true"
+image = "https://media.urbit.org/site/understanding-urbit/network-os/urbit-os-phones@2x.png"
 +++
 
 

--- a/content/understanding-urbit/project-history.md
+++ b/content/understanding-urbit/project-history.md
@@ -6,6 +6,7 @@ weight = 7
 flatten_pagination = "true"
 hide_next_title = "true"
 hide_previous_title = "true"
+image = "https://media.urbit.org/site/understanding-urbit/project-history/project-status-landscape-earth@2x.png"
 +++
 
 Can you move to Urbit today and never look back? Not quite yet. Urbit is still young.

--- a/content/understanding-urbit/urbit-id.md
+++ b/content/understanding-urbit/urbit-id.md
@@ -6,6 +6,7 @@ weight = 4
 flatten_pagination = "true"
 hide_next_title = "true"
 hide_previous_title = "true"
+image = "https://media.urbit.org/site/understanding-urbit/urbit-id/urbit-id-cards@2x.png"
 +++
 
 Every time you post a comment, like something, send a message, or use any app or service, you need an account. (And, behind the scenes, a network address.) Neither of these things belongs to you. The way things are going, they never will. No matter what you’re up to with your phone or laptop, you’re dependent on MEGACORP.

--- a/content/understanding-urbit/your-last-computer.md
+++ b/content/understanding-urbit/your-last-computer.md
@@ -6,6 +6,7 @@ weight = 2
 flatten_pagination = "true"
 hide_next_title = "true"
 hide_previous_title = "true"
+image = "https://media.urbit.org/site/understanding-urbit/your-last-computer/your-last-computer-waves@2x.png"
 +++
 
 This whole ‘simple, durable, yours’ thing may sound good, but what does it add up to? What does it feel like?

--- a/content/updates/2018-10-12-update.md
+++ b/content/updates/2018-10-12-update.md
@@ -7,6 +7,7 @@ aliases = ["/posts/2018-10-12-update/"]
 [extra]
 author = "Rob"
 ship = "~lodleb-ritrul"
+image = "https://media.urbit.org/fora/updates/2018.10.12-update.png"
 +++
 
 ![](https://media.urbit.org/fora/updates/2018.10.12-update.png)

--- a/content/updates/2018-10-24-update.md
+++ b/content/updates/2018-10-24-update.md
@@ -7,6 +7,7 @@ aliases = ["/posts/2018-10-24-update/"]
 [extra]
 author = "Rob"
 ship = "~lodleb-ritrul"
+image = "https://media.urbit.org/fora/updates/2018.10.24-update.jpg"
 +++
 
 Here's a short update from the team at Tlon for the week of `~2018.10.24`:

--- a/content/updates/2018-11-20-update.md
+++ b/content/updates/2018-11-20-update.md
@@ -7,6 +7,7 @@ aliases = ["/posts/2018-11-20-update/"]
 [extra]
 author = "Rob"
 ship = "~lodleb-ritrul"
+image = "https://media.urbit.org/fora/updates/2018.11.19-update.jpg"
 +++
 
 Here's a short update from the team at Tlon for the week of `~2018.11.20`:

--- a/content/updates/2018-11-6-update.md
+++ b/content/updates/2018-11-6-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2018-11-6-update/"]
 [extra]
 author = "Rob"
 ship = "~lodleb-ritrul"
+image = "https://media.urbit.org/fora/updates/2018.11.7-update.jpg"
 +++
 
 Here's a short update from the team at Tlon for the week of `~2018.11.6`:

--- a/content/updates/2018-12-18-update.md
+++ b/content/updates/2018-12-18-update.md
@@ -7,6 +7,7 @@ aliases = ["/posts/2018-12-18-update/"]
 [extra]
 author = "Rob"
 ship = "~lodleb-ritrul"
+image = "https://media.urbit.org/fora/updates/2018.12.18-update.png"
 +++
 
 Here's a short update from the team at Tlon for the week of `~2018.12.18`:

--- a/content/updates/2018-5-23-update.md
+++ b/content/updates/2018-5-23-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2018-5-23-update/"]
 [extra]
 ship = "~tonlur-sarret"
 author = ""
+image = "https://media.urbit.org/fora/updates/~2018.5.22-Update-1.jpg"
 +++
 
 Here's a short update from Tlon for the week of `~2018.5.22`:

--- a/content/updates/2018-5-30-update.md
+++ b/content/updates/2018-5-30-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2018-5-30-update/"]
 [extra]
 ship = "~tonlur-sarret"
 author = ""
+image = "https://media.urbit.org/fora/updates/~2018.5.30-Update-1.jpg"
 +++
 
 Here's an update from the team at Tlon for the week of `~2018.5.30`:

--- a/content/updates/2018-6-6-update.md
+++ b/content/updates/2018-6-6-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2018-6-6-update/"]
 [extra]
 ship = "~tonlur-sarret"
 author = ""
+image = "https://media.urbit.org/fora/updates/~2018.6.6-Update-1.jpg"
 +++
 
 Here's a short update from the team at Tlon for the week of `~2018.6.6`:

--- a/content/updates/2018-7-13-update.md
+++ b/content/updates/2018-7-13-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2018-7-13-update/"]
 [extra]
 author = "~tonlur-sarret"
 ship = "~poldec-tonteg"
+image = "https://media.urbit.org/fora/updates/~2018.7.13-Update-1.jpg"
 +++
 
 Here's a short update from the team at Tlon for the week of `~2018.7.13`:
@@ -15,7 +16,7 @@ Here's a short update from the team at Tlon for the week of `~2018.7.13`:
   cannot be patched up to make it work. You have to start over with a working
   simple system."
 
--[John Gall](https://en.wikipedia.org/wiki/John_Gall_(author)
+-[John Gall](https://en.wikipedia.org/wiki/John_Gall_(author))
 
 ![](https://media.urbit.org/fora/updates/~2018.7.13-Update-1.jpg)
 

--- a/content/updates/2018-7-20-update.md
+++ b/content/updates/2018-7-20-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2018-7-20-update/"]
 [extra]
 author = "~tonlur-sarret"
 ship = "~poldec-tonteg"
+image = "https://media.urbit.org/fora/updates/~2018.7.13-Update-1.jpg"
 +++
 
 Here's a short update from the team at Tlon for the week of `~2018.7.20`:

--- a/content/updates/2018-7-3-update.md
+++ b/content/updates/2018-7-3-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2018-7-3-update/"]
 [extra]
 author = "~tonlur-sarret"
 ship = "~poldec-tonteg"
+image = "https://media.urbit.org/fora/updates/~2018.7.2-Update-1.jpg"
 +++
 
 ![](https://media.urbit.org/fora/updates/~2018.7.2-Update-1.jpg)

--- a/content/updates/2018-7-30-update.md
+++ b/content/updates/2018-7-30-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2018-7-30-update/"]
 [extra]
 author = "~tonlur-sarret"
 ship = "~poldec-tonteg"
+image = "https://media.urbit.org/fora/updates/~2018.7.30-Update-1.jpg"
 +++
 
 Here's a short update from the team at Tlon for the week of `~2018.7.30`:

--- a/content/updates/2018-8-23-update.md
+++ b/content/updates/2018-8-23-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2018-8-23-update/"]
 [extra]
 author = "Anthony"
 ship = "~poldec-tonteg"
+image = "https://media.urbit.org/fora/updates/2018.8.23-update-1.jpeg"
 +++
 
 ![](https://media.urbit.org/fora/updates/2018.8.23-update-1.jpeg)

--- a/content/updates/2018-8-30-update.md
+++ b/content/updates/2018-8-30-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2018-8-30-update/"]
 [extra]
 author = "Anthony"
 ship = "~poldec-tonteg"
+image = "https://media.urbit.org/fora/updates/2018.8.29-update-1.jpg"
 +++
 
 ![](https://media.urbit.org/fora/updates/2018.8.29-update-1.jpg)

--- a/content/updates/2018-8-8-update.md
+++ b/content/updates/2018-8-8-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2018-8-8-update/"]
 [extra]
 author = "~tonlur-sarret"
 ship = "~poldec-tonteg"
+image = "https://media.urbit.org/fora/updates/~2018.8.8-Update-1.jpeg"
 +++
 
 Here's a short update from the team at Tlon for the week of `~2018.8.8`:

--- a/content/updates/2018-9-11-update.md
+++ b/content/updates/2018-9-11-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2018-9-11-update/"]
 [extra]
 author = "Anthony"
 ship = "~poldec-tonteg"
+image = "https://media.urbit.org/fora/updates/2018.9.11-update-1.jpg"
 +++
 
 I've gone short on words and long on links for this update, since sometimes the

--- a/content/updates/2019-11-06-update.md
+++ b/content/updates/2019-11-06-update.md
@@ -2,10 +2,12 @@
 title = "~2019.11.06 Update"
 date = 2019-11-06
 description = "Weekly Web Update"
+slug = "/updates/2019-11-06"
 aliases = ["/posts/updates/2019-11-06-update", "/posts/2019-11-06-update/"]
 [extra]
 author = ""
 ship = ""
+image = "https://media.urbit.org/site/posts/updates/~2019.11.06-update.jpg"
 +++
 
 ![](https://media.urbit.org/site/posts/updates/~2019.11.06-update.jpg)

--- a/content/updates/2019-2-11-update.md
+++ b/content/updates/2019-2-11-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2019-2-11-update/"]
 [extra]
 author = "Morgan"
 ship = "~hidrel-fabtel"
+image = "https://media.urbit.org/site/posts/updates/~2019.2.11-update-1.jpg"
 +++
 Here’s a short update from the team for the week of `~2019.2.11`:
 

--- a/content/updates/2019-2-25-update.md
+++ b/content/updates/2019-2-25-update.md
@@ -6,10 +6,11 @@ aliases = ["/posts/2019-2-25-update/"]
 [extra]
 author = "Morgan"
 ship = "~hidrel-fabtel"
+image = "https://media.urbit.org/site/posts/updates/~2019.2.25-update-1.jpg"
 +++
 Here’s a short update from the team for the week of `~2019.2.25`:
 
-![](https://media.urbit.org/site/posts/updates/~2019.2.25-update-1.jpg")
+![](https://media.urbit.org/site/posts/updates/~2019.2.25-update-1.jpg)
 
 ## Network
 

--- a/content/updates/2019-2-26-network-update.md
+++ b/content/updates/2019-2-26-network-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2019-2-26-network-update/"]
 [extra]
 author = "Anthony"
 ship = "~poldec-tonteg"
+image = "https://media.urbit.org/site/posts/updates/~2019.2.26-update-1.jpg"
 +++
 ![](https://media.urbit.org/site/posts/updates/~2019.2.26-update-1.jpg)
 

--- a/content/updates/2019-2-4-update.md
+++ b/content/updates/2019-2-4-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2019-2-5-update/"]
 [extra]
 author = "Rob"
 ship = "~lodleb-ritrul"
+image = "https://media.urbit.org/fora/updates/2019.2.4-update.jpg"
 +++
 Here's a short update from the team at Tlon for the week of `~2019.2.5`:
 

--- a/content/updates/2019-3-11-update.md
+++ b/content/updates/2019-3-11-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2019-3-11-update/"]
 [extra]
 author = "Morgan"
 ship = "~hidrel-fabtel"
+image = "https://media.urbit.org/site/posts/updates/~2019.3.11-update-1.jpg"
 +++
 Here’s a short update from the team for the week of `~2019.3.11`:
 

--- a/content/updates/2019-3-27-update.md
+++ b/content/updates/2019-3-27-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2019-3-27-update/"]
 [extra]
 author = "Morgan"
 ship = "~hidrel-fabtel"
+image = "https://media.urbit.org/site/posts/updates/~2019.3.27-update-1.jpg"
 +++
 Here’s a short update from the team as of `~2019.3.27`:
 

--- a/content/updates/2019-3-4-update.md
+++ b/content/updates/2019-3-4-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2019-3-4-update/"]
 [extra]
 author = "Morgan"
 ship = "~hidrel-fabtel"
+image = "https://media.urbit.org/site/posts/updates/~2019.3.4-update-1.jpg"
 +++
 Here’s a short update from the team for the week of `~2019.3.4`:
 

--- a/content/updates/2019-4-11-update.md
+++ b/content/updates/2019-4-11-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2019-4-11-update/"]
 [extra]
 author = "Morgan"
 ship = "~hidrel-fabtel"
+image = "https://media.urbit.org/site/posts/updates/~2019.4.11-update-1.jpg"
 +++
 Here’s a short update from the team as of `~2019.4.11`:
 

--- a/content/updates/2019-5-10-update.md
+++ b/content/updates/2019-5-10-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2019-5-10-update/"]
 [extra]
 author = "Morgan"
 ship = "~hidrel-fabtel"
+image = "https://media.urbit.org/site/posts/updates/~2019.5.10-update-1.jpg"
 +++
 
 ![](https://media.urbit.org/site/posts/updates/~2019.5.10-update-1.jpg)

--- a/content/updates/2019-5-17-update.md
+++ b/content/updates/2019-5-17-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2019-5-17-update/"]
 [extra]
 author = "Morgan"
 ship = "~hidrel-fabtel"
+image = "https://media.urbit.org/site/posts/updates/~2019.5.17-update-1.png"
 +++
 
 ![](https://media.urbit.org/site/posts/updates/~2019.5.17-update-1.png)

--- a/content/updates/2019-5-31-update.md
+++ b/content/updates/2019-5-31-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/2019-5-31-update/"]
 [extra]
 author = "Morgan"
 ship = "~hidrel-fabtel"
+image = "https://media.urbit.org/site/posts/updates/~2019.5.31-update-3.jpg"
 +++
 
 ![](https://media.urbit.org/site/posts/updates/~2019.5.31-update-3.jpg)

--- a/content/updates/2019-6-14-update.md
+++ b/content/updates/2019-6-14-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/updates/2019-6-14-update", "/posts/2019-6-14-update/"]
 [extra]
 author = "Morgan"
 ship = "~hidrel-fabtel"
+image = "https://media.urbit.org/site/posts/updates/~2019.6.14-update-1.jpg"
 +++
 
 ![](https://media.urbit.org/site/posts/updates/~2019.6.14-update-1.jpg)

--- a/content/updates/2019-7-25-update.md
+++ b/content/updates/2019-7-25-update.md
@@ -6,6 +6,7 @@ aliases = ["/posts/updates/2019-7-25-update", "/posts/2019-7-25-update/"]
 [extra]
 author = "Morgan"
 ship = "~hidrel-fabtel"
+image = "https://media.urbit.org/site/posts/updates/~2019.7.25-update-1.jpg"
 +++
 
 ![](https://media.urbit.org/site/posts/updates/~2019.7.25-update-1.jpg)

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,8 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@urbit">
     <meta name="twitter:creator" content="@urbit">
-    <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+    {% block image %}
+    {% endblock image %}
     {% block title %}
     {% endblock title %}
     {% block description %}

--- a/templates/doc.html
+++ b/templates/doc.html
@@ -7,6 +7,11 @@
   <meta name="og:description" content="From the Urbit documentation.">
   <meta name="description" content="From the Urbit documentation.">
 {% endblock description %}
+
+{% block image %}
+  <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+{% endblock image %}
+
 {% block bodyclasses %} class="docs" {% endblock bodyclasses %}
 {% block content %}
 <!-- header -->

--- a/templates/essays/list.html
+++ b/templates/essays/list.html
@@ -10,6 +10,10 @@
   <meta name="description" content="Directory for the Urbit Blog.">
 {% endblock description %}
 
+{% block image %}
+  <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+{% endblock image %}
+
 {% block content %}
 <!-- header -->
 <nav class="mt4 full fourth-1-lg mb3 mb0-m mb0-l mb0-xl">

--- a/templates/essays/post.html
+++ b/templates/essays/post.html
@@ -23,6 +23,14 @@
   {% endif %}"
 {% endblock bodyclasses %}
 
+{% block image %}
+  {% if page.extra.image %}
+    <meta name="twitter:image" content="{{ page.extra.image }}">
+  {% else %}
+    <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+  {% endif %}
+{% endblock image %}
+
 {% block content %}
 <nav class="mt4 full fourth-1-lg mb3 mb0-m mb0-l mb0-xl">
   <a class="gray3" href="/">Urbit</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,10 @@
 
 {% endblock templatestyles %}
 
+{% block image %}
+  <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+{% endblock image %}
+
 {% block bodyclasses %}class="index"{% endblock bodyclasses %}
 
 {% block title %} 

--- a/templates/list.html
+++ b/templates/list.html
@@ -8,6 +8,10 @@
   <meta name="description" content="Directory for {{ section.title }}.">
 {% endblock description %}
 
+{% block image %}
+  <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+{% endblock image %}
+
 {% block content %}
 <!-- header -->
 <nav class="mt4 full fourth-1-lg mb3 mb0-m mb0-l mb0-xl">

--- a/templates/media/list.html
+++ b/templates/media/list.html
@@ -9,6 +9,10 @@
   <meta name="description" content="A curated list of Urbit-related media.">
 {% endblock description %}
 
+{% block image %}
+  <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+{% endblock image %}
+
 {% block content %}
 <!-- header -->
 <nav class="mt4 full fourth-1-lg mb3 mb0-m mb0-l mb0-xl">

--- a/templates/page.html
+++ b/templates/page.html
@@ -15,6 +15,14 @@
   {% endif %}
 {% endblock description %}
 
+{% block image %}
+  {% if page.extra.image %}
+    <meta name="twitter:image" content="{{ page.extra.image }}">
+  {% else %}
+    <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+  {% endif %}
+{% endblock image %}
+
 {% block content %}
 
 <!-- header -->

--- a/templates/page_indiced.html
+++ b/templates/page_indiced.html
@@ -16,6 +16,14 @@
   {% endif %}
 {% endblock description %}
 
+{% block image %}
+  {% if page.extra.image %}
+    <meta name="twitter:image" content="{{ page.extra.image }}">
+  {% else %}
+    <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+  {% endif %}
+{% endblock image %}
+
 {% block content %}
 
 <!-- header -->

--- a/templates/sections/docs.html
+++ b/templates/sections/docs.html
@@ -7,6 +7,11 @@
   <meta name="og:description" content="From the Urbit documentation.">
   <meta name="description" content="From the Urbit documentation.">
 {% endblock description %}
+
+{% block image %}
+  <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+{% endblock image %}
+
 {% block bodyclasses %} class="docs" {% endblock bodyclasses %}
 {% block content %}
 <!-- header -->

--- a/templates/sections/docs/chapters.html
+++ b/templates/sections/docs/chapters.html
@@ -3,10 +3,16 @@
   <meta name="og:title" content="{{ section.title }} - {{ config.title }}">
   <title>{{ section.title }} - {{ config.title }}</title>
 {% endblock title %}
+
 {% block description %} 
   <meta name="og:description" content="From the Urbit documentation.">
   <meta name="description" content="From the Urbit documentation.">
 {% endblock description %}
+
+{% block image %}
+  <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+{% endblock image %}
+
 {% block content %}
 <!-- header -->
 <!-- content -->

--- a/templates/understanding-urbit/list.html
+++ b/templates/understanding-urbit/list.html
@@ -9,6 +9,10 @@
   <meta name="description" content="Urbit is a new kind of computer.">
 {% endblock description %}
 
+{% block image %}
+  <meta name="twitter:image" content="https://media.urbit.org/site/understanding-urbit/intro/intro-0.jpg">
+{% endblock image %}
+
 {% block content %}
 <!-- header -->
 <nav class="mt4 full fourth-1-lg mb3 mb0-m mb0-l mb0-xl absolute-xl">

--- a/templates/understanding-urbit/post.html
+++ b/templates/understanding-urbit/post.html
@@ -15,6 +15,14 @@
   {% endif %}
 {% endblock description %}
 
+{% block image %}
+  {% if page.extra.image %}
+    <meta name="twitter:image" content="{{ page.extra.image }}">
+  {% else %}
+    <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+  {% endif %}
+{% endblock image %}
+
 {% block bodyclasses %}
   class="essay
   {% if page.extra.classes %}

--- a/templates/updates/list.html
+++ b/templates/updates/list.html
@@ -10,6 +10,11 @@
 {% endblock description %}
 
 {% block bodyclasses %}class="updates"{% endblock bodyclasses %}
+
+{% block image %}
+  <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+{% endblock image %}
+
 {% block content %}
 <!-- header -->
 <nav class="mt4 full fourth-1-md fourth-1-lg mb3 mb0-m mb0-l mb0-xl">


### PR DESCRIPTION
Just warming up! We were previously showing the sig as our graphic on all pages, which is fine but not ideal. We have a lot of beautiful graphic content that makes for a captivating pull when sharing links to site content.

This PR adds the template components for specifying an image and (and the sig default) when generating the page's meta tags, and then adds the metadata on all applicable posts. (I also ended up cleaning up broken Markdown syntax as I found it.)