### PR TITLE
add white-space:pre-wrap to code tag to properly render gaps in inlin…

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -413,6 +413,7 @@ code, .code, .mono {
 
 code {
     @extend .bg-gray5, .pa1;
+    white-space: pre-wrap;
 }
 
     // code in headers


### PR DESCRIPTION
…e code

This got lost in the shuffle somewhere.  See: https://github.com/urbit/urbit.org/pull/145 and https://github.com/urbit/urbit.org/pull/162.

Before:
<img width="620" alt="Screen Shot 2019-11-17 at 12 54 29 AM" src="https://user-images.githubusercontent.com/15039850/69004344-68f37d00-08d7-11ea-92eb-02aba7e2318f.png">

After:
<img width="620" alt="Screen Shot 2019-11-17 at 12 52 56 AM" src="https://user-images.githubusercontent.com/15039850/69004350-7c064d00-08d7-11ea-8ca1-0ea459ae556b.png">

I don't know if this belongs in `sass/indigo.scss` or `sass/_main.scss`.  Please advise.

