### PR TITLE
Fix dual scroll bars on Firefox + Linux

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -49,7 +49,6 @@ body {
     color: #000;
     // Something about the main page video is causing the page to overflow.
     max-width:100vw;
-    overflow-x:hidden;
 }
 
 nav {


### PR DESCRIPTION
`overflow-x` doesn't seem to actually cause an overflow for the main page video (as its comment says in the scss), but it creates dual scroll bars on all the essays and posts, so I'm removing that line.

(Using Firefox on a Fedora Linux VM, who knows what else I'll find...)