### PR TITLE
remove left/right margin on post page lists

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -257,10 +257,12 @@ ul.posts, nav ul, nav li {
     list-style-type: none;
 }
 
-ul.posts {
-    li {
-        margin: 1rem 0 1rem 0;
-    }
+ul.posts li:not(:first-child) {
+    margin:1rem 0 1rem 0;
+}
+
+ul.posts li:first-child {
+    margin: 0 0 1rem 0;
 }
 
 nav ul.docs {

--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -257,6 +257,12 @@ ul.posts, nav ul, nav li {
     list-style-type: none;
 }
 
+ul.posts {
+    li {
+        margin: 1rem 0 1rem 0;
+    }
+}
+
 nav ul.docs {
     line-height: 30px;
 }

--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -258,11 +258,11 @@ ul.posts, nav ul, nav li {
 }
 
 ul.posts li:not(:first-child) {
-    margin:1rem 0 1rem 0;
+    margin:2rem 0 2rem 0;
 }
 
 ul.posts li:first-child {
-    margin: 0 0 1rem 0;
+    margin: 0 0 2rem 0;
 }
 
 nav ul.docs {

--- a/templates/essays/post.html
+++ b/templates/essays/post.html
@@ -43,8 +43,8 @@
   {% include "partials/navigation-search.html" %}
 </nav>
 
-<article class="mb4 measure-wide full c4-12-lg">
-    <h1 class="mb2 mt4 fw6">{{ page.title }}</h1>
+<article class="mb4 mt4 measure-wide full c4-12-lg">
+    <h2 class="f5 fw6 mt0 mb1">{{ page.title }}</h2>
     {% if page.extra.author %}
     <span class="dib" rel="author"> {{ page.extra.author }}
       {% if page.extra.ship %}


### PR DESCRIPTION
I was going a bit batty over how articles and post directories sat on the grid differently. Turns out some list margins were getting in the way. This fixes that. Makes the post pages look better on mobile, too.

(To check this PR, just go to a posts page and a blog post and compare.)