### PR TITLE
add community grants

### DIFF
--- a/content/community/community-grants.md
+++ b/content/community/community-grants.md
@@ -1,0 +1,14 @@
++++
+title = "Community Grants"
+description = "Select Urbit address space grants for your group or community."
+weight = 3
+[extra]
+hideprevious = "true"
+hidenext = "true"
++++
+
+Interested in getting your community on Urbit? We are currently accepting applications for select groups to get started on Urbit together using an [invite pool](@/docs/tutorials/creating-an-invite-pool.md).
+
+To get started, fill out the application below. Any information you share will be held privately, and only for the purpose of consideration for the grant.
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSf_uD5fUw6xqoxtzUhSwURFYO57XQl067N3vEdy7_rTD8T2VQ/viewform?embedded=true" width="640" height="1394" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>

--- a/content/community/governance.md
+++ b/content/community/governance.md
@@ -2,7 +2,7 @@
 title = "Governance"
 description = "On the governance of the project, including both the senate of galaxies and the core developers."
 aliases = ["/governance"]
-weight = 3
+weight = 4
 [extra]
 hidetitle = "true"
 hideprevious = "true"

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -27,7 +27,7 @@
       <li class="mt2 f6"><a href="https://groups.google.com/a/urbit.org/forum/#!forum/dev">urbit-dev</a></li>
       <li class="mt2 f6"><a href="/community/hoonschool">Hoon School</a></li>
       <li class="mt2 f6"><a href="/community/meetups">Meetups</a></li>
-      <li class="mt2 f6"><a href="/community/hosting-a-meetup">Hosting a Meetup</a></li>
+      <li class="mt2 f6"><a href="/community/community-grants">Community Grants</a></li>
       <li class="mt2 f6"><a href="/community/governance">Governance</a></li>
     </nav>
   </section>
@@ -35,7 +35,7 @@
     <nav class="c1-4-md c3-5-lg half-1 mt4 mb5">
       <h3 class="mt0 mb3 pt0 pb0">Developers</h3>
       <li class="mt2 f6"><a href="/docs">Documentation</a></li>
-      <li class="mt2 f6"><a href="https://grants.urbit.org">Grants</a></li>
+      <li class="mt2 f6"><a href="https://grants.urbit.org">Developer Grants</a></li>
       <li class="mt2 f6"><a href="/bounties">Security Bounties</a></li>
     </nav>
     <nav class="c4-7-md c5-7-lg half-2 mt4 mb5">


### PR DESCRIPTION
Embeds an application for community grants on its own page in the /community section. Adds some copy. Replaces "Hosting a Meetup" in the footer, since hosting a meetup is more or less related as a pair with "Meetups" generally.

Also renames the link to grants.urbit.org in the footer to "Developer Grants", though I know that's not strictly true. We may need a better name than a Community Grant for this page, in such case. Let me know what you think.

https://deploy-preview-315--urbit-org.netlify.com/community/community-grants/