### PR TITLE
Add glossary to documentation, navigation, and site search

### DIFF
--- a/static/glossary.js
+++ b/static/glossary.js
@@ -1,4 +1,5 @@
-var runes = [
+var glossary = [
+  // runes
     {
       "name": "dot",
       "symbol": ".",
@@ -978,5 +979,377 @@ var runes = [
       "usage": "Ford",
       "link": "/docs/tutorials/arvo/ford/#fascen",
       "desc": "Ford rune. Propagate extra arguments into renderers."
+    }, 
+    // glossary starts here
+    {
+      "name": "ames",
+      "symbol": "",
+      "usage": "Arvo",
+      "link": "/docs/glossary/ames/",
+      "desc": "The name of the Urbit network and the vane that communicates over it."
+    },
+    {
+      "name": "aqua",
+      "symbol": "",
+      "usage": "Arvo",
+      "link": "/docs/glossary/aqua/",
+      "desc": "A virtualization tool whose primary purpose is testing and development."
+    },
+    {
+      "name": "arvo",
+      "symbol": "",
+      "usage": "Arvo",
+      "link": "/docs/glossary/arvo/",
+      "desc": "The Urbit operating system and kernel."
+    },
+    {
+      "name": "atom",
+      "symbol": "",
+      "usage": "hoon-nock",
+      "link": "/docs/glossary/atom/",
+      "desc": "The most basic data type in Hoon and Nock, a non-negative integer of any size."
+    },
+    {
+      "name": "azimuth",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/azimuth/",
+      "desc": "Urbit's identity layer, built as a suite of smart contracts on the Ethereum blockchain."
+    },
+    {
+      "name": "behn",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/behn/",
+      "desc": "Timing vane of Arvo. Allows for applications to schedule events."
+    },
+    {
+      "name": "bridge",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/bridge/",
+      "desc": "A client made for interacting with Azimuth."
+    },
+    {
+      "name": "censure",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/censure/",
+      "desc": "Allows stars and galaxies to assign negative reputation information to other points of equal or lower rank."
+    },
+    {
+      "name": "ceremony",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/ceremony/",
+      "desc": "The event that transferred custody of Azimuth identities from a centralized ledger to the Ethereum blockchain."
+    },
+    {
+      "name": "chat",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/chat/",
+      "desc": "An application that handles communication between ships."
+    },
+    {
+      "name": "claims",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/claims/",
+      "desc": "Allows Urbit identities to make publicly visible assertions about their owner."
+    },
+    {
+      "name": "clay",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/clay/",
+      "desc": "The filesystem and typed revision-control vane of Arvo."
+    },
+    {
+      "name": "comet",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/comet/",
+      "desc": "A type of ship on the Urbit network."
+    },
+    {
+      "name": "delegated sending",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/delegated-sending/",
+      "desc": "A method by which a star can distribute planets, assigning them to a delegated planet."
+    },
+    {
+      "name": "desk",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/desk/",
+      "desc": "A revision-controlled branch of the Clay filesystem."
+    },
+    {
+      "name": "dill",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/dill/",
+      "desc": "The terminal-driver vane of Arvo."
+    },
+    {
+      "name": "document vote",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/docvote/",
+      "desc": "A voting action taken by the Galactic Senate over Azimuth."
+    },
+    {
+      "name": "ecliptic",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/ecliptic/",
+      "desc": "A contract that sets the rules for what is and is not possible on Azimuth."
+    },
+    {
+      "name": "event log",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/eventlog/",
+      "desc": "A totally ordered list of every single Arvo event a ship has undergone. A ship's state is a pure function of its event log."
+    },
+    {
+      "name": "eyre",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/eyre/",
+      "desc": "The web-server vane of Arvo. Handles all HTTP messages."
+    },
+    {
+      "name": "ford",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/ford/",
+      "desc": "The build-system vane of Arvo."
+    },
+    {
+      "name": "galaxy",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/galaxy/",
+      "desc": "8-bit Urbit addresses, sitting at the top of the identity hierarchy, that vote on network changes and act as infrastructural nodes."
+    },
+    {
+      "name": "gall",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/gall/",
+      "desc": "The application-management vane of Arvo. Userspace applications are stopped, started, and sandboxed by Gall."
+    },
+    {
+      "name": "hall",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/hall/",
+      "desc": "The former messaging protocol for Arvo, no longer in use."
+    },
+    {
+      "name": "hd wallet",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/hdwallet",
+      "desc": "A system of related Ethereum addresses that store and manage an Urbit identity, each a proxy with different permissions over its management."
+    },
+    {
+      "name": "hoon",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/hoon/",
+      "desc": "A strict, higher-order typed functional programming language that compiles to Nock."
+    },
+    {
+      "name": "invite tree",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/invitetree/",
+      "desc": "The state stored by the delegated sending contract, recording who gave a planet to whom under a specific star."
+    },
+    {
+      "name": "jacque",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/jacque/",
+      "desc": "A Nock interpreter written in Java, in active development as a worker process for Vere."
+    },
+    {
+      "name": "keyfile",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/keyfile/",
+      "desc": "A piece of information used to associate a ship with an Urbit identity."
+    },
+    {
+      "name": "landscape",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/landscape/",
+      "desc": "A front-end user interface for Urbit."
+    },
+    {
+      "name": "mark",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/mark/",
+      "desc": "A file type in the Clay filesystem."
+    },
+    {
+      "name": "modulo",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/modulo/",
+      "desc": "The name of the home screen interface for Urbit within Landscape."
+    },
+    {
+      "name": "moon",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/moon/",
+      "desc": "A kind of ship on the Arvo network, issued by planets."
+    },
+    {
+      "name": "nock",
+      "symbol": "",
+      "usage": "hoon-nock",
+      "link": "/docs/glossary/nock/",
+      "desc": "A purely functional typeless programming language, and Urbit's lowest-level language."
+    },
+    {
+      "name": "noun",
+      "symbol": "",
+      "usage": "hoon-nock",
+      "link": "/docs/glossary/noun/",
+      "desc": "An atom or a cell. The basic data structure in Nock."
+    },
+    {
+      "name": "OTA",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/ota-updates/",
+      "desc": "Ships have the ability to upgrade themselves over the air. They receive updates from a sponsor star or galaxy."
+    },
+    {
+      "name": "pH",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/ph/",
+      "desc": "A Gall app that is a framework for fleet testing using Aqua."
+    },
+    {
+      "name": "pill",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/pill/",
+      "desc": "A bootstrap sequence to launch an Urbit ship for the first time."
+    },
+    {
+      "name": "planet",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/planet/",
+      "desc": "An Urbit identity at the bottom of the identity hierarchy. Issued by stars."
+    },
+    {
+      "name": "proxies",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/proxies/",
+      "desc": "Ethereum addresses in the Urbit HD Wallet that have limited powers."
+    },
+    {
+      "name": "replay",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/replay/",
+      "desc": "How Vere computes the state of a ship's Arvo instance from an event log."
+    },
+    {
+      "name": "sail",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/sailudon",
+      "desc": "A domain specific language for Hoon. Expresses XML data structures to render webpages."
+    },
+    {
+      "name": "udon",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/sailudon",
+      "desc": "A domain specific language for Hoon. Similar to Markdown."
+    },
+    {
+      "name": "senate",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/senate/",
+      "desc": "The body of all galaxies that govern Azimuth by majority vote."
+    },
+    {
+      "name": "ship",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/ship/",
+      "desc": "An instance of an Urbit computer that is a peer on the network."
+    },
+    {
+      "name": "arvo.network",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/shiparvonetwork/",
+      "desc": "A way to connect to a ship via HTTP, using DNS lookup."
+    },
+    {
+      "name": "star",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/star/",
+      "desc": "An Urbit identity sitting between stars and galaxies in the identity hierarchy. Infrastructural nodes for child planets."
+    },
+    {
+      "name": "sync",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/sync/",
+      "desc": "<code>|sync</code> sets up synchronization between two Clay desks."
+    },
+    {
+      "name": "talk",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/talk/",
+      "desc": "Urbit's first user application, sending messages between ships. No longer used, and replaced by Chat."
+    },
+    {
+      "name": "vane",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/vane/",
+      "desc": "An Arvo kernel module that performs essential system operations."
+    },
+    {
+      "name": "vere",
+      "symbol": "",
+      "usage": "arvo",
+      "link": "/docs/glossary/vere/",
+      "desc": "The Nock runtime environment and Urbit virtual machine, running on Unix."
+    },
+    {
+      "name": "vote",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/voting/",
+      "desc": "Voting is a power available to galaxies in their capacities as members of the Galactic Senate."
+    },
+    {
+      "name": "wallet generator",
+      "symbol": "",
+      "usage": "azimuth",
+      "link": "/docs/glossary/wallet-generator/",
+      "desc": "Generates an Urbit HD wallet."
     }
   ]

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -272,13 +272,20 @@ function initSearch() {
       return;
     }
 
-    for (let rune of runes) {
-      if (rune.symbol === term) {
+    for (let entry of glossary) {
+      if (entry.symbol === term) {
         glossaryResults.style.display="block";
         glossaryResultsItem.innerHTML = `
-        <a href="${rune.link}"><h3 class="black"><code class="red3 mr1">${rune.symbol}</code> ${rune.name}</h3>
-        <p class="black">${rune.desc}</p>
-         <span class="db tr black fw5" style="font-family: 'Inter UI', sans-serif;">Read more in Documentation -></span></a>
+        <a href="${entry.link}"><h3 class="black"><code class="pa0 red3 mr1">${entry.symbol}</code>${entry.name}</h3>
+        <p class="black">${entry.desc}</p>
+         <span class="db tr black fw5 mb3" style="font-family: 'Inter UI', sans-serif;">Read more in Documentation -></span></a>
+        `
+      } else if (entry.name === term.toLowerCase()) {
+        glossaryResults.style.display="block";
+        glossaryResultsItem.innerHTML = `
+        <a href="${entry.link}"><h3 class="black">${entry.name}</h3>
+        <p class="black">${entry.desc}</p>
+         <span class="db tr black fw5 mb3" style="font-family: 'Inter UI', sans-serif;">Read more in Glossary -></span></a>
         `
       }
     }

--- a/templates/base.html
+++ b/templates/base.html
@@ -62,7 +62,7 @@
     {% block content %}
     {% endblock content %}
     {% if config.build_search_index %}
-    <script type="text/javascript" src="{{ get_url(path="runes.js") | safe }}"></script>
+    <script type="text/javascript" src="{{ get_url(path="glossary.js") | safe }}"></script>
     <script type="text/javascript" src="{{ get_url(path="elasticlunr.min.js") | safe }}"></script>
     <script type="text/javascript" src="{{ get_url(path="search_index.en.js") | safe }}"></script>
     <script src="https://unpkg.com/popper.js@1"></script>

--- a/templates/partials/navigation-docs.html
+++ b/templates/partials/navigation-docs.html
@@ -10,10 +10,22 @@
     <span id="search-icon" class="f3 gray3">⚲</span><span class="ml3 gray2">Search</span>
   </button>
   <ul class="lh-copy">
+  <li class="ml2 mt1"><a href="/using/install">Install -> </a></li>
+  <li class="ml2 mt1"><a href="/using/operations/">Operations Manual -></a></li>
+  <li class="ml2 mt1 mb4"><a href="/using/develop/">Developer's Guide -></a></li>
   {% block menu %}
     {% set index = get_section(path="docs/_index.md") %}
     {% for s in index.subsections %}
     {% set subsection = get_section(path=s) %}
+    {% if subsection.extra.nav %}
+      <li class="ml3 mt1"><a
+        {% if current_url == subsection.permalink %}
+          class="fw6"
+        {% endif %}
+        href="{{ subsection.permalink }}">
+          {{ subsection.title }}
+        </a></li>
+    {% else %}
     <details {% if current_url is containing(subsection.path) %}
               open
              {% endif %}
@@ -71,6 +83,7 @@
         {% endfor %}
       {% endif %}
     </details>
+    {% endif %}
     {% endfor %}
   {% endblock menu %}
   </ul>
@@ -84,9 +97,16 @@
   </a>
   <select class="db mt4 pa2 b--black ba br0 mw4 f6 fw5" id="docsSelect" style="text-indent: 0.725rem;">
     <option>Navigation ↓</option>
+    <option> </option>
+    <option value="https://urbit.org/using/install">Install</option>
+    <option value="https://urbit.org/using/operations/">Operations Manual</option>
+    <option value="https://urbit.org/using/develop">Developer's Guide</option>
     {% set index = get_section(path="docs/_index.md") %}
     {% for s in index.subsections %}
     {% set subsection = get_section(path=s) %}
+    {% if subsection.extra.nav %}
+    <option value="{{ subsection.permalink }}">{{ subsection.title }}</option>
+    {% else %}
     <option> </option>
     <option>{{ subsection.title }}</option>
     <option>---</option>
@@ -116,6 +136,7 @@
       {% endfor %}
     {% endif %}
     {% endfor %}
+    {% endif %}
     {% endif %}
     {% endfor %}
   </select>

--- a/templates/sections/docs/glossary.html
+++ b/templates/sections/docs/glossary.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% block title %} 
+  <meta name="og:title" content="{{ section.title }} - {{ config.title }}">
+  <title>{{ section.title }} - {{ config.title }}</title>
+{% endblock title %}
+
+{% block description %} 
+  <meta name="og:description" content="From the Urbit documentation.">
+  <meta name="description" content="From the Urbit documentation.">
+{% endblock description %}
+
+{% block image %}
+  <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+{% endblock image %}
+
+{% block content %}
+<!-- header -->
+<!-- content -->
+{% include "partials/navigation-docs.html" %}
+<article class="mt4 mb6 full c4-11-lg">
+<!-- header -->
+<h1>{{ section.title }}</h1>
+<!-- body -->
+
+<div class="measure-wide mb4">
+{{ section.content | safe }}
+
+</div>
+
+{% set terms = get_section(path="docs/glossary/_index.md") %}
+{% set arvoTerms = terms.pages | filter(attribute="extra.category", value="arvo") | sort(attribute="title") %}
+{% set azimuthTerms = terms.pages | filter(attribute="extra.category", value="azimuth") | sort(attribute="title") %}
+{% set hoonNockTerms = terms.pages | filter(attribute="extra.category", value="hoon-nock") | sort(attribute="title") %}
+<div class="flex flex-wrap justify-between">
+  <div class="mt0 w-100 w-50-l w-30-xl"><a class="fw6" href="/docs/glossary/arvo/">Arvo</a>
+    <p>The Urbit OS.</p>
+  {% for term in arvoTerms %}
+  <li class="list mb1 mt1"><a href="{{term.permalink}}">{{ term.title }}</a></li>
+  {% endfor %}
+  </div>
+  <div class="mt4 mt0-l mt0-xl w-100 w-50-l w-30-xl">
+    <a class="fw6" href="/docs/glossary/azimuth">Azimuth</a>
+    <p>The Urbit identity layer.</p>
+  {% for term in azimuthTerms %}
+  <li class="list mb1 mt1"><a href="{{term.permalink}}">{{ term.title }}</a></li>
+  {% endfor %}
+  </div>
+
+  <div class="mt4 mt0-l mt0-xl w-100 w-50-l w-40-xl">
+    <a class="fw6" href="/docs/glossary/hoon">Hoon</a> <span class="fw6">+</span> <a class="fw6" href="/docs/glossary/nock">Nock</a>
+    <p>Hoon is Urbit's high-level programming language. It compiles to Nock, Urbit's low-level language.</p>
+  {% for term in hoonNockTerms %}
+  <li class="list mb1 mt1"><a href="{{term.permalink}}">{{ term.title }}</a></li>
+  {% endfor %}
+  </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
Closes #293. 

- Adds templates and custom navigation for the glossary within the Urbit documentation. Moves usage information to the top of the documentation sidebar once again.
- Glossary template generates its link list programmatically, which is then sorted alphabetically for each category.
- Renames runes.js to glossary.js and adds the glossary definitions to site-wide search.

![image](https://user-images.githubusercontent.com/20846414/70495914-8b467800-1adc-11ea-9255-6a95f8d91c23.png)

![image](https://user-images.githubusercontent.com/20846414/70495965-94cfe000-1adc-11ea-9d98-1477c7c933ed.png)

![image](https://user-images.githubusercontent.com/20846414/70496064-a618ec80-1adc-11ea-9a55-d81ed40ff774.png)

## Deployment

This branch is pulling its copy of the docs from [its "glossary" branch](https://github.com/urbit/docs/tree/glossary). To make corrections to copy on the docs, edits must be performed there and pulled back into this preview copy of urbit.org with a submodule commit.

To merge this PR, the glossary branch should be merged into master in the docs repository.

After that, this branch will once again check out master and merge.