### PR TITLE
essay template: author + address margin fix, slight color tweak

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -241,12 +241,6 @@ h4 {
     padding: 1rem 0 0.5rem 0;
 }
 
-    // author and ship styling
-span[rel=author] {
-    @extend .fw4;
-    margin-right: 5px;
-}
-
 address {
     display: inline;
     font-style: normal;

--- a/templates/essays/post.html
+++ b/templates/essays/post.html
@@ -47,7 +47,7 @@
     <h2 class="f5 fw6 mt0 mb1">{{ page.title }}</h2>
     {% if page.extra.author %}
     <span class="db"> 
-      <span class="dib mr1" rel="author">{{ page.extra.author }}</span>
+      <span class="dib fw4 mr1" rel="author">{{ page.extra.author }}</span>
       {% if page.extra.ship %}
       <address class="dib gray0 fw4 mono">{{ page.extra.ship }}</address>
     {% endif %}

--- a/templates/essays/post.html
+++ b/templates/essays/post.html
@@ -46,9 +46,10 @@
 <article class="mb4 mt4 measure-wide full c4-12-lg">
     <h2 class="f5 fw6 mt0 mb1">{{ page.title }}</h2>
     {% if page.extra.author %}
-    <span class="dib" rel="author"> {{ page.extra.author }}
+    <span class="db"> 
+      <span class="dib mr1" rel="author">{{ page.extra.author }}</span>
       {% if page.extra.ship %}
-      <address class="dib fw4 ml2 mono">{{ page.extra.ship }}</address>
+      <address class="dib gray0 fw4 mono">{{ page.extra.ship }}</address>
     {% endif %}
     </span>
     {% if page.date %}


### PR DESCRIPTION
If a post had multiple authors, the margin on the left of `<address>` element would push it slightly askew from the date and author name.

This just places it on the author's name instead, so they're always lined up.

This PR also changes the ship's color to `gray0` to, like the date, more subtly segregate the metadata from the author name.