### PR TITLE
remove glossary li margin

### DIFF
--- a/templates/sections/docs/glossary.html
+++ b/templates/sections/docs/glossary.html
@@ -35,14 +35,14 @@
   <div class="mt0 w-100 w-50-l w-30-xl"><a class="fw6" href="/docs/glossary/arvo/">Arvo</a>
     <p>The Urbit OS.</p>
   {% for term in arvoTerms %}
-  <li class="list mb1 mt1"><a href="{{term.permalink}}">{{ term.title }}</a></li>
+  <li class="list mb1 ml0 mt1"><a href="{{term.permalink}}">{{ term.title }}</a></li>
   {% endfor %}
   </div>
   <div class="mt4 mt0-l mt0-xl w-100 w-50-l w-30-xl">
     <a class="fw6" href="/docs/glossary/azimuth">Azimuth</a>
     <p>The Urbit identity layer.</p>
   {% for term in azimuthTerms %}
-  <li class="list mb1 mt1"><a href="{{term.permalink}}">{{ term.title }}</a></li>
+  <li class="list mb1 ml0 mt1"><a href="{{term.permalink}}">{{ term.title }}</a></li>
   {% endfor %}
   </div>
 
@@ -50,7 +50,7 @@
     <a class="fw6" href="/docs/glossary/hoon">Hoon</a> <span class="fw6">+</span> <a class="fw6" href="/docs/glossary/nock">Nock</a>
     <p>Hoon is Urbit's high-level programming language. It compiles to Nock, Urbit's low-level language.</p>
   {% for term in hoonNockTerms %}
-  <li class="list mb1 mt1"><a href="{{term.permalink}}">{{ term.title }}</a></li>
+  <li class="list mb1 ml0 mt1"><a href="{{term.permalink}}">{{ term.title }}</a></li>
   {% endfor %}
   </div>
 </div>


### PR DESCRIPTION
It's slightly askew. Now it is not. Also updates docs.