### PR TITLE
UU: CTA is full grid on mobile

### DIFF
--- a/templates/understanding-urbit/list.html
+++ b/templates/understanding-urbit/list.html
@@ -79,7 +79,7 @@
     {% endfor %}
 </footer>
 
-<section class="c4-10-lg mv6">
+<section class="full c4-10-lg mv6">
     <iframe name="nothing" style="display:none;"></iframe>
     <p class="mt5">If you’d like to follow our progress, we send monthly updates via email:</p>
     <form
@@ -110,7 +110,7 @@
         </div>
     </div>
     </form>
-    <p class="full mt3 mb3 mb3-xl lh-copy">You can also follow us on <a class="bb" href="https://twitter.com/urbit">Twitter</a> or <a class="bb" href="https://github.com/urbit">Github</a>.</p>
-    <p class="full mt0 mb3 mb4-xl lh-copy">Or, preferably, on Urbit itself in <code>~dopzod/urbit-help</code></p>
+    <p class="mt3 mb3 mb3-xl lh-copy">You can also follow us on <a class="bb" href="https://twitter.com/urbit">Twitter</a> or <a class="bb" href="https://github.com/urbit">Github</a>.</p>
+    <p class="mt0 mb3 mb4-xl lh-copy">Or, preferably, on Urbit itself in <code>~dopzod/urbit-help</code></p>
 </section>
 {% endblock content %}

--- a/templates/understanding-urbit/post.html
+++ b/templates/understanding-urbit/post.html
@@ -73,7 +73,7 @@
 
     {% include "partials/pagination.html" %}
   </article>
-  <section class="c4-10-lg mv6">
+  <section class="full c4-10-lg mv6">
       <iframe name="nothing" style="display:none;"></iframe>
       <p class="mt5">If you’d like to follow our progress, we send monthly updates via email:</p>
       <form
@@ -104,7 +104,7 @@
           </div>
       </div>
       </form>
-      <p class="full mt3 mb3 mb3-xl lh-copy">You can also follow us on <a class="bb" href="https://twitter.com/urbit">Twitter</a> or <a class="bb" href="https://github.com/urbit">Github</a>.</p>
-      <p class="full mt0 mb3 mb4-xl lh-copy">Or, preferably, on Urbit itself in <code>~dopzod/urbit-help</code></p>
+      <p class="mt3 mb3 mb3-xl lh-copy">You can also follow us on <a class="bb" href="https://twitter.com/urbit">Twitter</a> or <a class="bb" href="https://github.com/urbit">Github</a>.</p>
+      <p class="mt0 mb3 mb4-xl lh-copy">Or, preferably, on Urbit itself in <code>~dopzod/urbit-help</code></p>
   </section>
 {% endblock content %}


### PR DESCRIPTION
The CTA's `<section>` only had a grid declaration for the large viewpoint. This produced a squashed CTA on mobile.

<img width="285" alt="Screen Shot 2019-12-20 at 9 56 35 AM" src="https://user-images.githubusercontent.com/20846414/71263117-435ef680-230f-11ea-93d0-5ebdb1d34004.png">

This PR adds the "full" fallback to cover all the viewpoints.

<img width="281" alt="Screen Shot 2019-12-20 at 9 56 49 AM" src="https://user-images.githubusercontent.com/20846414/71263145-4fe34f00-230f-11ea-9b24-a723338c3307.png">
