### PR TITLE
docs: add hoon template

### DIFF
--- a/templates/sections/docs/hoon.html
+++ b/templates/sections/docs/hoon.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% block title %} 
+  <meta name="og:title" content="{{ section.title }} - {{ config.title }}">
+  <title>{{ section.title }} - {{ config.title }}</title>
+{% endblock title %}
+
+{% block description %} 
+  <meta name="og:description" content="From the Urbit documentation.">
+  <meta name="description" content="From the Urbit documentation.">
+{% endblock description %}
+
+{% block image %}
+  <meta name="twitter:image" content="https://media.urbit.org/logo/urbit-logo-card.png">
+{% endblock image %}
+
+{% block content %}
+<!-- header -->
+<!-- content -->
+{% include "partials/navigation-docs.html" %}
+<article class="mt4 mb6 full c4-11-lg">
+<!-- header -->
+<h1>{{ section.title }}</h1>
+<!-- body -->
+
+<div class="measure-wide mb4">
+{{ section.content | safe }}
+
+{% set lessons = get_section(path="docs/tutorials/hoon/_index.md") %}
+
+<ul>
+  <h2 class="mv4">Chapter 1</h2>
+{% for lesson in lessons.pages %}
+  {% if lesson.title is starting_with("1") %}
+  <li><a href="{{lesson.permalink}}">{{lesson.title}}</a></li>
+  {% endif %}
+{% endfor %}
+  <h2 class="mv4">Chapter 2</h2>
+  {% for lesson in lessons.pages %}
+  {% if lesson.title is starting_with("2") %}
+  <li><a href="{{lesson.permalink}}">{{lesson.title}}</a></li>
+  {% endif %}
+{% endfor %}
+
+<br/>
+{% for lesson in lessons.pages %}
+  {% if (lesson.title is not starting_with("2")) and (lesson.title is not starting_with("1")) %}
+  <li><a href="{{lesson.permalink}}">{{lesson.title}}</a></li>
+  {% endif %}
+{% endfor %}
+</ul>
+</div>
+{% endblock content %}


### PR DESCRIPTION
Closes #269.

Adds a basic programmatically generated index page for the Hoon tutorials. Nb. It hard codes the chapters, and dumps the remainder lessons and appendices afterward. But at least there's no need to keep track of this by hand anymore.

![image](https://user-images.githubusercontent.com/20846414/71384319-a02c0c80-25ae-11ea-8b86-c0a247beb411.png)
