### PR TITLE
even glossary padding, use indigo class

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -379,7 +379,6 @@ input[type="search"] {
     }
   }
   .glossary-results__item {
-    padding: 0 1rem 0 1rem;
     &:hover {
         background-color: #F9F9F9;
       }

--- a/templates/partials/search-overlay.html
+++ b/templates/partials/search-overlay.html
@@ -9,8 +9,8 @@
       </div>
       <div id="full-results">
         <div id="glossary-results" class="glossary-results bt b--gray3 w-100">
-          <div class="glossary-results__header mv1 gray3 f6">
-            <div class="glossary-results__item">
+          <div class="glossary-results__header gray3 f6">
+            <div class="glossary-results__item pa3">
             </div>
           </div>
         </div>


### PR DESCRIPTION
Uneven highlighting, top had less padding than bottom. Not a good implementation on my part. Cleaner now in all respects.

Before:

![image](https://user-images.githubusercontent.com/20846414/73027947-77dc3b80-3e02-11ea-90d5-324ae553829c.png)

After:

<img width="686" alt="Screen Shot 2020-01-23 at 5 03 41 PM" src="https://user-images.githubusercontent.com/20846414/73027957-7c085900-3e02-11ea-9689-e7975d8d9826.png">

