### PR TITLE
Using Bridge: some touch-ups

### DIFF
--- a/content/using/operations/using-bridge.md
+++ b/content/using/operations/using-bridge.md
@@ -10,13 +10,13 @@ aliases = ["/docs/getting-started/using-bridge/"]
 
 This guide assumes that you have an Urbit ID, or that you have found someone to send an Urbit ID to your Ethereum address and are looking to claim it.
 
-### Online Bridge
+### Hosted Bridge
 
 To connect to Bridge, go to [https://bridge.urbit.org](https://bridge.urbit.org) into your browser, and enter your identity's credentials in the appropriate fields. If you were invited to claim an Urbit ID, it's very likely that you received an email that would direct you to Bridge, and you can simply follow the hyperlink in that email.
 
 Once you arrive, proceed through the steps presented. You'll eventually arrive at a page with a few choices: `Invite`, `Admin`, and `Boot Arvo`. `Admin` is the only option that you're interested in right now; click on it. On the `Admin` page, click the `Download Arvo Keyfile` button. Once you have downloaded the keyfile, you can exit Bridge and proceed to [install the Urbit binary](@/using/install.md).
 
-### Offline Bridge
+### Local Bridge
 
 Alternatively, Bridge can be run locally. It's more complicated, but we recommend this option for managing sufficiently valuable assets, such as several stars or more. To install local Bridge, navigate to the [release page on GitHub](https://github.com/urbit/bridge/releases/). Download the `.zip` file of the latest version. After you download it, follow the instructions below.
 

--- a/content/using/operations/using-bridge.md
+++ b/content/using/operations/using-bridge.md
@@ -29,9 +29,11 @@ To use Bridge:
 
 You can then use the Bridge app by navigating to `http://localhost:5000` in your internet browser.
 
-Note: Bridge allows you to both make reads and writes to the Ethereum blockchain. Writing to the blockchain, such as changing your networking keys, will incur a transaction cost that will require you to have some ETH in your address.
+### Log in
 
 Once the program is running in your browser, go through the steps presented according to the type of wallet you have. You’ll be presented with a few login options. A notable option is Urbit Master Ticket. This is for those who used our Wallet Generator software. If you bought points from an Urbit sale and then used the Wallet Generator, your networking keys will be set for you. All other login options will require you to set your own networking keys.
+
+Note: Bridge allows you to both make reads and writes to the Ethereum blockchain. Writing to the blockchain, such as changing your networking keys, will incur a transaction cost that will require you to have some ETH in the address you log in with.
 
 ### Accept your transfer
 


### PR DESCRIPTION
Tried finding this in the docs repo first. Confusing.

This changes the headers for various ways of running Bridge to be more accurate. There is no "offline" version of modern Bridge, only a locally hosted one. You'll always be "online" in the sense of needing an internet connection and talking directly to the chain.

~~Also unsure why we don't just refer to the usage instructions on the release page for local Bridge. Those are more likely to be accurate than the docs here. Anyone opposed to me taking the instructions here out and simply referring to the releases page?~~ lol those are still for old bridge, which _can_ actually be offline

The "Note: transactions cost money" part came a little out of nowhere, so I lightly restructured around it.