### PR TITLE
templates: mobile templates use full grid

### DIFF
--- a/templates/essays/list.html
+++ b/templates/essays/list.html
@@ -25,7 +25,7 @@
   {% include "partials/navigation-search.html" %}
 </nav>
 <!-- content -->
-<article class="mt4 mb4 c1-12 c4-12-lg">
+<article class="mt4 mb4 c1-13 c4-12-lg">
   <ul class="posts measure-wide">
     {% set posts = get_section(path="blog/_index.md") %}
     {% for page in posts.pages %}

--- a/templates/list.html
+++ b/templates/list.html
@@ -23,7 +23,7 @@
   {% include "partials/navigation-search.html" %}
 </nav>
 <!-- content -->
-<article class="mt4 mb7 c1-12 c4-12-lg">
+<article class="mt4 mb7 c1-13 c4-12-lg">
   <ul class="posts">
     {% set posts = get_section(path=section.relative_path) %}
     {% for page in posts.pages %}

--- a/templates/media/list.html
+++ b/templates/media/list.html
@@ -24,7 +24,7 @@
   {% include "partials/navigation-search.html" %}
 </nav>
 <!-- content -->
-<article class="mt4 mb4 c1-12 c4-10-lg measure-wide">
+<article class="mt4 mb4 c1-13 c4-10-lg measure-wide">
   <ul class="posts">
     {% set posts = get_section(path="media/_index.md") %}
     {% for page in posts.pages %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -55,7 +55,7 @@
 
 {% endif %}
 
-<article class="mt4 mb4 c1-12 c4-10-lg">
+<article class="mt4 mb4 c1-13 c4-10-lg">
     {% if page.extra.hidetitle %} {% else %}<h1>{{ page.title }}</h1>{% endif %}
     {% if page.extra.author %}
   <span class="mt2 dib" rel="author"> {{ page.extra.author }} </span>

--- a/templates/page_indiced.html
+++ b/templates/page_indiced.html
@@ -66,7 +66,7 @@
 {% endif %}
 {% endfor %}
 </nav>
-        <article class="mt4 mb6 c1-12 c4-10-lg measure-wide">
+        <article class="mt4 mb6 c1-13 c4-10-lg measure-wide">
             {% if page.extra.hidetitle %} {% else %}<h1>{{ page.title }}</h1>{% endif %}
           {% if page.extra.author %}
           <span class="mt2 dib" rel="author"> {{ page.extra.author }} </span>

--- a/templates/updates/list.html
+++ b/templates/updates/list.html
@@ -26,7 +26,7 @@
   {% include "partials/navigation-search.html" %}
 </nav>
 <!-- content -->
-<main class="mt4 mb4 c1-12 c4-10-lg measure-wide">
+<main class="mt4 mb4 c1-13 c4-10-lg measure-wide">
 
   {% set posts = get_section(path="updates/_index.md") %}
 


### PR DESCRIPTION
One of those things that irked me randomly tonight just idly thumbing through post directories specifically — the mobile layout seemed a little off-kilter toward the left, too narrow, imperfect ...

Turns out: the fallback responsive declaration was `c1-12`, when `c1-13` is what we want in order to use the full grid (alongside the usual gutters on the left and right).

Before / after:

![image](https://user-images.githubusercontent.com/20846414/73332498-ea02b500-4234-11ea-89d7-6f2489ff8842.png)
