### PR TITLE
index.html: add latest posts, streamline landing

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -50,7 +50,43 @@
   <p><strong>Urbit ID</strong> is a decentralized digital identity system. Your
   Urbit ID is a username, network address and crypto wallet designed for Urbit OS.</p>
   <p>Urbit OS + Urbit ID are designed to work together as a single system. Both are completely <a href="https://github.com/urbit/urbit">open source</a> for anyone to build on top of, play with and experiment with.</p>
-  <p>Urbit is <i>not quite</i> ready for everyday users. But if you're curious, keep going ↓</p>
+    <ul class="list">
+      <li class="mt3">
+        <a class="b--blue2 blue2 bb" href="/using/install/">Install + Setup</a>
+      </li>
+      <li class="mt3">
+        <a class="b--green2 green2 bb" href="/docs/">Documentation</a>
+      </li>
+    </ul>
+</section>
+
+
+<section class="full lh-copy c-7-12-md c7-11-lg mt4">
+  <p class="fw6">Latest Posts</p>
+  {% set s = get_section(path="updates/_index.md") %}
+  {% set e = get_section(path="blog/_index.md") %}
+  {% set allposts = s.pages
+            | concat (with=e.pages)
+            | sort(attribute="date")
+            | reverse
+            %}
+  {% for page in allposts | slice (end=2) %}
+    <a class="bb-0" href="{{ page.permalink }}">
+      <li class="mb2 list">
+        <h2 class="f5 fw6 mt0 mb1">{{ page.title }}</h2>
+        {% if page.extra.image %}
+        <img class="db pv2 obj-cover h4 w-50" src="{{ page.extra.image }}" />
+        {% endif %}
+        <time class="mono f6">{{ page.date | date(format="~%Y.%-m.%-d") }}</time>
+        <span class="mono f6">
+          {% if page.extra.ship %}
+            <address class="mono f6 mh2">{{ page.extra.ship }}</address>
+          {% endif %}
+          <a class="mono f6" href="/{{page.components[0] | lower}}">{{ page.components[0] | lower}}</a>
+        </span>
+      </li>
+    </a>
+  {% endfor %}
 </section>
 
 <section class="full c2-7-md c3-7-lg mt5">
@@ -70,44 +106,6 @@
       </a>
     </li>
     {% endfor %}
-  </ul>
-</section>
-
-<section class="full c7-12-md c7-11-lg mt5">
-  <h1 class="mb3">Developer Resources</h1>
-    <p class="lh-copy mt1">If you're someone who likes playing with experimental software, you should dive right in. Booting an Urbit takes only a few minutes.</p>
-  <ul class="list">
-    <li class="mt3">
-      <a class="b--black bb" href="/using/install/">Install + Setup</a>
-    </li>
-    <li class="mt3">
-      <a class="b--black bb" href="/docs/">Documentation</a>
-    </li>
-    <li class="mt3">
-      <a class="b--black bb" href="/community/hoonschool">Hoon School</a>
-    </li>
-    <li class="mt3">
-      <a class="b--black bb" href="https://grants.urbit.org">Developer Grants</a>
-    </li>
-  </ul>
-</section>
-
-<section class="full c2-7-md c3-7-lg mt5">
-  <h1 class="mb3">Learn More</h1>
-  <p class="lh-copy mt1">We share ongoing project developments, discuss technical considerations, and update our public roadmap as often as possible.</p>
-  <ul class="list">
-    <li class="mt3">
-      <a class="b--black bb" href="/blog">Blog</a>
-    </li>
-    <li class="mt3">
-      <a class="b--black bb" href="/updates/">Updates</a>
-    </li>
-    <li class="mt3">
-      <a class="b--black bb" href="/media">Media</a>
-    </li>
-    <li class="mt3">
-      <a class="b--black bb" href="/faq/">FAQ</a>
-    </li>
   </ul>
 </section>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,7 +41,7 @@
   "></iframe> -->
 </section>
 
-<section class="full lh-copy c2-7-md c3-7-lg mt4">
+<section class="full lh-copy c2-7-md c3-7-lg mt5">
   <p><strong>Urbit OS</strong> is a clean slate reimagining of the operating system as an 'overlay OS.' It runs on any Unix machine with an internet connection.</p>
   <p>It's a compact system for an individual to run their own permanent personal server.</p>
   <p><strong>Urbit ID</strong> is a decentralized digital identity system. Your
@@ -58,7 +58,7 @@
 </section>
 
 
-<section class="full lh-copy c-7-12-md c7-11-lg mt4">
+<section class="full lh-copy c7-12-md c7-11-lg mt5">
   <p class="fw6">Latest Posts</p>
   {% set s = get_section(path="updates/_index.md") %}
   {% set e = get_section(path="blog/_index.md") %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -42,15 +42,12 @@
 </section>
 
 <section class="full lh-copy c2-7-md c3-7-lg mt4">
-  <p class="mb4">
-      Urbit is two new pieces of technology:<br/>
-      Urbit OS + Urbit ID.
-  </p>
-  <p><strong>Urbit OS</strong> is a clean slate reimagining of the operating system as an 'overlay OS'. It runs on any Unix machine with an internet connection. Urbit OS is a compact system for an individual to run their own permanent personal server.</p>
+  <p><strong>Urbit OS</strong> is a clean slate reimagining of the operating system as an 'overlay OS.' It runs on any Unix machine with an internet connection.</p>
+  <p>It's a compact system for an individual to run their own permanent personal server.</p>
   <p><strong>Urbit ID</strong> is a decentralized digital identity system. Your
-  Urbit ID is a username, network address and crypto wallet designed for Urbit OS.</p>
-  <p>Urbit OS + Urbit ID are designed to work together as a single system. Both are completely <a href="https://github.com/urbit/urbit">open source</a> for anyone to build on top of, play with and experiment with.</p>
-    <ul class="list">
+  Urbit ID is a username, network address, and crypto wallet.</p>
+  <p>Both are designed to work together as a single system, completely <a class="b--black bb" href="https://github.com/urbit/urbit">open source</a>.</p>
+    <ul class="list mt4">
       <li class="mt3">
         <a class="b--blue2 blue2 bb" href="/using/install/">Install + Setup</a>
       </li>
@@ -72,7 +69,7 @@
             %}
   {% for page in allposts | slice (end=2) %}
     <a class="bb-0" href="{{ page.permalink }}">
-      <li class="mb2 list">
+      <li class="mb4 list">
         <h2 class="f5 fw6 mt0 mb1">{{ page.title }}</h2>
         {% if page.extra.image %}
         <img class="db pv2 obj-cover h4 w-50" src="{{ page.extra.image }}" />

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,7 +79,6 @@
           {% if page.extra.ship %}
             <address class="mono f6 mh2">{{ page.extra.ship }}</address>
           {% endif %}
-          <a class="mono f6" href="/{{page.components[0] | lower}}">{{ page.components[0] | lower}}</a>
         </span>
       </li>
     </a>


### PR DESCRIPTION
Closes #356. Intended as a counter-proposal PR. 

Removes extraneous links and streamlines the CTA: 
- explanatory content has a brief version with immediate links, then a longer version below it at left
- latest updates and subscribing for updates live on the right 

Updates and Blog are surfaced and shown to be fresh immediately; additional content lives in the footer as a full site map for people who already live here; or who want to explore the site.

Brings the homepage from a grid of six to a grid of four, but tries to retain a rhythm and an organisation that immediately funnels users into the site's latest. 

(Also trimmed some of the very top copy for pacing.)

<img width="1325" alt="image" src="https://user-images.githubusercontent.com/20846414/74212465-5385b900-4c62-11ea-8a55-17f398f8ea88.png">

cc @loganallenc 