### PR TITLE
updates: fix slugs

### DIFF
--- a/content/updates/2019-11-06-update.md
+++ b/content/updates/2019-11-06-update.md
@@ -2,7 +2,7 @@
 title = "~2019.11.06 Update"
 date = 2019-11-06
 description = "Weekly Web Update"
-slug = "/updates/2019-11-06"
+slug = "2019-11-06"
 aliases = ["/posts/updates/2019-11-06-update", "/posts/2019-11-06-update/"]
 [extra]
 author = ""
@@ -12,29 +12,29 @@ image = "https://media.urbit.org/site/posts/updates/~2019.11.06-update.jpg"
 
 ![](https://media.urbit.org/site/posts/updates/~2019.11.06-update.jpg)
 
-Hello from San Francisco! 
+Hello from San Francisco!
 
-We’re thinking of everyone in the North Bay and elsewhere who were affected by the recent fires. While we’ve had a few days of poor air quality in SF, we’re grateful that it hasn’t been as bad as last year. 
+We’re thinking of everyone in the North Bay and elsewhere who were affected by the recent fires. While we’ve had a few days of poor air quality in SF, we’re grateful that it hasn’t been as bad as last year.
 
 Here are some updates from the Tlon team:
 
 1 -
 Tlon has been on tour! We just got back from Berlin where we gave a talk at the Lightning Conference. [Check it out](https://youtu.be/vVIt06w3IbM?t=2030). While we were there, we [talked](https://www.youtube.com/watch?v=775vmOKxwSY) to the World Crypto Network.
 
-2 - 
+2 -
 If you’re wondering what all this Bitcoin stuff is about, we summed it up [here](https://urbit.org/blog/urbit-and-bitcoin/).
 
-3 - 
+3 -
 We’re offering a free, introductory-level online course on Hoon, the programming language that’s designed for use with Urbit. Hoon 101 begins on November 11th and runs for six weeks. Sign up [here](https://urbit.org/hoonschool/).
 
 4 -
-We’ve got a new version of Ames (the Urbit OS / Arvo networking protocol) compiling and up to date with master. `~pilfer-pandex` also wrote some compiler documentation that is getting rave reviews around the office. `~wicdev-wisryt` was so inspired that he added tab completion to the Dojo and built [a language server](https://github.com/urbit/urbit/pull/1910). 
+We’ve got a new version of Ames (the Urbit OS / Arvo networking protocol) compiling and up to date with master. `~pilfer-pandex` also wrote some compiler documentation that is getting rave reviews around the office. `~wicdev-wisryt` was so inspired that he added tab completion to the Dojo and built [a language server](https://github.com/urbit/urbit/pull/1910).
 
-5 - 
+5 -
 Kenny, a long time community member, is hosting the first-ever Urbit meetup in Seattle on November 12th. Details [here](http://meetu.ps/c/4tZGf/c0Pdg/a).
- 
-6 - 
+
+6 -
 The next San Francisco meetup is on November 15th. [RSVP here](https://www.meetup.com/urbit-sf/events/266146513/).
- 
- 
+
+
 Until next time.

--- a/content/updates/2019-12-06-update.md
+++ b/content/updates/2019-12-06-update.md
@@ -2,7 +2,7 @@
 title = "~2019.12.6 Weekly Web Update"
 date = 2019-12-06
 description = "Weekly Web Update"
-slug = "/updates/2019-12-06"
+slug = "2019-12-06"
 [extra]
 author = ""
 ship = ""
@@ -18,9 +18,9 @@ We recently released urbit v0.10.0. This continuity-breaching release contains b
 
 A few release highlights:
 
-* Our networking vane, Ames, has been completely rewritten. Its protocol has been simplified, and several new features have been added to it. We expect Ames to be much more reliable and easy to upgrade. 
+* Our networking vane, Ames, has been completely rewritten. Its protocol has been simplified, and several new features have been added to it. We expect Ames to be much more reliable and easy to upgrade.
 
-* Perhaps most importantly, Ames now supports arbitrary-length negative acks, which was one of the primary networking bugs on our old network. 
+* Perhaps most importantly, Ames now supports arbitrary-length negative acks, which was one of the primary networking bugs on our old network.
 
 * Gall, our application sandbox, has also been significantly changed. This has also been a long-running project at Tlon that we’re really excited to get out on the live network. Gall itself is about a thousand lines shorter.
 
@@ -30,14 +30,14 @@ A few release highlights:
 
 Check out the full release notes [here](https://github.com/urbit/urbit/releases/tag/v0.10.0).
 
-2 - 
+2 -
 This year we set out to get Arvo to a point that we can credibly call ‘stable.' ~poldec-tonteg wrote about the details of how we accomplished stability [here](https://urbit.org/blog/stable-arvo/).
 
-3 - 
+3 -
 The final San Francisco meetup of the year is on December 13th. We hope to see you – [RSVP here](https://www.meetup.com/urbit-sf/events/266904108/?rv=ea1_v2&_xtd=gatlbWFpbF9jbGlja9oAJDA0YTUxZjZlLWU1ZGQtNGJkYS1hN2JlLWQwZTc0MDA0ZTAwZA).
 
-4 - 
+4 -
 The Seattle Urbit group is hosting a meetup on December 18th. [RSVP](https://www.meetup.com/Urbit-Seattle/events/266619060/) for tech and holiday cheer.
- 
- 
+
+
 Talk to you soon!

--- a/content/updates/2020-02-06-update.md
+++ b/content/updates/2020-02-06-update.md
@@ -2,7 +2,7 @@
 title = "~2020.2.6 Update"
 date = 2020-02-06
 description = "A brief update from the Tlon team for ~2020.2.6."
-slug = "/updates/2020-02-06"
+slug = "2020-02-06"
 [extra]
 author = "Corrina"
 ship = "~roslet-tanner"
@@ -17,8 +17,8 @@ It’s been a busy 2020 already, and we’re excited about everything that’s g
 Fixes related to the network stability vote.
 [Updates](https://github.com/urbit/urbit/pull/1996) to both Gall and Ames (our application sandbox and networking module, respectively).
 [Support in Bridge](https://github.com/urbit/bridge/pull/335) for withdrawing stars from the linear release contracts.
- 
-2. Gavin (`~ridlur-figbud`) wrote about how we created sigils, the visual representation of Urbit IDs. Read the post [here](https://urbit.org/blog/creating-sigils/). 
+
+2. Gavin (`~ridlur-figbud`) wrote about how we created sigils, the visual representation of Urbit IDs. Read the post [here](https://urbit.org/blog/creating-sigils/).
 
 3. We’re pleased to announce the latest round of our semiannual gifts to Urbit contributors. It’s our way of rewarding the hard work of contributors to the project over the last six months. To see all the contributions we’ve recognized, take a look at the [History](https://grants.urbit.org/history) section on the Grants website.
     - `~bannum-magtus` has been tireless in their efforts as a community Guide in the #ship-starting-support channel on our [Discord server](https://discord.gg/C9ENTt3), and as an Urbit evangelizer.
@@ -26,16 +26,16 @@ Fixes related to the network stability vote.
     - `~minder-folden` was a deep font of Urbit-related content, outreach, and support.
     - `~risruc-habteb` provided invaluable, consistent support in urbit-help.
     - `~rabsef-bicrym` for their efforts to teach Hoon to the community.
-    - [`~dinleb-rambep`](https://github.com/pkova) brought a steady stream of useful contributions to the [urbit repository](https://github.com/urbit/urbit/pulls?utf8=%E2%9C%93&q=author%3Apkova). 
+    - [`~dinleb-rambep`](https://github.com/pkova) brought a steady stream of useful contributions to the [urbit repository](https://github.com/urbit/urbit/pulls?utf8=%E2%9C%93&q=author%3Apkova).
 
-4. Looking for a more formal way to contribute and get rewarded? Look for a [Bounty](https://grants.urbit.org/bounties) to claim, or pitch a [Proposal](https://grants.urbit.org/proposals) of your own. We’re always on the lookout for community members who distinguish themselves through their contributions. 
+4. Looking for a more formal way to contribute and get rewarded? Look for a [Bounty](https://grants.urbit.org/bounties) to claim, or pitch a [Proposal](https://grants.urbit.org/proposals) of your own. We’re always on the lookout for community members who distinguish themselves through their contributions.
 
 5. Community member Reid is hosting a Dallas-Fort Worth meetup on February 12. [RSVP](https://www.meetup.com/Urbit-DFW/events/268194997/?rv=ea1_v2&_xtd=gatlbWFpbF9jbGlja9oAJGUwMGVjNGVmLTM3YTMtNDI1Yy05MDY1LTMyZGNiZjIxNDc2MA) to join.
- 
+
 6. `~rabsef-bicrym` is coordinating a Denver meetup on February 13 during [ETHDenver](https://www.ethdenver.com/). Come say hi to other community members and folks from Tlon. For more details and to RSVP contact `~rabsef-bicrym` at [denver.urbit.meetup@protonmail.com](mailto:denver.urbit.meetup@protonmail.com).
- 
-7. The next SF meetup will be on February 28 at our offices. Join us for a drink and a chat about all things Urbit. [RSVP](https://www.meetup.com/urbit-sf/events/268519069/?rv=co1&_xtd=gatlbWFpbF9jbGlja9oAJDYzNTAyYWNhLTBlYWQtNDAwNC1iODNlLTljMDk0NzQyNTE3NQ) and bring a friend. 
- 
+
+7. The next SF meetup will be on February 28 at our offices. Join us for a drink and a chat about all things Urbit. [RSVP](https://www.meetup.com/urbit-sf/events/268519069/?rv=co1&_xtd=gatlbWFpbF9jbGlja9oAJDYzNTAyYWNhLTBlYWQtNDAwNC1iODNlLTljMDk0NzQyNTE3NQ) and bring a friend.
+
 We’ve also scheduled a meetup in SF for [March 27](https://www.meetup.com/urbit-sf/events/268519156/). We hope to see you at one of these events!
- 
+
 Until next time.


### PR DESCRIPTION
Quick catch.

Slugs should be `post-name` not `full-section-path/post-name`, which was making some weird URL permalinks.

Also the latest post was dated 2029, so I revised that too.