### PR TITLE
urbit.org: change search hotkey, add hint

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -314,10 +314,6 @@ nav.previous, nav.next {
     // min-width: 110px;
     text-align: left;
     background: transparent;
-    span#search-icon {
-      display: inline-block;
-      transform: translate(-4px, 2px) rotate(-45deg);
-    }
     span.search-slash {
       font-size: 0.75em;
       position: absolute;

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -15,8 +15,11 @@ function initHotKeys() {
       document.body.classList.remove('has-active-search-window');
     }
 
-    // / to open toggle window
-    if (key === '/' || key === 'Period' || key === 58) {
+    // Ctrl or Meta + / to open toggle window
+    if (
+      (event.getModifierState("Control") || event.getModifierState("Meta")) &&
+      (key === '/' || key === 'Period' || key === 58)
+      ) {
       if (bodyEl.classList.contains('has-active-search-window')) {
         // if it's already open don't do anything!
       } else {
@@ -232,6 +235,7 @@ function initSearch() {
   var searchWindow = document.getElementById('search-window');
   var searchActive = bodyEl.classList.contains('has-active-search-window');
 
+
   if (toggleSearchWindow !== null) {
     toggleSearchWindow.onclick = function () {
       inputReset.style.display = "none";
@@ -325,7 +329,6 @@ function initSearch() {
 if (document.readyState === "complete" ||
   (document.readyState !== "loading" && !document.documentElement.doScroll)
 ) {
-  initToggleSearchWindow();
 } else {
   document.addEventListener("DOMContentLoaded", function () {
     initSearch();

--- a/templates/partials/navigation-docs.html
+++ b/templates/partials/navigation-docs.html
@@ -8,6 +8,7 @@
   </a>
   <button id="js-search-window-toggle" class="mt2 mb4 dn db-m db-l db-xl" type="button"  style="outline:none">
     <span id="search-icon" class="f3 gray3">⚲</span><span class="ml3 gray2">Search</span>
+    <span class="absolute pa1 ba b--gray3 gray3 br1 f7" id="keyhint" style="right: -139px;top: 6px;">Ctrl + /</span>
   </button>
   <ul class="lh-copy">
   <li class="ml2 mt1"><a href="/using/install">Install -> </a></li>

--- a/templates/partials/navigation-docs.html
+++ b/templates/partials/navigation-docs.html
@@ -1,4 +1,30 @@
 <!-- First nav is desktop-specific. Second nav is dropdown version for mobile. -->
+
+{% set sectionTitle = "urbit.org" %}
+{% if page %}
+  {% if "docs" in page.components %}
+    {% set sectionTitle = "Docs" %}
+  {% endif %}
+  {% if "updates" in page.components %}
+    {% set sectionTitle = "Updates" %}
+  {% endif %}
+  {% if "blog" in page.components %}
+    {% set sectionTitle = "Blog" %}
+  {% endif %}
+{% endif %}
+
+{% if section %}
+  {% if "docs" in section.components %}
+    {% set sectionTitle = "Docs" %}
+  {% endif %}
+  {% if "updates" in section.components %}
+    {% set sectionTitle = "Updates" %}
+  {% endif %}
+  {% if "blog" in section.components %}
+    {% set sectionTitle = "Blog" %}
+  {% endif %}
+{% endif %}
+
 {% block content %}
 <nav class="bg-gray5 dn db-xl pt4 full-left no-break docs pr4">
     <a class="gray3" href="{{config.base_url}}">Urbit</a>
@@ -6,10 +32,11 @@
   <a href="{{config.base_url}}/docs/">
   Documentation
   </a>
-  <button id="js-search-window-toggle" class="mt2 mb4 dn db-m db-l db-xl" type="button"  style="outline:none">
-    <span id="search-icon" class="f3 gray3">⚲</span><span class="ml3 gray2">Search</span>
-    <span class="absolute pa1 ba b--gray3 gray3 br1 f7" id="keyhint" style="right: -139px;top: 6px;">Ctrl + /</span>
-  </button>
+<button id="js-search-window-toggle" class="pointer pa0 pv3 dn db-m db-l db-xl bw-0 relative" type="button"
+  style="outline:none">
+  <span class="dib pv1 v-mid gray3">Search {{sectionTitle}}</span>
+  <span class="ml1 pa1 dib v-mid ba br1 b--gray3 gray3 f7" id="keyhint">Ctrl + /</span>
+</button>
   <ul class="lh-copy">
   <li class="ml2 mt1"><a href="/using/install">Install -> </a></li>
   <li class="ml2 mt1"><a href="/using/operations/">Operations Manual -></a></li>
@@ -141,8 +168,10 @@
     {% endif %}
     {% endfor %}
   </select>
-  <button id="js-search-window-toggle" class="mt4 mb4 dn db-m db-l db-xl" type="button"  style="outline:none">
-    <span id="search-icon" class="f3 gray3">⚲</span><span class="ml3 gray2">Search</span>
+  <button id="js-search-window-toggle" class="pointer pa0 pt3 dn db-m db-l db-xl bw-0 relative" type="button"
+    style="outline:none">
+    <span class="pv1 dib v-mid gray3">Search {{sectionTitle}}</span>
+    <span class="ml1 pa1 dib v-mid ba br1 b--gray3 gray3 f7" id="keyhint">Ctrl + /</span>
   </button>
 </nav>
 {% endblock content %}

--- a/templates/partials/navigation-search.html
+++ b/templates/partials/navigation-search.html
@@ -1,4 +1,8 @@
-<button id="js-search-window-toggle" class="pointer mt2 dn db-m db-l db-xl bw-0 mb3" type="button"  style="outline:none">
+<button id="js-search-window-toggle" class="pointer mt2 dn db-m db-l db-xl bw-0 mb3 relative" type="button"  style="outline:none">
   <span id="search-icon" class="f3 gray3">⚲</span>
   <span class="gray3">Search</span>
+  <span class="absolute pa1 ba b--gray3 gray3 br1 f7" id="keyhint" style="
+      right: -56px;
+      top: 6px;
+  ">Ctrl + /</span>
 </button>

--- a/templates/partials/navigation-search.html
+++ b/templates/partials/navigation-search.html
@@ -1,8 +1,29 @@
-<button id="js-search-window-toggle" class="pointer mt2 dn db-m db-l db-xl bw-0 mb3 relative" type="button"  style="outline:none">
-  <span id="search-icon" class="f3 gray3">⚲</span>
-  <span class="gray3">Search</span>
-  <span class="absolute pa1 ba b--gray3 gray3 br1 f7" id="keyhint" style="
-      right: -56px;
-      top: 6px;
-  ">Ctrl + /</span>
+{% set sectionTitle = "urbit.org" %}
+{% if page %}
+  {% if "docs" in page.components %}
+    {% set sectionTitle = "Docs" %}
+  {% endif %}
+  {% if "updates" in page.components %}
+    {% set sectionTitle = "Updates" %}
+  {% endif %}
+  {% if "blog" in page.components %}
+    {% set sectionTitle = "Blog" %}
+  {% endif %}
+{% endif %}
+
+{% if section %}
+  {% if "docs" in section.components %}
+    {% set sectionTitle = "Docs" %}
+  {% endif %}
+  {% if "updates" in section.components %}
+    {% set sectionTitle = "Updates" %}
+  {% endif %}
+  {% if "blog" in section.components %}
+    {% set sectionTitle = "Blog" %}
+  {% endif %}
+{% endif %}
+
+<button id="js-search-window-toggle" class="pointer pa0 pt3 dn db-m db-l db-xl bw-0 relative" type="button"  style="outline:none">
+  <span class="pv1 dib v-mid gray3">Search {{sectionTitle}}</span>
+  <span class="ml1 pa1 dib v-mid ba br1 b--gray3 gray3 f7" id="keyhint">Ctrl + /</span>
 </button>


### PR DESCRIPTION
- Search hotkey is now `Ctrl+/` and `⌘+/`.
- Search hotkey hint added and pinned beside the search button (immediately beside in regular layout, on the end of the nav block in Docs). 

While we could make the hint switch between Ctrl or ⌘ depending on user agent, the JS always loads about a second too late — making every single page load have a blank hint suddenly pop in. Not really ideal behaviour. UX suggestions welcome, but right now I just keep it saying Ctrl, which is always going to be correct.

<img width="1056" alt="Screen Shot 2020-02-15 at 3 40 53 PM" src="https://user-images.githubusercontent.com/20846414/74596233-9b616300-5009-11ea-8da5-58afbab8e3b7.png">

![image](https://user-images.githubusercontent.com/20846414/74596231-96041880-5009-11ea-82c0-43b88f688a67.png)