### PR TITLE
Add mb4 to search

### DIFF
--- a/templates/partials/navigation-search.html
+++ b/templates/partials/navigation-search.html
@@ -23,7 +23,7 @@
   {% endif %}
 {% endif %}
 
-<button id="js-search-window-toggle" class="pointer pa0 pt3 mb4 dn db-m db-l db-xl bw-0 relative" type="button"  style="outline:none">
+<button id="js-search-window-toggle" class="pointer pa0 pt3 mb3 dn db-m db-l db-xl bw-0 relative" type="button"  style="outline:none">
   <span class="pv1 dib v-mid gray3">Search {{sectionTitle}}</span>
   <span class="ml1 pa1 dib v-mid ba br1 b--gray3 gray3 f7" id="keyhint">Ctrl + /</span>
 </button>

--- a/templates/partials/navigation-search.html
+++ b/templates/partials/navigation-search.html
@@ -23,7 +23,7 @@
   {% endif %}
 {% endif %}
 
-<button id="js-search-window-toggle" class="pointer pa0 pt3 dn db-m db-l db-xl bw-0 relative" type="button"  style="outline:none">
+<button id="js-search-window-toggle" class="pointer pa0 pt3 mb4 dn db-m db-l db-xl bw-0 relative" type="button"  style="outline:none">
   <span class="pv1 dib v-mid gray3">Search {{sectionTitle}}</span>
   <span class="ml1 pa1 dib v-mid ba br1 b--gray3 gray3 f7" id="keyhint">Ctrl + /</span>
 </button>


### PR DESCRIPTION
Search box is too close to the start of the intra-page navigation of `page_indiced` templates (Developer's Guide, FAQ, etc) — this adds some room for those cases.