### PR TITLE
understanding-urbit: measure-wide

### DIFF
--- a/templates/partials/pagination.html
+++ b/templates/partials/pagination.html
@@ -1,4 +1,4 @@
-<footer class="relative">{% if page.earlier %}
+<footer class="relative measure-wide">{% if page.earlier %}
   <a class="bb-0" href="{{page.earlier.permalink}}">
     <nav class="previous absolute right-1 t-right">
       {% if page.extra.hide_previous_title %} {% else %}<p class="mb0 f5">Previous Post:</p>{% endif %}

--- a/templates/understanding-urbit/list.html
+++ b/templates/understanding-urbit/list.html
@@ -32,7 +32,7 @@
 
 </nav>
 <!-- content -->
-<section class="full c4-10-lg">
+<section class="full c4-10-lg measure-wide">
   <h1 id="introduction" class="mb4 full mt4 ">Introduction</h1>
   <p class="full mt0 mb4 mb4-xl lh-copy">We think the internet can’t be saved. The way things are going, MEGACORP will always control our apps and services because we can no longer run them ourselves.</p>
   <p class="full mt0 mb4 mb4-xl lh-copy">The only way out of this mess is with a completely new platform that’s owned and controlled by its users.</p>
@@ -68,7 +68,7 @@
   <p class="full mt0 mb4 mb4-xl lh-copy">Ultimately, we think that new technology is most likely to get adopted if it can provide a much, much better user experience. So that’s what we’re focussing on creating.</p>
 </section>
 
-<footer class="relative mt4 c4-10-lg full">
+<footer class="relative mt4 c4-10-lg full measure-wide">
     {% set posts = get_section(path="understanding-urbit/_index.md") %}
     {% for directorypage in posts.pages | slice (end=1) %}
     <a href="{{directorypage.permalink}}">
@@ -79,7 +79,7 @@
     {% endfor %}
 </footer>
 
-<section class="full c4-10-lg lh-copy mt6 mb4">
+<section class="full c4-10-lg lh-copy mt6 mb4 measure-wide">
     <iframe name="nothing" style="display:none;"></iframe>
     <p class="mt5">If you’d like to follow our progress, we send monthly updates via email:</p>
     <form

--- a/templates/understanding-urbit/post.html
+++ b/templates/understanding-urbit/post.html
@@ -53,7 +53,7 @@
   {% endfor %}
 </nav>
 
-  <article class="full c4-10-lg">
+  <article class="full c4-10-lg measure-wide">
       <h1 class="mb4 mt4">{{ page.title }}</h1>
   {% if page.extra.author %}
   <span class="dib" rel="author"> {{ page.extra.author }}
@@ -73,7 +73,7 @@
 
     {% include "partials/pagination.html" %}
   </article>
-  <section class="full c4-10-lg lh-copy mt6 mb4">
+  <section class="full c4-10-lg lh-copy mt6 mb4 measure-wide">
       <iframe name="nothing" style="display:none;"></iframe>
       <p class="mt5">If you’d like to follow our progress, we send monthly updates via email:</p>
       <form


### PR DESCRIPTION
Understanding Urbit uses the full width of the grid — unlike all other written content on the site. This commit enforces the same `measure-wide` width across all UU elements.

<img width="819" alt="image" src="https://user-images.githubusercontent.com/20846414/74804857-74c45600-52af-11ea-9b03-28947c38c6c6.png">
