### PR TITLE
adds commands to check life and rift number

### DIFF
--- a/content/using/operations/using-your-ship.md
+++ b/content/using/operations/using-your-ship.md
@@ -182,6 +182,13 @@ Because Urbit networking is stateful we call this a _continuity breach_. Everyth
 
 When this happens, back up any files you'd like to save, shut down your urbit, and recreate it (as if you were starting for the first time).
 
+### Life and rift number
+
+You can check your ship's _life_ and _rift_ number by running the `+keys`
+generator. You can inspect the life and rift number of any ship by running the
+`.^(* %j /=life=/(scot %p <ship>))` and `.^(* %j /=rift=/(scot %p <ship>))`
+commands in dojo, respectively.
+
 ## DNS proxying {#dns-proxying}
 
 We have a system that lets you request a domain name for your ship in the form of `ship.arvo.network`, where `ship` is your ship's name minus the `~`. This allows users to access their ships remotely using Landscape, our graphical web interface.

--- a/content/using/operations/using-your-ship.md
+++ b/content/using/operations/using-your-ship.md
@@ -185,7 +185,8 @@ When this happens, back up any files you'd like to save, shut down your urbit, a
 ### Life and rift number
 
 You can check your ship's _life_ and _rift_ number by running `+keys our` in
-dojo. You can inspect another ship's life and rift number by running `+keys ~sampel-palnet`.
+dojo. You can inspect another ship's life and rift number by running `+keys
+~sampel-palnet`. For information on what life and rift are, see [Guide to Breaches](@/docs/tutorials/guide-to-breaches.md).
 
 ## DNS proxying {#dns-proxying}
 

--- a/content/using/operations/using-your-ship.md
+++ b/content/using/operations/using-your-ship.md
@@ -184,10 +184,8 @@ When this happens, back up any files you'd like to save, shut down your urbit, a
 
 ### Life and rift number
 
-You can check your ship's _life_ and _rift_ number by running the `+keys`
-generator. You can inspect the life and rift number of any ship by running the
-`.^(* %j /=life=/(scot %p <ship>))` and `.^(* %j /=rift=/(scot %p <ship>))`
-commands in dojo, respectively.
+You can check your ship's _life_ and _rift_ number by running `+keys our` in
+dojo. You can inspect another ship's life and rift number by running `+keys ~sampel-palnet`.
 
 ## DNS proxying {#dns-proxying}
 


### PR DESCRIPTION
Edits to using/operations/using-your-ship.md. This information is duplicated in
https://github.com/urbit/docs/pull/812 and I'm not entirely sure it should be
there, but it should definitely be here.

This page really needs some work on re-organizing, and we (docs) have discussed
this before but not actually done anything. I think just adding a table of
contents would be a decent bandaid that will only take a few minutes, so I'll
put up another PR for that soon.

----

#