### PR TITLE
Adds TOC to using-your-ship

### DIFF
--- a/content/using/operations/using-your-ship.md
+++ b/content/using/operations/using-your-ship.md
@@ -8,6 +8,46 @@ aliases = ["docs/using/arvo-network-dns/", "docs/using/messaging/", "docs/using/
 hidetitle = "true"
 +++
 
+## Table of Contents
+
+- [Using your ship](#using-your-ship)
+  * [Shutdown](#shutdown)
+  * [Restart](#restart)
+  * [Logging](#logging)
+  * [Moving your pier](#moving-your-pier)
+  * [Console](#console)
+  * [Landscape](#landscape)
+  * [Moons {#moons}](#moons---moons-)
+  * [Continuity breaches](#continuity-breaches)
+  * [Life and rift number](#life-and-rift-number)
+- [DNS proxying {#dns-proxying}](#dns-proxying---dns-proxying-)
+  * [Planets and Stars](#planets-and-stars)
+  * [Galaxies](#galaxies)
+  * [More information](#more-information)
+- [Messaging {#messaging}](#messaging---messaging-)
+  * [Quickstart](#quickstart)
+  * [Joining a chat](#joining-a-chat)
+  * [Hoon](#hoon)
+  * [URLs](#urls)
+  * [Expanding messages](#expanding-messages)
+  * [Creating and managing chats {#chat-management}](#creating-and-managing-chats---chat-management-)
+  * [Configuration](#configuration)
+  * [Miscellaneous configuration](#miscellaneous-configuration)
+- [Shell {#using-the-shell}](#shell---using-the-shell-)
+  * [Quickstart](#quickstart-1)
+  * [Generators](#generators)
+  * [Hood](#hood)
+  * [Dojo manual](#dojo-manual)
+  * [Sources](#sources)
+  * [Variables](#variables)
+  * [Troubleshooting](#troubleshooting)
+- [Filesystem {#filesystem}](#filesystem---filesystem-)
+  * [Quickstart](#quickstart-2)
+  * [Clay manual](#clay-manual)
+  * [Revision-control](#revision-control)
+  * [Merge strategies](#merge-strategies)
+  * [Manipulation](#manipulation)
+
 ## Using your ship
 
 Your urbit (also called your _ship_) is a persistent Unix process that you mainly control from the console.

--- a/content/using/operations/using-your-ship.md
+++ b/content/using/operations/using-your-ship.md
@@ -182,6 +182,13 @@ Because Urbit networking is stateful we call this a _continuity breach_. Everyth
 
 When this happens, back up any files you'd like to save, shut down your urbit, and recreate it (as if you were starting for the first time).
 
+### Life and rift number
+
+You can check your ship's _life_ and _rift_ number by running the `+keys`
+generator. You can inspect the life and rift number of any ship by running the
+`.^(* %j /=life=/(scot %p <ship>))` and `.^(* %j /=rift=/(scot %p <ship>))`
+commands in dojo, respectively.
+
 ## DNS proxying {#dns-proxying}
 
 We have a system that lets you request a domain name for your ship in the form of `ship.arvo.network`, where `ship` is your ship's name minus the `~`. This allows users to access their ships remotely using Landscape, our graphical web interface.


### PR DESCRIPTION
This is just a bandaid for this page the makes it a little more navigable but
still needs some TOC. I removed deeper entries in the TOC since that made it
rather long.

This actually has the same content, plus the TOC, as #367. I thought I was
practicing good git hygeine by making it a separate PR, but wanted to avoid a
situation where the TOC containing the new entry for life and rift number might
get accepted before the content it refers to. So this actually makes #367
redundant, but at least it meets the goal of splitting potential discussion of
these changes into two PRs. I'll try to give it a little more forethought in the future.

----

#