### PR TITLE
Revert "Update binaries to v0.10.4"

### DIFF
--- a/content/using/install.md
+++ b/content/using/install.md
@@ -45,9 +45,9 @@ Urbit: a personal server operating function
 We provide static binaries for macOS. You can grab the latest stable release as follows:
 
 ```sh
-curl -O https://bootstrap.urbit.org/urbit-v0.10.4-darwin.tgz
-tar xzf urbit-v0.10.4-darwin.tgz
-cd urbit-v0.10.4-darwin
+curl -O https://bootstrap.urbit.org/urbit-darwin-v0.10.3.tgz
+tar xzf urbit-darwin-v0.10.3.tgz
+cd urbit-darwin-v0.10.3
 ./urbit
 ```
 
@@ -56,9 +56,9 @@ cd urbit-v0.10.4-darwin
 We also provide static binaries for 64-bit Linux distributions (Ubuntu, Debian, Fedora, Arch, etc.). You can get the latest stable release similarly:
 
 ```sh
-curl -O https://bootstrap.urbit.org/urbit-v0.10.4-linux64.tgz
-tar xzf urbit-v0.10.4-linux64.tgz
-cd urbit-v0.10.4-linux64
+curl -O https://bootstrap.urbit.org/urbit-linux64-v0.10.3.tgz
+tar xzf urbit-linux64-v0.10.3.tgz
+cd urbit-linux64-v0.10.3
 ./urbit
 ```
 


### PR DESCRIPTION
Reverts urbit/urbit.org#372

0.10.4 causes the OS1 OTA to not apply properly. This can be fixed by downgrading, but we should just not suggest 0.10.4 in docs for now.