### PR TITLE
remove smooth scrolling in most contexts

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -613,13 +613,6 @@ hr {
     margin: 2rem 0 2rem 0;
 }
 
-
-// smooth scrolling
-
-.scroll-smooth {
-    scroll-behavior: smooth;
-}
-
 .vid-insert-wrap {
   position: relative;
   width: 100vw;

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="scroll-smooth">
+<html lang="en">
   <head>
     <!-- START META -->
     <meta charset="UTF-8">


### PR DESCRIPTION
Stops the site from making you sit and wait for it to smoothly scroll through when accessing lower content on a long page. 

Just removes smooth scrolling from the `html` tag and from the SCSS, basically; though the inter-page navigation on FAQ pages and the like still retain that behaviour since it works fine there really.