### PR TITLE
mention both dojo and chat-cli in install.md

### DIFF
--- a/content/using/install.md
+++ b/content/using/install.md
@@ -115,7 +115,7 @@ Or, if you'd prefer to copy your key in, you can run:
 
 Either command will create a directory called `sampel-palnet/` and begin building your ship. It may take a few minutes.
 
-When your ship is finished booting, you will see the `~sampel-palnet:chat-cli/` prompt. Press `Ctrl-x` to switch from chat-cli into Dojo. At that point, you should permanently erase your keyfile from your machine.
+When your ship is finished booting, you will see either the `~sampel-palnet:dojo>` or `~sampel-palnet:chat-cli/` prompt. If you're seeing `:chat-cli` press `Ctrl-x` to switch into Dojo. At that point, you should permanently erase your keyfile from your machine.
 
 ## The Dojo
 


### PR DESCRIPTION
I've been told this can go either way: [https://github.com/urbit/urbit/issues/2248#issuecomment-601639995](https://github.com/urbit/urbit/issues/2248#issuecomment-601639995)
To cover our bases, it'd be best to mention both dojo and chat-cli as possibilities.