### PR TITLE
update '~dopzod/urbit-help' to '~/~dopzod/urbit-help' since you gotta do that now

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -153,7 +153,7 @@
     </li>
   </ul>
   <p class="lh-copy">
-    Or, boot Urbit and join <code>~dopzod/urbit-help</code>
+    Or, boot Urbit and join <code>~/~dopzod/urbit-help</code>
   </p>
 </section>
 


### PR DESCRIPTION
os1 changed the syntax for joining chats, at least on landscape. now chats that arent affiliated with a group have a ~/ at the front, which i guess denotes the group they are in internally
just gonna put this here if its okay since its really like one of the biggest mentions of u-h

it doesnt look nearly as elegant but its more correct i guess.