### PR TITLE
Force all redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,10 +1,10 @@
-/docs/introduction                   /docs
-/docs/getting-started                /using/install
-/docs/getting-started/azimuth        /understanding-urbit/urbit-id
-/landscape                           /using/develop
-/docs/getting-started/using-a-star   /using/operations/stars-and-galaxies/
-/docs/bridge                         /using/operations/using-bridge/
-/docs/pki                            /docs/concepts/azimuth/
-/docs/arvo/internals/                /docs/tutorials/arvo/
-/primer                              /understanding-urbit/
-/install                             /using/install
+/docs/introduction                   /docs 301!
+/docs/getting-started                /using/install 301!
+/docs/getting-started/azimuth        /understanding-urbit/urbit-id 301!
+/landscape                           /using/develop 301!
+/docs/getting-started/using-a-star   /using/operations/stars-and-galaxies/ 301!
+/docs/bridge                         /using/operations/using-bridge/ 301!
+/docs/pki                            /docs/concepts/azimuth/ 301!
+/docs/arvo/internals/                /docs/tutorials/arvo/ 301!
+/primer                              /understanding-urbit/ 301!
+/install                             /using/install 301!


### PR DESCRIPTION
Netlify is [changing their redirect code](https://community.netlify.com/t/changed-behavior-in-redirects/10084) and to be honest, I'm unsure how it might even affect us, but to be safe, I'm updating the redirects file with the syntax to force the redirect, in order to retain the same functionality.

(Test by going to some of these now-redirected paths on the left-hand side, I suppose.)