### PR TITLE
various: add 'inter' fallback

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -145,7 +145,7 @@ footer nav {
         position: absolute;
         right: -36px;
         top: 13px;
-        font-family: "Inter UI", sans-serif;
+        font-family: "Inter UI", "Inter", sans-serif;
     }
     &.next p:first-of-type:not([data-flat=true])::before {
         content: "<--";
@@ -153,7 +153,7 @@ footer nav {
         position: absolute;
         left: -36px;
         top: 13px;
-        font-family: "Inter UI", sans-serif;
+        font-family: "Inter UI", "Inter", sans-serif;
     }
     // flattened pagination
     &.previous p:first-of-type::after {
@@ -162,7 +162,7 @@ footer nav {
         position: absolute;
         right: -36px;
         top: 0;
-        font-family: "Inter UI", sans-serif;
+        font-family: "Inter UI", "Inter", sans-serif;
     }
     &.next p:first-of-type::before {
         content: "<-";
@@ -170,7 +170,7 @@ footer nav {
         position: absolute;
         left: -36px;
         top: 0;
-        font-family: "Inter UI", sans-serif;
+        font-family: "Inter UI", "Inter", sans-serif;
     }
 }
 
@@ -431,7 +431,7 @@ input[type="search"] {
 
   #search-reset {
     cursor: pointer;
-    font-family: "Inter UI", sans-serif;
+    font-family: "Inter UI", "Inter", sans-serif;
     user-select: none;
     transform: scale(1.5);
   }
@@ -508,7 +508,7 @@ details {
             vertical-align: baseline;
             margin-right: 0.5rem;
             @extend .gray1;
-            font-family: "Inter UI", sans-serif;
+            font-family: "Inter UI", "Inter", sans-serif;
             font-weight: 400;
         }
     }
@@ -560,7 +560,7 @@ select {
     border: 0;
     outline: 0;
     background: transparent;
-    font-family: "Inter UI", sans-serif;
+    font-family: "Inter UI", "Inter", sans-serif;
 }
 nav.docs:not(.mobile) {
     height: 100vh;
@@ -579,7 +579,7 @@ nav.docs details {
         transform: rotate(90deg);
         vertical-align: baseline;
         @extend .gray1, .fw6;
-        font-family: "Inter UI", sans-serif;
+        font-family: "Inter UI", "Inter", sans-serif;
     }
     &[open] > summary {
         @extend .fw6;

--- a/templates/partials/search-overlay.html
+++ b/templates/partials/search-overlay.html
@@ -5,7 +5,7 @@
       <div class="search-bar pa0 bw0 z-1 di items-center flex w-100">
         <span class="header__search-icon ml3 absolute z-1 f5 gray3">⚲</span>
         <form id="search-form" class="w-100"><input id="search" autocomplete="off" type="search" class="search-bar__input bw0 black" placeholder="Go to..."></form>
-        <a id="search-reset" class="f6 pr3 gray3 no-underline pointer:hover">&#57503;</a>
+        <a id="search-reset" class="f6 pr3 gray3 no-underline pointer:hover">×</a>
       </div>
       <div id="full-results">
         <div id="glossary-results" class="glossary-results bt b--gray3 w-100">


### PR DESCRIPTION
Some kind of weirdness is going on with the Inter typeface and UI elements. 

<img width="375" alt="Screen Shot 2020-04-16 at 10 45 57 PM" src="https://user-images.githubusercontent.com/20846414/79526827-25db3880-8034-11ea-9a2d-91dc0c7ae1ee.png">

I added "Inter" as a fallback font for UI elements and changed the escaped HTML entity to its direct Unicode character.

<img width="226" alt="Screen Shot 2020-04-16 at 10 45 48 PM" src="https://user-images.githubusercontent.com/20846414/79526866-3f7c8000-8034-11ea-8d25-3f1ea040e730.png">

(Probably worth comparing the two in each browser.)