### PR TITLE
barbuc entry to glossary

### DIFF
--- a/static/glossary.js
+++ b/static/glossary.js
@@ -313,7 +313,7 @@ var glossary = [
     "symbol": "|$",
     "usage": "Cores",
     "link": "/docs/reference/hoon-expressions/rune/bar/#barbuc",
-    "desc": "Produce a wet gate that yields a mold builder."
+    "desc": "Produce a wet gate that is a mold builder."
   },
   {
     "name": "barcab",

--- a/static/glossary.js
+++ b/static/glossary.js
@@ -309,6 +309,13 @@ var glossary = [
     "desc": "Runes used to produce cores."
   },
   {
+    "name": "barbuc",
+    "symbol": "|$",
+    "usage": "Cores",
+    "link": "/docs/reference/hoon-expressions/rune/bar/#barbuc",
+    "desc": "Produce a wet gate that yields a structure."
+  },
+  {
     "name": "barcab",
     "symbol": "|_",
     "usage": "Cores",

--- a/static/glossary.js
+++ b/static/glossary.js
@@ -313,7 +313,7 @@ var glossary = [
     "symbol": "|$",
     "usage": "Cores",
     "link": "/docs/reference/hoon-expressions/rune/bar/#barbuc",
-    "desc": "Produce a wet gate that yields a structure."
+    "desc": "Produce a wet gate that yields a mold builder."
   },
   {
     "name": "barcab",

--- a/static/glossary.js
+++ b/static/glossary.js
@@ -313,7 +313,7 @@ var glossary = [
     "symbol": "|$",
     "usage": "Cores",
     "link": "/docs/reference/hoon-expressions/rune/bar/#barbuc",
-    "desc": "Produce a wet gate that is a mold builder."
+    "desc": "Declare a wet gate mold builder."
   },
   {
     "name": "barcab",


### PR DESCRIPTION
This adds barbuc `|$` to the glossary.

This PR is tied to https://github.com/urbit/docs/pull/877 and should not be merged until that one is merged.