### PR TITLE
Remove horizontal scrollbar on chrome and firefox

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -627,7 +627,7 @@ hr {
 
 .vid-insert-wrap {
   position: relative;
-  width: 100vw;
+  width: calc(100vw - 12px);
   height: 100vh;
 }
 


### PR DESCRIPTION
If you use `100vw` with padding, you will get overflow on body.

## Before

![Screenshot from 2020-05-17 20-40-26@2x](https://user-images.githubusercontent.com/1455726/82143431-edbb5580-987e-11ea-8c14-c57c4fe38262.png)

## After

![Screenshot from 2020-05-17 20-40-19@2x](https://user-images.githubusercontent.com/1455726/82143436-f318a000-987e-11ea-8b54-bc2970cf72d5.png)
