### PR TITLE
Fix video causing overflow

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -627,7 +627,7 @@ hr {
 
 .vid-insert-wrap {
   position: relative;
-  width: 100vw;
+  max-width: 100vw;
   height: 100vh;
 }
 


### PR DESCRIPTION
This should fix horizontal overflow of the page's body.

Tested on latest FF and Chromium, for desktop and mobile resolutions.