### PR TITLE
fixes install directions on running urbit command

### DIFF
--- a/content/using/install.md
+++ b/content/using/install.md
@@ -108,7 +108,7 @@ Find the absolute path to the keyfile that you downloaded from Bridge. Copy it.
 
 ### Step 3: Run the boot command
 
-If you are not already within the directory you installed above, enter it by running `cd urbit-v0.10.4-darwin` (for Mac) or `cd urbit-v0.10.4-linux64` (for Linux) from where you ran the install commands. It contains your Urbit binary. 
+If you are not already within the directory you installed above, enter it by running `cd urbit-v0.10.4-darwin` (for Mac) or `cd urbit-v0.10.4-linux64` (for Linux) from where you ran the install commands. It contains your Urbit binary, and your ship will be installed here as well.
 
 Once you're inside, run the command below, except with `sampel-palnet` replaced by the name of your
 Urbit identity, and `path/to/my-planet.key` replaced with the path to your keyfile:

--- a/content/using/install.md
+++ b/content/using/install.md
@@ -108,9 +108,9 @@ Find the absolute path to the keyfile that you downloaded from Bridge. Copy it.
 
 ### Step 3: Run the boot command
 
-Type `cd` in your terminal to return to your home directory. If you want to store your ship somewhere besides your home directory, change the terminal's working directory to the desired directory.
+If you are not already within the directory you installed above, enter it by running `cd urbit-v0.10.4-darwin` (for Mac) or `cd urbit-v0.10.4-linux64` (for Linux) from where you ran the install commands. It contains your Urbit binary. 
 
-Run the command below, except with `sampel-palnet` replaced by the name of your
+Once you're inside, run the command below, except with `sampel-palnet` replaced by the name of your
 Urbit identity, and `path/to/my-planet.key` replaced with the path to your keyfile:
 
 ```sh


### PR DESCRIPTION
Previous instructions were misleading as to where you can run `./urbit` from