### PR TITLE
bucbar entry in glossary

### DIFF
--- a/static/glossary.js
+++ b/static/glossary.js
@@ -631,6 +631,13 @@ var glossary = [
     "desc": "Runes used for defining custom types."
   },
   {
+      "name": "bucbar",
+      "symbol": "$|",
+      "usage": "Structures",
+      "link": "/docs/reference/hoon-expressions/rune/buc/#bucbar"
+      "desc": "<code>[%bsbr p=spec q=hoon]</code>: structure that satisfies a validator."
+  },
+  {
     "name": "buccab",
     "symbol": "$_",
     "usage": "Structures",


### PR DESCRIPTION
This adds an entry for `$|` in `static/glossary.js`. It should wait on
https://github.com/urbit/docs/pull/884 to be merged.

----

#