### PR TITLE
various: point users to urbit community

### DIFF
--- a/content/understanding-urbit/people-history.md
+++ b/content/understanding-urbit/people-history.md
@@ -27,7 +27,7 @@ Tlon is also working to set up an urbit.org foundation. This is still in process
 
 Urbit.live started selling Urbit IDs very early once that became possible, and also plans to offer services within the Urbit ecosystem.
 
-The community of contributors and core developers has been steadily contributing to the code base since before Tlon existed, and they’re still going strong. They can primarily be found on Urbit itself, in `~/~dopzod/urbit-help`, the [urbit-dev mailing list](https://groups.google.com/a/urbit.org/forum/#!forum/dev) and on [GitHub](https://github.com/urbit).
+The community of contributors and core developers has been steadily contributing to the code base since before Tlon existed, and they’re still going strong. They can primarily be found on Urbit itself, in the Urbit Community (`~bitbet-bolbel/urbit-community)`, the [urbit-dev mailing list](https://groups.google.com/a/urbit.org/forum/#!forum/dev) and on [GitHub](https://github.com/urbit).
 
 When the Urbit ID address space went on-chain in early 2019 there were about 2,000 star holders and 70 galaxy holders – that number has since grown steadily. For the most part, the best way to connect with them is through Urbit itself.
 
@@ -38,7 +38,7 @@ src="https://media.urbit.org/site/understanding-urbit/uu-people-history-2a.jpg"/
 src="https://media.urbit.org/site/understanding-urbit/uu-people-history-2c.jpg"
 />
 
-Given how new and unusual Urbit is, it attracts a wide variety of interesting people — both technical and non-technical. The community is generally happy to talk to people about what Urbit is, what we’re up to, and where we’re going. The best way to get involved is to simply join `~/~dopzod/urbit-help` — which our [setup instructions](/using/operations/using-your-ship/) can help you do.
+Given how new and unusual Urbit is, it attracts a wide variety of interesting people — both technical and non-technical. The community is generally happy to talk to people about what Urbit is, what we’re up to, and where we’re going. The best way to get involved is to simply join the Urbit Community at `~bitbet-bolbel/urbit-community` — which our [setup instructions](/using/operations/using-your-ship/) can help you do.
 
 For those interested in contributing there are some simple instructions on [GitHub](https://github.com/urbit/urbit/blob/master/CONTRIBUTING.md#contributing-to-urbit), but we also run a [grants program](https://grants.urbit.org/) where we reward contributors with Urbit ID address space. Grants aren’t solely for pre-determined projects, either. If you have something you’d like to propose, we’d love to hear from you.
 

--- a/content/using/develop.md
+++ b/content/using/develop.md
@@ -26,7 +26,7 @@ Just arrived and unsure what to work on? An ideal way to get started is by exper
 
 Prefer learning with an instructor? We also offer an online course that covers the basics of Urbit development called [Hoon School](@/community/hoonschool.md). If course-based learning works well for you, we recommend you sign up.
 
-The Urbit developer community congregates around [the urbit-dev mailing list](https://groups.google.com/a/urbit.org/forum/#!forum/dev), the `~/~dopzod/urbit-help` channel on Landscape, and [Urbit’s GitHub repository](https://github.com/urbit/urbit). It’s a good idea to sign up, see what people are talking about, and introduce yourself.
+The Urbit developer community congregates around [the urbit-dev mailing list](https://groups.google.com/a/urbit.org/forum/#!forum/dev), the `~bitbet-bolbel/urbit-community` group on Landscape, and [Urbit’s GitHub repository](https://github.com/urbit/urbit). It’s a good idea to sign up, see what people are talking about, and introduce yourself.
 
 Once you’re comfortable working with Urbit, check out the [project’s issues on GitHub](https://github.com/urbit/urbit/issues) or some of our [contribution bounties](https://grants.urbit.org/).
 

--- a/content/using/install.md
+++ b/content/using/install.md
@@ -205,16 +205,7 @@ Landscape is the Urbit web interface, and it's the best way to interact with you
 
 ### Joining the community
 
-Once you are in Landscape we recommend joining the Urbit Community group. You
-will need to obtain an invite, which can be had by first joining
-the `~/~dopzod/urbit-help` chat channel and asking for an invitation from there.
-This is most likely to succeed quickly during standard US West Coast working hours.
-Once you have the invite you can accept it by navigating to your Groups by
-clicking on All Groups in the upper left hand corner of Landscape, then Manage
-All Groups, and in there you should see an invitation. From this interface you
+Once you are in Landscape we recommend joining the Urbit Community group.
+Navigating to your Groups by clicking on All Groups in the upper left hand corner of Landscape, then Manage
+All Groups. Click "Join Group" and enter `~bitbet-bolbel/urbit-community`. From this interface you
 can join the various Chat, Publish, and Link instances contained in the group.
-
-You can join `~/~dopzod/urbit-help` from either Landscape or chat-cli. To join from
-Landscape first click on the Messaging tile on the home screen. Then press Join Chat
-in the upper left corner and enter `~/~dopzod/urbit-help` into the prompt and
-press Join Chat. To join from chat-cli, first make sure your console has been switched from Dojo to the `:chat-cli` application by pressing `Ctrl-x`. The prompt will display `~sampel-palnet:chat-cli` if in the correct mode. Then type `;join ~/~dopzod/urbit-help` and press Enter.

--- a/content/using/operations/using-your-ship.md
+++ b/content/using/operations/using-your-ship.md
@@ -196,7 +196,7 @@ You can find an identity's number by running ``` `@`~marzod ``` in any Dojo, whe
 4. Copy the "contract ABI" from [here](https://etherscan.io/address/ecliptic.eth#code) and paste it into the "ABI/JSON interface" field.
 5. Select the `escape()` function, passing in two arguments: your identity number, and the number of your desired sponsor.
 6. Sign and submit the transaction.
-7. Get in touch with your prospective sponsor, since they won't be notified otherwise. You can do this by contacting them on the network via chat, or joining `~/~dopzod/urbit-help` and asking around.
+7. Get in touch with your prospective sponsor, since they won't be notified otherwise. You can do this by contacting them on the network via chat, or joining `~bitbet-bolbel/urbit-community` and asking around.
 8. Wait for your request to be accepted by the prospective sponsor.
 9. If your request is not accepted by your prospective sponsor, a last resort, you can make a request to escape to `~marzod`, which is operated by Tlon, the company leading the development of Urbit.
 
@@ -264,23 +264,21 @@ Let’s get started using the `:chat-cli` application, also known more simply as
 
 ### Quickstart
 
-The most common uses of `:chat-cli` right now are communicating over a public chat channel on `~/~dopzod/urbit-help.` Everyone is more than welcome in `~/~dopzod/urbit-help`. It's the place to get help, ask questions and chat about Urbit in general.
-
-Note that largely equivalent functionality is also available through Chat's web UI in landscape. This is available from your ship’s URL address, mentioned earlier in this guide.
+The most common use for `:chat-cli` right now is, of course, communicating in group chats.
 
 ### Joining a chat
 
 In `:chat-cli`, any kind of medium for a message is called a _chat_. There are four "types" of chats, but for now we'll be dealing with the _channel_, a publicly accessible chatroom for general use. We'll discuss the other three kinds in the [chat management](#chat-management) section later on.
 
-Let's join the `~/~dopzod/urbit-help` channel. Use `ctrl-x` to switch from the Dojo prompt to the Chat prompt.
+Join the Urbit Community from Dojo using `:group-store|join ~bitbet-bolbel/urbit-community`. Once you've joined, join the General chat from chat-cli. Use `ctrl-x` to switch from the Dojo prompt to the Chat prompt.
 
 Then:
 
 ```
-~sampel-palnet:chat-cli/ ;join ~/~dopzod/urbit-help
+~sampel-palnet:chat-cli/ ;join ~darrux-landes/general
 ```
 
-Now that you're in, try post a line to `~/~dopzod/urbit-help`:
+Now that you're in, try post a line to `~darrux-landes/general`:
 
 ```
 ~sampel-palnet:chat-cli= Hello, world!
@@ -290,7 +288,7 @@ You'll see your message printed below messages from others that came before it. 
 
 ```
 ~sampel-palnet:chat-cli= ;chats
-~dopzod/urbit-help
+~darrux-landes/general
 ```
 
 Glyphs will be automatically assigned to channels, but have the option of binding a glyph (single non-alphanumeric character) to the channel you're joining; the syntax is in the form of `;join ~/~dopzod/books +`. The chosen glyph will be the symbol that ends your prompt, and it will be what you use as a shortcut to switch to this channel.
@@ -303,7 +301,7 @@ Glyphs will be automatically assigned to channels, but have the option of bindin
 Use `;leave` to unsubscribe from a channel:
 
 ```
-~sampel-palnet:chat-cli= ;leave ~/~dopzod/urbit-help
+~sampel-palnet:chat-cli= ;leave ~darrux-landes/general
 ```
 
 Now, let's create a channel we can invite some friends to:
@@ -312,7 +310,7 @@ Now, let's create a channel we can invite some friends to:
 ~sampel-palnet:chat-cli= ;create channel /my-channel
 ```
 
-Now you can tell your friends to `;join ~/~your-urbit/my-channel`.
+Now you can tell your friends to `;join ~your-urbit/my-channel`.
 
 In order to see messages in `:chat-cli` you may need to do the following in Dojo:
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -153,7 +153,7 @@
     </li>
   </ul>
   <p class="lh-copy">
-    Or, boot Urbit and join <code>~/~dopzod/urbit-help</code>
+    Or, boot Urbit and join the <code>~bitbet-bolbel/urbit-community</code>
   </p>
 </section>
 

--- a/templates/understanding-urbit/list.html
+++ b/templates/understanding-urbit/list.html
@@ -111,6 +111,6 @@
     </div>
     </form>
     <p class="mt3 mb3 mb3-xl lh-copy">You can also follow us on <a class="bb" href="https://twitter.com/urbit">Twitter</a> or <a class="bb" href="https://github.com/urbit">Github</a>.</p>
-    <p class="mt0 mb3 mb4-xl lh-copy">Or, preferably, on Urbit itself in <code>~/~dopzod/urbit-help</code></p>
+    <p class="mt0 mb3 mb4-xl lh-copy">Or, preferably, on Urbit itself in the <code>~bitbet-bolbel/urbit-community</code></p>
 </section>
 {% endblock content %}

--- a/templates/understanding-urbit/post.html
+++ b/templates/understanding-urbit/post.html
@@ -105,6 +105,6 @@
       </div>
       </form>
       <p class="mt3 mb3 mb3-xl lh-copy">You can also follow us on <a class="bb" href="https://twitter.com/urbit">Twitter</a> or <a class="bb" href="https://github.com/urbit">Github</a>.</p>
-      <p class="mt0 mb3 mb4-xl lh-copy">Or, preferably, on Urbit itself in <code>~/~dopzod/urbit-help</code></p>
+      <p class="mt0 mb3 mb4-xl lh-copy">Or, preferably, on Urbit itself in the <code>~bitbet-bolbel/urbit-community</code></p>
   </section>
 {% endblock content %}


### PR DESCRIPTION
- Sig prepended paths are dead
- We can now point people directly to Urbit Community, so this changes copy likewise
- Some intro copy is amended for a flow that directs people to the Group paradigm first instead of the IRC-style flow