### PR TITLE
 Keep guide up to date with other docs

### DIFF
--- a/content/using/operations/hosting.md
+++ b/content/using/operations/hosting.md
@@ -18,8 +18,7 @@ This guide uses Digital Ocean as the cloud provider, but others can be used.
  - Create an account on [Digital Ocean][Digital Ocean].
  - Create a droplet with the following settings:
  - **Image**: Ubuntu 20.04 x64
- - **Plan**: Basic
- - **Size**: $20 (4GB/2CPU)
+ - **Plan**: 4GB RAM
  - **Add block storage**: Skip
  - **Datacenter Region**: Choose the region closest to you.
  - **VPC Network**: No VPC

--- a/content/using/operations/hosting.md
+++ b/content/using/operations/hosting.md
@@ -17,12 +17,9 @@ This guide uses Digital Ocean as the cloud provider, but others can be used.
 ## Create a Digital Ocean droplet
  - Create an account on [Digital Ocean][Digital Ocean].
  - Create a droplet with the following settings:
- - **Image**: Ubuntu 18.04 x64
- - **Plan**: Standard
- - **Size**: 
-   - **Minimum**: $10 (2GB/1CPU) 
-   - **Recommended**: $15 (3GB/1CPU) 
-   - **Bonus**: $20 (4GB/2CPU)
+ - **Image**: Ubuntu 20.04 x64
+ - **Plan**: Basic
+ - **Size**: $20 (4GB/2CPU)
  - **Add block storage**: Skip
  - **Datacenter Region**: Choose the region closest to you.
  - **VPC Network**: No VPC
@@ -43,16 +40,18 @@ There are a lot of domain name registrars you can use, this guide suggests [gand
 Once you've registered your domain you'll need to configure it to use Digital Ocean for DNS. The following steps are done on the Gandi website.
  - Click Domain on the left panel
  - Click the domain you're going to use for Urbit
- - Click "Gandi's LiveDNS nameservers" under name servers on the overview page
+ - Click "Gandi's LiveDNS" under Nameservers in the Domain configuration section of the overview page
  - Click Change
- - Remove Gandi servers and add the Digital Ocean ones instead: 
+ - Click External
+ - Add the Digital Ocean nameservers:
    - `ns1.digitalocean.com`
    - `ns2.digitalocean.com`
    - `ns3.digitalocean.com`
  - Save the change.
- - It can take some time for this change to propagate, but I found it to be pretty quick (a few minutes).
+ - - It can take 12-24 hours for this change to propagate.
  - Now that you've updated the DNS records you can add the domain to your droplet.
- - Back on the DO site, click Networking from the left panel and then enter the domain you registered to have it set for your project.
+ - - Back on the DO site, click Networking from the left panel and then enter the domain you registered.
+ - Click on that domain and add an A record that directs to the IP of your droplet (found on your droplet's page).
 
 ## Creating your non-root user
 With our domain in place we're now ready to actually log into the box and start to configure the server itself.
@@ -106,6 +105,8 @@ Finally we're ready to install Urbit on your very own server. This part is actua
  - Next we're going to install Urbit on the server and permit it to bind to the web port:
    ```
    $ ssh your_user@your_domain
+   $ mkdir urbit
+   $ cd urbit
    $ curl -O https://bootstrap.urbit.org/urbit-v0.10.8-linux64.tgz
    $ tar xzf urbit-v0.10.8-linux64.tgz
    $ cd urbit-v0.10.8-linux64
@@ -114,14 +115,14 @@ Finally we're ready to install Urbit on your very own server. This part is actua
  - Now we're going to tar up your local ship and send it to your server, from your local machine's urbit directory:
    ```
    $ tar -zcvf <ship_dir_name>.tar.gz <ship_dir_name>
-   $ scp <ship_dir_name>.tar.gz  your_user@your_domain:/home/your_user/urbit-v0.10.8-linux64
+   $ scp <ship_dir_name>.tar.gz  your_user@your_domain:/home/your_user/urbit
    ```
  - Back on your server let's untar your ship and start it up with the Ames port we allowed through the firewall:
    ```
    $ ssh your_user@your_domain
-   $ cd urbit-v0.10.8-linux64
+   $ cd urbit
    $ tar -zxvf <ship_dir_name>.tar.gz
-   $ ./urbit <ship_dir_name>
+   $ ./urbit-v0.10.8-linux64/urbit <ship_dir_name>
    ```
  - Now we run a few commands in Dojo to request a Let’s Encrypt cert for your domain (replace `tld` with whatever your top-level domain is e.g. `com` in `example.com`:
    ```
@@ -137,12 +138,12 @@ Finally, to leave your Urbit running after you disconnect we can leave it in a S
    ```
    $ screen -S urbit
    ```
- - This will start a screen session, we can now start up the Urbit ship in this session:
+ - This will start a screen session, we can now start up the Urbit ship from the `urbit` directory in this session:
    ```
-   $ ./urbit <ship_dir_name>
+   $ ./urbit-v0.10.8-linux64/urbit <ship_dir_name>
    ```
  - Then we can disconnect from the screen session and leave the ship running with `control-a d`
- - To get back into the screen sesssion:
+ - To get back into the screen session:
    ```
    $ screen -r
    ```


### PR DESCRIPTION
* Urbit install guide now uses parent urbit directory
* Digital Ocean changed plans from standard to basic and dropped the $15 3GB plan to 2GB of memory.
* DO boxes now use Ubuntu 20.04 by default
* Gandi changed their UI again for no reason