### PR TITLE
Add link to "pier" to glossary json

### DIFF
--- a/static/glossary.js
+++ b/static/glossary.js
@@ -1318,6 +1318,13 @@ var glossary = [
     "desc": "A Gall app that is a framework for fleet testing using Aqua."
   },
   {
+    "name": "pier",
+    "symbol": "",
+    "usage": "arvo",
+    "link": "/docs/glossary/pier/",
+    "desc": "The stored state of an Urbit ship on disk."
+  },
+  {
     "name": "pill",
     "symbol": "",
     "usage": "arvo",


### PR DESCRIPTION
The "pier" article was added in https://github.com/urbit/docs/pull/946 - this adds the link to it to the main glossary page

cc @matildepark 