### PR TITLE
star and galaxy hosting correction

### DIFF
--- a/content/using/operations/stars-and-galaxies.md
+++ b/content/using/operations/stars-and-galaxies.md
@@ -8,9 +8,11 @@ template = "page_indiced.html"
 
 To boot your galaxy or star, follow our [installation instructions](@/using/install.md).
 
-### Hosting your star
+### Hosting your star 
 
-If you plan to distribute planets in any capacity, you must keep your star running. If you fail to do so, those planets will become orphans that are unable to communicate with the network.
+If you plan to distribute planets in any capacity, we ask that you keep your star
+running. If you fail to do so, those planets will become orphans that are unable
+to communicate with the network unless they transfer to a new star.
 
 See our [cloud hosting instructions](@/using/operations/hosting.md) for
 instructions on settings up a Digital Ocean droplet.
@@ -27,13 +29,15 @@ By default, your star accepts software updates from its galaxy and routes them t
 
 To ensure new planets can connect to your ship, users are expected to participate in network-wide breaches by [updating to the latest Urbit version](@/using/install.md), deleting (or archiving) your pier, and then booting your ship using the new binary. If you don’t participate, you won’t be able to communicate with anyone on the network who has updated to the new era.
 
-Network-wide breaches are distinct from personal breaches, wherein an individual ship cycles its personal network keys using bridge, and then follows the same steps outlined above.
+Network-wide breaches are distinct from personal breaches, wherein an individual ship cycles its personal network keys using Bridge, and then follows the same steps outlined above.
 
 See our [Guide to Breaches](https://urbit.org/docs/tutorials/guide-to-breaches) for more information and for instructions on breaching.
 
 ### Star-owner etiquette
 
-- If you distribute planets, boot and run your star on the Arvo network, or the planets won't be able to boot for the first time or connect.
+- If you distribute planets, boot and run your star on the Arvo network, or the
+  planets won't be able to boot for the first time or connect unless they
+  transfer to a different star.
 - A star is networking infrastructure. For that reason, the machine running your star or galaxy must have sufficient bandwidth and processing power for your dependent planets.
 - When messaging others, communicate using your star only when speaking in an official/infrastructural capacity. Otherwise, use your personal planet.
 

--- a/content/using/operations/stars-and-galaxies.md
+++ b/content/using/operations/stars-and-galaxies.md
@@ -12,9 +12,8 @@ To boot your galaxy or star, follow our [installation instructions](@/using/inst
 
 If you plan to distribute planets in any capacity, you must keep your star running. If you fail to do so, those planets will become orphans that are unable to communicate with the network.
 
-To make this as simple as possible, we’re building Terraform-based tooling for star and planet hosting via Google Cloud Platform. Once it’s ready we’ll open source the tooling so you can host stars and planets for yourself and others.
-
-In the meantime, there are [existing instructions](@/using/install.md) for those familiar with booting a Linux instance on GCP, AWS, Digital Ocean, etc.
+See our [cloud hosting instructions](@/using/operations/hosting.md) for
+instructions on settings up a Digital Ocean droplet.
 
 ### Distributing planets
 

--- a/content/using/operations/stars-and-galaxies.md
+++ b/content/using/operations/stars-and-galaxies.md
@@ -8,7 +8,7 @@ template = "page_indiced.html"
 
 To boot your galaxy or star, follow our [installation instructions](@/using/install.md).
 
-### Hosting your star 
+### Hosting your star
 
 If you plan to distribute planets in any capacity, we ask that you keep your star
 running. If you fail to do so, those planets will become orphans that are unable


### PR DESCRIPTION
Removed some incorrect copy about our plans for hosting software. Linked to our
documentation on hosting. Clarified that you really ought to run your star if
you distribute planets, but it is not a requirement and the planets under it won't be doomed.

Based on a request in the UC docs channel

----

#