### PR TITLE
Explain unresponsive prompt

### DIFF
--- a/content/using/install.md
+++ b/content/using/install.md
@@ -232,6 +232,8 @@ Or, if you'd prefer to copy your key in, you can run:
 
 Either command will create a directory called `sampel-palnet/` and begin building your ship. It may take a few minutes.
 
+Dojo might be unresponsive for some time (minutes) during first boot, for example you might see a `<<http>>` or `<<behn>>` spinner and keyboard is unresponsive.
+
 When your ship is finished booting, you will see either the `~sampel-palnet:dojo>` or `~sampel-palnet:chat-cli/` prompt. If you're seeing `:chat-cli` press `Ctrl-X` to switch into Dojo.
 
 To shut down your ship, use `Ctrl-D`. To start your ship up again, run the following from your `urbit` directory:


### PR DESCRIPTION
During install I was at first able to execute `(add 2 2)`, then I the `<<http>>` spinnter came up more often until the prompt became unresponsive to any keyboard input. Incidentally, that behaviour behaviour was explained at https://discord.com/channels/586329492260257812/596041386063691786/776134117590695936 and https://discord.com/channels/586329492260257812/596041386063691786/776134249098903642 and was helpful to both the person asking and me reading along.