### PR TITLE
update instructions for sponsor escape

### DIFF
--- a/content/using/operations/using-bridge.md
+++ b/content/using/operations/using-bridge.md
@@ -73,3 +73,39 @@ From the detail page associated with your point, click the `Generate Arvo Keyfil
 Click `Generate ->`, which will download a keyfile onto your machine.
 
 With that keyfile in hand, you can now exit Bridge and continue to the guide to [install the Urbit binary](@/using/install.md).
+
+### Escaping your sponsor
+
+To use the network as a planet or star, you must be sponsored by an active star
+or galaxy, respectively. If your sponsor isn't suiting your needs, you can
+escape to a different one. 
+
+#### Prerequisites
+
+- A little bit of ETH in your management proxy address to pay for the
+  transaction.
+- The `@p` of the sponsor you want to escape to. You should negotiate the
+  transfer with the sponsor ahead of time, as they will need to accept it on
+  their end. If you cannot find one, contact Tlon at support@urbit.org and we
+  will assist you in escaping to one of our stars/galaxies.
+
+#### Instructions
+
+1. Login to [Bridge](https://bridge.urbit.org) with the management proxy address
+   for the ship that will be escaping their sponsor. The ownership address will
+   also do, as will the master ticket if you have that.
+2. Click on the "OS" button at the bottom of the screen.
+3. Below Network, you will find the `@p` of your current sponsor. Click "Change"
+   to the right of that.
+4. Enter the `@p` of your new sponsor.
+5. Click the "Request" button and then complete the transaction.
+
+This action will consume a small amount of ETH. Your sponsor will then need to
+accept you via a similar process in Bridge, which will require ETH on their end.
+After the transaction is completed on Ethereum, it will still take some time for
+the information to propagate to the Urbit network. After 30 minutes or so, you
+may check that your sponsor has successfully been altered by running
+`(sein:title our now our)` in dojo and confirming that the `@p` matches that of
+your new sponsor.
+
+Changing your sponsor will also automatically change your OTA source to your new sponsor.

--- a/content/using/operations/using-bridge.md
+++ b/content/using/operations/using-bridge.md
@@ -76,9 +76,9 @@ With that keyfile in hand, you can now exit Bridge and continue to the guide to 
 
 ### Escaping your sponsor
 
-To use the network as a planet or star, you must be sponsored by an active star
-or galaxy, respectively. If your sponsor isn't suiting your needs, you can
-escape to a different one. 
+As a planet or star, it behooves you to be sponsored by an active star or galaxy,
+respectively. If your sponsor isn't suiting your needs, you can escape to a
+different one.
 
 #### Prerequisites
 
@@ -108,4 +108,6 @@ may check that your sponsor has successfully been altered by running
 `(sein:title our now our)` in dojo and confirming that the `@p` matches that of
 your new sponsor.
 
-Changing your sponsor will also automatically change your OTA source to your new sponsor.
+Once you change your sponsor, you will likely want to change your source of
+[OTAs](@/docs/glossary/ota-updates.md) to them as well. To accomplish this, enter `|ota
+~sponsor %kids` in dojo, where `~sponsor` is the `@p` of your new sponsor.

--- a/content/using/operations/using-your-ship.md
+++ b/content/using/operations/using-your-ship.md
@@ -185,28 +185,11 @@ To cycle the keys of a moon without breaching, run:
 
 ### Escaping A Sponsor {#escape}
 
-To use the network as a planet or star, you must be sponsored by an active star or galaxy, respectively. If your sponsor isn't suiting your needs, you can escape to a different one. The [Bridge](https://bridge.urbit.org/) software doesn't yet support escaping. For the time being, however, you can follow this guide.
-
-#### Prerequisites
-
-- A little bit of ETH in your management proxy address to pay for the transaction.
-- The identity number of the sponsor you want to escape from.
-- The identity number of the sponsor you want to escape to.
-
-You can find an identity's number by running ``` `@`~marzod ``` in any Dojo, where `~marzod` is the name of the relevant identity.
-
-#### Instructions
-
-0. If you have your management proxy in Metamask, you can use Etherscan [here](https://etherscan.io/address/ecliptic.eth#writeContract). Skip steps 1-4.
-1. Go to either myetherwallet.com or mycrypto.com. Since this is a low-risk operation, and you're signing with a low-value key, it's fine to use their online versions. Sign in with your management mnemonic. (They may still force you to download their tool to log in like this.)
-2. Navigate to the "interact with contract" page of the tool you're using.
-3. Specify a contract address of `0x6ac07B7C4601B5CE11de8Dfe6335B871C7C4dd4d`.
-4. Copy the "contract ABI" from [here](https://etherscan.io/address/ecliptic.eth#code) and paste it into the "ABI/JSON interface" field.
-5. Select the `escape()` function, passing in two arguments: your identity number, and the number of your desired sponsor.
-6. Sign and submit the transaction.
-7. Get in touch with your prospective sponsor, since they won't be notified otherwise. You can do this by contacting them on the network via chat, or joining `~bitbet-bolbel/urbit-community` and asking around.
-8. Wait for your request to be accepted by the prospective sponsor.
-9. If your request is not accepted by your prospective sponsor, a last resort, you can make a request to escape to `~marzod`, which is operated by Tlon, the company leading the development of Urbit.
+To use the network as a planet or star, you must be sponsored by an active star
+or galaxy, respectively. If your sponsor isn't suiting your needs, you can
+escape to a different one. This can be done with
+[Bridge](https://bridge.urbit.org/) following the instructions
+[here](@/using/operations/using-bridge.md#escaping-your-sponsor).
 
 ### Continuity breaches
 


### PR DESCRIPTION
Addresses https://github.com/urbit/docs/issues/982

I'm not actually certain that escaping automatically changes your OTA source.
@Fang-?

I changed the sponsor on one of my ships last week and noted that
`(sein:title our now our)` hadn't changed yet ~10 minutes later, but I don't
remember when I checked next and saw that it had. So saying 30 minutes is a bit
of a guess.


----

#