### PR TITLE
redirects: add latest release downloads

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -8,3 +8,5 @@
 /docs/arvo/internals/                /docs/tutorials/arvo/ 301!
 /primer                              /understanding-urbit/ 301!
 /install                             /using/install 301!
+/install/mac/latest                  http://github.com/urbit/urbit/releases/latest/download/darwin.tgz
+/install/linux64/latest              http://github.com/urbit/urbit/releases/latest/download/linux64.tgz


### PR DESCRIPTION
- Adds `urbit.org/install/mac/latest` and `urbit.org/install/linux64/latest` and uses the GitHub API to grab the asset of the same name from our latest release.

See urbit/urbit#4067 for the other half of this.