### PR TITLE
Suggest hardware requirements for planets and stars.

### DIFF
--- a/content/using/operations/stars-and-galaxies.md
+++ b/content/using/operations/stars-and-galaxies.md
@@ -38,7 +38,7 @@ See our [Guide to Breaches](https://urbit.org/docs/tutorials/guide-to-breaches) 
 - If you distribute planets, boot and run your star on the Arvo network, or the
   planets won't be able to boot for the first time or connect unless they
   transfer to a different star.
-- A star is networking infrastructure. For that reason, the machine running your star or galaxy must have sufficient bandwidth and processing power for your dependent planets.
+- A star is networking infrastructure. For that reason, the machine running your star or galaxy must have sufficient bandwidth, storage, and processing power for your dependent planets. Until event log pruning is implemented, expect ships to consume more disk space every year; stars looking to serve around 100 planets will want to ensure around 50GB of space per year of operation.
 - When messaging others, communicate using your star only when speaking in an official/infrastructural capacity. Otherwise, use your personal planet.
 
 ### Taxes

--- a/content/using/operations/using-your-ship.md
+++ b/content/using/operations/using-your-ship.md
@@ -67,6 +67,12 @@ Delete the tar file, and, after installing Urbit on your new server, start your 
 ./urbit your-urbit
 ```
 
+### Hardware requirements
+
+Urbit can run on any x86 computer, ideally with at least 2GB of RAM.
+
+Urbit maintains a persistent log of the history of your ship. Eventually this log will be automatically trimmed when necessary, but for now it only increases in size. An actively used planet will consume 5-50 GB of storage space per year of operation.
+
 ### Console
 
 Your Urbit terminal is separated into two parts: the prompt (the bottom line) and the record (everything above that). The record is shared; all the output from all the apps in your command set appears in it. The prompt is multiplexed.

--- a/content/using/operations/using-your-ship.md
+++ b/content/using/operations/using-your-ship.md
@@ -69,7 +69,7 @@ Delete the tar file, and, after installing Urbit on your new server, start your 
 
 ### Hardware requirements
 
-Urbit can run on any x86 computer, ideally with at least 2GB of RAM.
+Urbit can run on any x86 computer (unofficial, unsupported [ARM binaries](https://botter-nidnul.github.io/AArch64_Urbit_Static_Binaries.html) are also available), ideally with at least 2GB of RAM.
 
 Urbit maintains a persistent log of the history of your ship. Eventually this log will be automatically trimmed when necessary, but for now it only increases in size. An actively used planet will consume 5-50 GB of storage space per year of operation.
 


### PR DESCRIPTION
Fixes #360. As the issue mentions, the main non-obvious requirement is disk space. I gave these estimates:

- a star with ~100 planets will consume ~50GB/year
- an actively used personal planet will consume 5-50GB/year

I believe these estimates to be reasonable based on personal experience and pier sizes posted on urbit-community just before the last breach for bragging rights. I don't have a star, especially not one with 100 planets, so I can't confirm that, but I assume the original author of #360 said that from experience. 5 GB might be a low estimate for an actively used planet after a year, but "actively used" is a fuzzy term and we don't want to scare people off with a high estimate.

The second commit also mentions ~botter-nidnul's unofficial ARM binaries as referenced in #406, with the caveat that they are 'unofficial and unsupported'. I think as long as their unoffical nature is mentioned, they should be included in the docs so people for whom Raspberry Pi's are their only Unix-like environment are included. As a harm-reduction measure, better to have people running the unofficial binaries on a Pi than to run it in WSL and have it be slow and similarly unsupported. If you disagree with this change, you can cherry-pick the first commit, or I can remove it.