### PR TITLE
install: Clarify wget/curl and WSL2 instructions

### DIFF
--- a/content/using/install.md
+++ b/content/using/install.md
@@ -61,9 +61,7 @@ sudo setcap 'cap_net_bind_service=+ep' /path/to/urbit
 
 > Please note that this method of installing Urbit is experimental, and we may not be able to assist you if you encounter issues related to WSL 2.
 
-These instructions have been tested and verified for WSL 2 + Ubuntu 18.04 LTS.
-
-Urbit cannot run on Windows itself, but there is a convenient way to run a Linux distro using the [Windows Subsystem for Linux 2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install) on Windows 10. Install the Windows Subsystem for Linux 2 and open a Linux terminal in Windows, then follow the Linux installation instructions above.
+Urbit cannot run on Windows itself, but there is a convenient way to run a Linux distro using the [Windows Subsystem for Linux 2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install) on Windows 10. Install the Windows Subsystem for Linux 2 and open a Linux terminal in Windows, then follow the Linux installation instructions above. These instructions have been tested and verified for WSL 2 + Ubuntu 18.04 LTS, as demonstrated in `~sitful-hatred`'s step-by-step setup guide [here](https://subject.network/posts/urbit-wsl2/).
 
 For performance reasons, do not install Urbit in the mounted Windows volume, but install it in the Linux file system. For example, in your home directory, which can be navigated to by entering `cd ~`.
 

--- a/content/using/install.md
+++ b/content/using/install.md
@@ -55,7 +55,7 @@ To access your Urbit via HTTP on port 80 on Ubuntu, you may need to run the foll
 sudo apt-get install libcap2-bin
 sudo setcap 'cap_net_bind_service=+ep' /path/to/urbit
 ```
-(Where `urbit` is the urbit executable downloaded with `curl` prior)
+(Where `urbit` is the urbit executable downloaded with `wget` prior)
 
 ### Windows
 

--- a/content/using/install.md
+++ b/content/using/install.md
@@ -32,7 +32,7 @@ Regardless of your Urbit ID, you'll want the Urbit binary installed first. The U
 #macOS:
 mkdir urbit
 cd urbit
-wget --content-disposition https://urbit.org/install/mac/latest
+curl -JLO https://urbit.org/install/mac/latest
 tar zxvf ./darwin.tgz --strip=1
 ./urbit
 
@@ -259,7 +259,7 @@ First shut down your ship, by running the following in dojo (or with `Ctrl-D`).
 Next download and extract the most recent binary from inside your `urbit` directory:
 ```sh
 #macOS:
-wget --content-disposition https://urbit.org/install/mac/latest
+curl -JLO https://urbit.org/install/mac/latest
 tar zxvf ./darwin.tgz --strip=1
 
 #Linux:


### PR DESCRIPTION
The install instructions were recently changed to use `wget` rather than `curl`, but `wget` isn't available by default on MacOS, so I restored the `curl` instructions for those lines. I *believe* that `curl -JLO` replicates all the behaviors of `wget --content-disposition` but I welcome correction.

I also updated one line which still referenced `curl` on Ubuntu, and added a link to `~sitful-hatred`'s [awesome WSL2 instructions](https://subject.network/posts/urbit-wsl2/) in the Windows section.

This is my first pull request, so if I've violated any style guidelines, thank you for your patience!