### PR TITLE
Add OTA setup instructions for comets

### DIFF
--- a/content/using/install.md
+++ b/content/using/install.md
@@ -127,6 +127,27 @@ Good, your Dojo is working correctly. Now let's run our first useful command in 
 
 The `>=` output means that a command was successful. Now you can see your ship's files in its Unix directory.
 
+### Updating your comet
+
+The Urbit binary comes with a somewhat recent release of the Urbit OS, but ships can update automatically ("over the air"), so new binaries aren't necessary every time it's updated. Planets have automatic updates enabled by default, but this is not the case for comets. Many comets are used only once and thrown away, so it would be wasteful to update every single comet as soon as it boots. If you plan to use your comet for more than a quick test, you'll probably want to ensure you're running the latest version of the OS.
+
+You can enable updates for your comet by typing `|ota (sein:title our now our) %kids` into Dojo and pressing Enter.
+
+```
+> |ota (sein:title our now our) %kids
+>=
+```
+
+If you want to make sure you'll get updates, you can check by typing `|ota` with no arguments:
+
+```
+~sampel_marzod:dojo> |ota
+OTAs enabled from %kids on ~marzod
+use |ota %disable or |ota ~sponsor %kids to reset it
+> |ota
+>=
+```
+
 ### Using Landscape
 
 Landscape is the Urbit web interface, and it's the best way to interact with your ship. To access Landscape:

--- a/content/using/install.md
+++ b/content/using/install.md
@@ -81,7 +81,7 @@ To boot a comet, go into the command line and run the following command from the
 ./urbit -c mycomet
 ```
 
-Since your identity on the network is not verified, it may take up to an hour to generate your comet. As it boots, will spin out a bunch of boot messages and create a directory called `mycomet`. Toward the end of the boot process, you'll see something like:
+Since your identity on the network is not verified, it may take up to an hour to generate your comet. As it boots, it will spit out a bunch of boot messages and create a directory called `mycomet`. Toward the end of the boot process, you'll see something like:
 
 ```
 ames: on localhost, UDP 31337.


### PR DESCRIPTION
Comets don't come with OTAs enabled by default, probably for a few reasons:
- UX for comets wasn't a focus until recently, when getting a planet became a significant barrier to onboarding
- Many comets are ephemeral and only used for testing, where the boot pill normally suffices and updating to the very latest version is wasteful
- Stars hosting comets don't want to pay for "freeloaders" and want to do as little as possible for non-Sybil-resistant ships to prevent DDoS attacks

However, doing support for comets in urbit-help & on Discord, this seems to be one of the top stumbling blocks to getting set up. Some people have had issues joining certain channels in urbit-community with the urbit-v1.0 pill hash (which is probably another ticket in itself...) which have magically gone away once they were up to date.

Here I explain how to enable OTAs for comets (there was no existing section for that since planets do it by default) via their sponsor, if only so I can direct people with this issue to this section.