### PR TITLE
Add anchor links

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -650,3 +650,22 @@ hr {
 nav::-webkit-scrollbar {
     display: none;
 }
+
+
+// custom anchor styling
+a.zola-anchor {
+    visibility: hidden;
+    padding: 0 0.1rem;
+    &:hover {
+	background-color: black;
+	color: white;
+    }
+}
+
+h1, h2, h3, h4, h5, h6 {
+    &:hover > a.zola-anchor {
+        visibility: visible;
+        border-bottom-style: none;
+    }
+}
+

--- a/templates/anchor-link.html
+++ b/templates/anchor-link.html
@@ -1,0 +1,2 @@
+<!-- original at https://github.com/getzola/zola/blob/29b073640e26d96ab167c88ca70b18660f176cb4/docs/sass/_docs.scss#L48 -->
+<a class="zola-anchor" href="#{{ id }}" aria-label="Anchor link for: {{ id }}">¶</a>


### PR DESCRIPTION
This is a draft pr for adding anchor links as discussed in #285.  

I have created the `anchor-link.html` template and added styling for it in `_main.scss`. 
Then, one can add `insert_anchor_links = "right"` to any section's front matter and expect it to work ([docs](https://www.getzola.org/documentation/content/linking/#anchor-insertion)). I tried it out with `urbit.org/contents/docs` and it seemed to work nicely, but I didn't know where it would actually be appropriate to put it so I haven't made that change yet. Also, since it is a submodule I don't know exactly how I would update that alongside the urbit.org repo. 

Since I am new to contributing I don't exactly know the conventions for the repo, so please let me know if you need changes made before merging.
