### PR TITLE
bifurcated install guide

### DIFF
--- a/content/using/install.md
+++ b/content/using/install.md
@@ -118,7 +118,7 @@ There are five kinds of Urbit IDs but to get started you only need to know about
 
 ***
 
-**Planets** are scarce (this prevents spamming, among other things) and usually require a price to acquire. As plans for Urbit come to fruition, most people will use these.
+**Planets** are scarce (this prevents spamming, among other things) and usually require a price to acquire. This is the recommended way to run Urbit, but it's a bit more involved.
 
 A planet name looks like `~sampel-palnet`.
 
@@ -207,6 +207,8 @@ The dojo is Urbit's command line. You can use it to control your ship, or to exe
 
 ### Purchase a Permanent Identity {#boot-your-planet}
 
-You can continue using this comet indefinitely. There are currently few differences between using a comet-level identity and a planet-level one. However, some groups will not allow comets entry in order to maintain a certain level of quality, and changes may be made in the future that further devalue comets. They will always, however, be able to access the basic functions of the network. A comet also comes with a long and fairly unmemorable name whereas a planet has a short name and a "sigil" (avatar) associated with it that makes it more identifiable on the network. You may notice all this within the first few minutes of using Urbit.
+You can continue using this comet indefinitely. There are currently few differences between using a comet-level identity and a planet-level one. However, some groups will not allow comets entry in order to maintain a certain level of quality, and changes may be made in the future that further devalue comets. They will always, however, be able to access the basic functions of the network.
+
+A comet also comes with a long and fairly unmemorable name whereas a planet has a short name and a "sigil" (avatar) associated with it that makes it more identifiable on the network. You may notice all this within the first few minutes of using Urbit.
 
 [To read instructions on how to purchase and use a planet, visit this page](/using/planet).

--- a/content/using/install.md
+++ b/content/using/install.md
@@ -143,7 +143,7 @@ To boot a comet, go into the command line and run the following command from the
 ~/urbit/urbit -c mycomet
 ```
 
-It may take a while to load the comet. This comes along with it being free. It won't take more than an hour, but will probably only take a few minutes. When it's done you'll some messages ending like this:
+It may take a while to load the comet (probably only take a few minutes, but it could take longer). This comes along with it being free. When it's done you'll some messages ending like this:
 
 ```
 ames: on localhost, UDP 31337.
@@ -178,7 +178,7 @@ At the moment, the most common way to use Urbit is through a web app named Lands
 
 ### Updating your comet {#updating}
 
-The Urbit binary comes with a somewhat recent release of the Urbit OS, but ships can update automatically ("over the air"), so new binaries aren't necessary every time it's updated. Planets have automatic updates enabled by default, but this is not the case for comets. Many comets are used only once and thrown away, so it would be wasteful to update every single comet as soon as it boots. If you plan to use your comet for more than a quick test, you'll probably want to ensure you're running the latest version of the OS.
+The Urbit application comes with a recent release of the Urbit OS, but automatic updates ("over the air") can be enabled so new binaries aren't necessary for each update. Planets have automatic updates enabled by default, but this is not the case for comets. Many comets are used only once and thrown away, so it would be wasteful to update every single comet as soon as it boots. If you plan to use your comet for more than a quick test, you'll probably want to ensure you're running the latest version of the OS.
 
 You can enable updates for your comet by typing `|ota (sein:title our now our) %kids` into Dojo and pressing Enter.
 

--- a/content/using/install.md
+++ b/content/using/install.md
@@ -197,7 +197,15 @@ use |ota %disable or |ota ~sponsor %kids to reset it
 >=
 ```
 
-### Purchase a Permanent Identity {#planet}
+### Read More about the Dojo {#the-dojo}
+
+The dojo is Urbit's command line. You can use it to control your ship, or to execute arbitrary code. Check out the links below for more information.
+
+- [Basic Operations](/using/operations/using-your-ship)
+- [Basic Hoon](/docs/tutorials/hoon/hoon-school/setup)
+- [Glossary Entry](/docs/glossary/dojo)
+
+### Purchase a Permanent Identity {#boot-your-planet}
 
 You can continue using this comet indefinitely. There are currently few differences between using a comet-level identity and a planet-level one. However, some groups will not allow comets entry in order to maintain a certain level of quality, and changes may be made in the future that further devalue comets. They will always, however, be able to access the basic functions of the network. A comet also comes with a long and fairly unmemorable name whereas a planet has a short name and a "sigil" (avatar) associated with it that makes it more identifiable on the network. You may notice all this within the first few minutes of using Urbit.
 

--- a/content/using/install.md
+++ b/content/using/install.md
@@ -1,75 +1,149 @@
 +++
-title = "Install + Setup"
+title = "Getting Started"
 weight = 1
 description = "How to install Urbit."
 template = "page_indiced.html"
 aliases = ["/docs/getting-started/"]
 +++
 
-This guide covers how to install and set up your own planet (or comet), but installation for a star is exactly the same. You will first install the Urbit binary, then you will either boot a comet or a planet.  It's not too difficult, but if you would prefer to have someone run your urbit for you, consider a [hosting provider](#hosting-providers).
+The price of using other platforms is your data and its security. There's a reason they're free to use.
 
+The price of using Urbit is your own responsibility — you must run it yourself (or pay someone to run it for you).
 
-## Installing Urbit
+It's easy and it keeps getting easier.
 
-You'll want to install Urbit binary first.  Follow the instructions below to install the binary on Windows, MacOS, or Linux.
+There are currently two ways to run Urbit:
 
-### Windows
+If you use Mac or Linux and are not afraid of a few terminal commands, we recommend you run it yourself. That is the aim of this guide.
+
+If you run Windows or just want to give it a shot without worrying about the gritty bits, you may want to consider a [hosting provider](/using/planet#hosting-providers).
+
+## Installing Urbit {#macos-and-linux}
+
+Choose the code for your operating system and run the commands in your terminal.
+
+<div id="os">
+  <input type="radio" id="macos" name="os" checked>
+  <label for="macos">MacOS</label>
+  <div class="tab">
+
+```sh
+mkdir ~/urbit
+cd ~/urbit
+curl -JLO https://urbit.org/install/mac/latest
+tar zxvf ./darwin.tgz --strip=1
+~/urbit/urbit
+```
+  </div>
+
+  <input type="radio" id="linux" name="os">
+  <label for="linux">Linux</label>
+  <div class="tab">
+
+```sh
+mkdir ~/urbit
+cd ~/urbit
+wget --content-disposition https://urbit.org/install/linux64/latest
+tar zxvf ./linux64.tgz --strip=1
+~/urbit/urbit
+```
+
+Linux users may need to run this command in another terminal window to access your Urbit on port 80:
+
+```sh
+sudo apt-get install libcap2-bin
+sudo setcap 'cap_net_bind_service=+ep' ~/urbit/urbit
+```
+</div>
+
+  <input type="radio" id="windows" name="os">
+  <label for="windows">Windows</label>
+  <div class="tab">
 
 > Please note that this method of installing Urbit is experimental, and we may not be able to assist you if you encounter issues related to WSL 2.
 
 Urbit cannot run on Windows itself, but there is a convenient way to run Linux using the [Windows Subsystem for Linux 2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install) on Windows 10. Install the Windows Subsystem for Linux 2 and open a Linux terminal in Windows, then follow the Linux installation instructions below. These instructions have been tested and verified for WSL 2 + Ubuntu 18.04 LTS, as demonstrated in `~sitful-hatred`'s step-by-step setup guide [here](https://subject.network/posts/urbit-wsl2/).
 
 For performance reasons, do not install Urbit in the mounted Windows volume, but install it in the Linux file system. For example, in your home directory, which can be navigated to by entering `cd ~`.
+</div>
+</div>
 
-### macOS {#macos-and-linux}
+<style>
+  #os {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  #os label {
+    order: -1;
+    padding: .5rem;
+    border-width: 1px 0px 0px 1px;
+    border-style: solid;
+    cursor: pointer;
+  }
+  #os label[for=windows] {
+    border-right-width: 1px;
+  }
+  #os input[type="radio"] {
+    display: none;
+  }
+  #os .tab {
+    display: none;
+    border: 1px solid;
+    padding: 1rem;
+    max-width: 100%;
+  }
+  #os input[type='radio']:checked + label {
+    font-weight: bold;
+  }
+  #os input[type='radio']:checked + label + .tab {
+    display: block;
+}
+</style>
 
-**The macOS binary does not work on M1 macs.  Sorry.  We're working on an M1 release**
-
-```sh
-mkdir urbit
-cd urbit
-curl -JLO https://urbit.org/install/mac/latest
-tar zxvf ./darwin.tgz --strip=1
-./urbit
-
-```
-### Linux
-```sh
-mkdir urbit
-cd urbit
-wget --content-disposition https://urbit.org/install/linux64/latest
-tar zxvf ./linux64.tgz --strip=1
-./urbit
-```
-
-Once you've followed the appropriate install instructions, you can check if everything went right by running the `./urbit` command. Installation was successful if you get a block of output that begins with the line below:
+If successful, you will see a block of output beginning with the line:
 
 ```
 Urbit: a personal server operating function
 ```
 
-To access your Urbit via HTTP on port 80 on Ubuntu, you may need to run the following:
-```sh
-sudo apt-get install libcap2-bin
-sudo setcap 'cap_net_bind_service=+ep' /path/to/urbit
-```
-(Where `urbit` is the urbit executable downloaded with `wget` prior)
+## Booting a Free Identity {#comet}
 
-### Choose to boot a comet or a planet
+There are two parts to Urbit: an **ID** and an **Operating System**.
 
-If you just want to try Urbit out, you can use a comet. These are disposable, free identities, that are good for people who are new to Urbit and want to check out the network, but they aren't good for building a reputation as a friendly and responsible resident. Their long names (example: `~dasres-ragnep-lislyt-ribpyl--mosnyx-bisdem-nidful-marzod`) make them difficult to remember—and some communities ban comets to prevent spam—but they're still a good way to see what Urbit is about before buying your own planet.
+You have just installed the Operating System on your computer.
 
-To start with a comet, continue below. For planet instructions, see [further below](#boot-your-planet).
+The **ID** is similar to a username and password on another site. The difference is that the public part (the username) is verified by thousands of people around the world while only you hold the key (the password) to that ID.
 
-## Booting a comet {#comet}
+There are five kinds of Urbit IDs but to get started you only need to know about two: we call them **planets** and **comets**.
+
+***
+
+**Planets** are scarce (this prevents spamming, among other things) and usually require a price to acquire. As plans for Urbit come to fruition, most people will use these.
+
+A planet name looks like `~sampel-palnet`.
+
+[Follow this guide](/using/planet) if you have already acquired a planet.
+
+[Find a planet to purchase](/using/planet#purchase)
+
+***
+
+**Comets** are practically unlimited and free to acquire. At present, these are a great way to try out the network for free.
+
+A comet name looks like `~dasres-ragnep-lislyt-ribpyl--mosnyx-bisdem-nidful-marzod`.
+
+[Read more about Urbit ID here](/understanding-urbit/urbit-id)
+
+
+***
 
 To boot a comet, go into the command line and run the following command from the `urbit` directory you created during [Urbit installation](#installing-urbit):
 
 ```sh
-./urbit -c mycomet
+~/urbit/urbit -c mycomet
 ```
 
-Since your identity on the network is not verified, it may take up to an hour to generate your comet. As it boots, it will spit out a bunch of boot messages and create a directory called `mycomet`. Toward the end of the boot process, you'll see something like:
+It may take a while to load the comet. This comes along with it being free. It won't take more than an hour, but will probably only take a few minutes. When it's done you'll some messages ending like this:
 
 ```
 ames: on localhost, UDP 31337.
@@ -81,19 +155,26 @@ http: live (insecure, loopback) on 12321
 
 When your comet is finished booting, you will see `~sampel_marzod:dojo>` (Dojo: the Urbit command line).
 
-Get your password to log into landscape (the Urbit web interface) by typing:
-
-```sh
-+code
-```
-
 To exit Urbit, use `Ctrl-D` or enter `|exit` into Dojo.
 
 To start your comet up again, run the following from your `urbit` directory (note the lack of `-c` argument):
 
 ```sh
-./urbit mycomet
+~/urbit/urbit mycomet
 ```
+
+## Using Landscape
+
+Urbit is an entirely new computer, so by default it drops you into the "dojo," which is its terminal. Like your current computer, it can be used to do just about anything if you know the right commands. You only need to know one command for now.
+
+At the moment, the most common way to use Urbit is through a web app named Landscape, which comes with Urbit. It runs in your browser and provides an interface to Urbit without using the terminal. You need to get the password, or `code`.
+
+1. With your Urbit running, look for a line that says something like `http: live (insecure, public) on 80`. The number given is the port that your ship is using. It will probably be 80, but we're just making sure. (Don't worry about the "insecure, public" part — that just means you can access it from your own web browser. It doesn't give anyone else access.)
+2.  If the port given is `80`, simply type `localhost` into your browser's address bar. If the given port is a different number, such as `8080`, you would type `localhost:8080`. You'll be met with a login prompt.
+3. In the window where you found the port number, type `+code` and press return. Copy-paste the code that appears into the "Access Key" field in the browser, and press continue.
+4. Once in, take a look around and read the instructions on screen. If you ever get logged out, follow these instructions again.
+
+## Next Steps
 
 ### Updating your comet {#updating}
 
@@ -116,131 +197,8 @@ use |ota %disable or |ota ~sponsor %kids to reset it
 >=
 ```
 
-Now that you’re up and running, skip ahead to the [Setup guide](#setup).
+### Purchase a Permanent Identity {#planet}
 
-## Booting a planet {#boot-your-planet}
+You can continue using this comet indefinitely. There are currently few differences between using a comet-level identity and a planet-level one. However, some groups will not allow comets entry in order to maintain a certain level of quality, and changes may be made in the future that further devalue comets. They will always, however, be able to access the basic functions of the network. A comet also comes with a long and fairly unmemorable name whereas a planet has a short name and a "sigil" (avatar) associated with it that makes it more identifiable on the network. You may notice all this within the first few minutes of using Urbit.
 
-There are two options for getting started with a planet. You can purchase one on your own and run Urbit yourself, or you can purchase a planet and hosting services through a [hosting provider](#hosting-providers).
-
-### Purchase a planet
-
-There are a few ways to get your own planet:
-
-- Getting an invitation from a friend.
-- Purchasing a planet, including hosting, from a [hosting provider](#hosting-providers) such as [geturbitid.com](https://www.geturbitid.com/).
-- Manually setting up and hosting an planet purchased from a third party such as [urbit.live](https://urbit.live), [OpenSea](https://opensea.io), [planet.market](https://planet.market/), [urbit.me](https://urbit.me), [urth systems](https://urth.systems/), or [Urbit Marketplace](https://urbitmarketplace.com/).
-
-Note that when you buy a planet, you should ensure with the provider that your parent star is operating. If you need to escape a non-operational star, see [Escaping A Sponsor](@/using/operations/using-your-ship.md#escape).
-
-### Hosting Providers {#hosting-providers}
-
-Hosting providers will often sell you a planet and run it for you. This option is very simple but will probably cost a regular fee.
-
-Urbit is designed to be portable. This means that if you sign up for hosting now but later want to leave your hosting provider and run your Urbit yourself, you should be able to work with them to obtain all of your data and boot your planet back up without losing anything.
-
-Using hosting does mean that you're trusting your provider with your data, but so long as you have your planet, you'll always own your identity.
-
-Current hosting providers are:
-
-- [Tlon Corporation](https://tlon.io): Tlon is the creator of Landscape and is primarily responsible for the creation and maintenance of the Urbit project itself.
-- [Get an Urbit ID](https://www.geturbitid.com/): Get an Urbit ID was the first hosting provider and is run by a member of the Urbit community.
-
-
-### Choose to run your planet on your computer or on a cloud service
-
-Urbit must run on an existing computer somewhere.  Most users run their planet on their personal computer, but we recommend eventually using a cloud service (Digital Ocean, Linode, etc) because it allows your planet to be accessed from anywhere on multiple devices. Hosting your planet in the cloud also allows it to always be online and ready for automatic updates. You are welcome to run from your personal computer and switch to the cloud later...all without losing any data!
-
-There is a guide for [hosting your planet on DigitalOcean](@/using/operations/hosting.md) and [hosting your planet on Linode](https://jeremytunnell.com/2021/01/09/how-to-install-urbit-on-a-linode-vps), but any cloud hosting service should work.
-
-### Get your keyfile {#keyfile}
-
-If you received an email invite to Urbit, the master ticket should be a .pdf file in the passport folder inside the archive that you downloaded. **If you bought your planet or someone sent you one you probably do not have a master ticket, and you probably don't need one.  Do not issue a new master ticket unless you are sure you need to.**
-
-1. Connect to [Bridge](https://bridge.urbit.org). (Bridge is like an Urbit wallet)
-2. Enter the name of your planet and the associated master ticket if you have one. Click the "Metamask, Mnemonic, Hardware Wallet..." button if you don't have a master ticket.
-3. Once you're logged in, click the "OS" option.
-4. Click the "Download Arvo Keyfile" button. If this is grayed out, click on "Reset Networking Keys", then click on "Reset Networking Keys" on the following page, validate the transaction using your wallet, and then click "Send Trasaction". Once the transaction is complete, the "Download Arvo Keyfile" button should be available for you to press. You should receive a `.key` file that contains the secret needed to boot your planet. Hold onto this file.
-
-### Run the boot command {#the-dojo}
-
-Navigate to your `urbit` directory.
-
-Open your keyfile (it is just a text file) and copy the key inside.  Paste it into the following command, with `sampel-palnet` replaced by the name of your planet.  **Do not include the tilde in your planet name.**
-
-```sh
-./urbit -w sampel-palnet -G rAnDoMkEy
-```
-
-Or you can copy the keyfile into the current directory and run:
-
-```sh
-./urbit -w sampel-palnet -k ./my-planet.key
-```
-
-Either command will create a directory called `sampel-palnet/` and begin booting your planet. It may take a few minutes.
-
-When your planet is finished booting, you will see `~sampel-palnet:dojo>` (Dojo: the Urbit command line).
-
-Get your password to log into landscape (the Urbit web interface) by typing:
-
-```sh
-+code
-```
-
-To shut down your planet, use `Ctrl-D`.
-
-To start your planet up again, run the following from your `urbit` directory.
-
-```sh
-./urbit sampel-palnet
-```
-
-Note that `sampel-palnet/` is the path of a folder, which we just created in your `urbit` directory. This folder is called your planet's **pier**, and it holds all of your data.
-
-Never boot multiple instances of your planet at the same time. You can prevent this from happening on accident by only ever keeping a single copy of your pier.
-
-**Important:** once a key has been used to boot a planet onto the network, it cannot be used to boot that planet again later - doing so will cause communication problems with other planets. For this reason you should **delete the keyfile from your machine once your planet has booted successfully**. If you do use the same key twice, you'll need to reset your planet to restore its functionality.
-
-Delete the keyfile with the command below:
-
-```sh
-rm ./my-planet.key
-```
-
-## Setup {#setup}
-
-The first thing you generally want to do with a new planet is to **mount** it. A planet being mounted means that it can be seen by Linux, allowing files to be shared between it and your planet. To mount your planet, type `|mount %` at the Dojo prompt.
-
-```
-|mount %
->=
-```
-
-The `>=` output means that a command was successful. Now you can see your planet's files in its directory.
-
-To understand what happened with this command, read more about Urbit’s filesystem (called “clay”) [here](@/docs/tutorials/arvo/clay.md).
-
-### Using Landscape
-
-Landscape is the Urbit web interface, and it's the best way to interact with your planet. To access Landscape:
-
-1. Start your planet. In the boot messages, look for a line that says something like `http: live (insecure, public) on 80`. The number given is the port that your planet is using.
-2. If the port given is 80, and you are running Urbit on your personal computer, simply type `localhost` into your browser's address bar. If you are running urbit on a cloud server, type the ip of your cloud server.  If the given port is a different number, such as `8080`, you would type `localhost:8080` or `your-cloud-ip:8080`. You'll be met with a login prompt.
-3. Type your password you got from running `+code` above.
-4. You're in! Now you can explore groups, join chat channels, share links, and much more.
-
-### Join a group
-
-Now that you're on Landscape, join the Urbit Community, a great place for newcomers to ask questions.
-
-Click the `Join a Group` button, then enter `~bitbet-bolbel/urbit-community` into the field and press the `Join Group` button.
-
-From the Urbit Community group you can join a variety of chatrooms, notebooks, and collections.
-
-### Next Steps
-
-Now that you’re up and running, take some time to deepen your understanding by checking out some of our other guides:
-
-- [Host your Ship in the Cloud](@/using/operations/hosting.md): Follow this guide to set your ship up to run as a cloud server, accessible from anywhere.
-- [Read the Operations Manual](@/using/operations/using-your-ship.md): Become an expert pilot by learning to use your ship.
-- [Learn to Develop on Urbit](@/using/develop.md): Learn how to contribute to or develop on Urbit.
+[To read instructions on how to purchase and use a planet, visit this page](/using/planet).

--- a/content/using/planet.md
+++ b/content/using/planet.md
@@ -1,0 +1,129 @@
++++
+title = "Setting up Your Planet"
+weight = 1
+description = "Getting started with a permanent Urbit identity."
+template = "page_indiced.html"
++++
+
+A planet is a permanent Urbit identity. It can never be taken from you, and its reputation will be tied to your own. If you're not yet familiar with the Urbit network, please follow the [Getting Started guide](/using/install), which will explain the basics and walk you through using a free identity. This guide explains the next steps.
+
+### Purchase a planet {#purchase}
+
+There are a few ways to get your own planet:
+
+- Getting an invitation from a friend (or stranger).
+- Purchasing a planet, including hosting, from a [hosting provider](#hosting-providers) such as [geturbitid.com](https://www.geturbitid.com/).
+- Manually setting up and hosting an planet purchased from a third party such as [urbit.live](https://urbit.live), [OpenSea](https://opensea.io), [planet.market](https://planet.market/), [urbit.me](https://urbit.me), [urth systems](https://urth.systems/), or [Urbit Marketplace](https://urbitmarketplace.com/).
+
+Note that when you buy a planet, you should ensure with the provider that your parent star is operating. If you need to escape a non-operational star, see [Escaping A Sponsor](/using/operations/using-bridge/#escaping-your-sponsor).
+
+### Hosting Providers {#hosting-providers}
+
+Hosting providers will often sell you a planet and run it for you. This option is very simple but will probably cost a regular fee.
+
+Urbit is designed to be portable. This means that if you sign up for hosting now but later want to leave your hosting provider and run your Urbit yourself, you should be able to work with them to obtain all of your data and boot your planet back up without losing anything.
+
+Using hosting does mean that you're trusting your provider with your data, but so long as you have your planet, you'll always own your identity.
+
+Current hosting providers are:
+
+- [Tlon Corporation](https://tlon.io): Tlon is the creator of Landscape and is primarily responsible for the creation and maintenance of the Urbit project itself.
+- [Get an Urbit ID](https://www.geturbitid.com/): Get an Urbit ID was the first hosting provider and is run by a member of the Urbit community.
+
+
+### Choose to run your planet on your computer or on a cloud service
+
+Urbit must run on an existing computer somewhere.  Most users run their planet on their personal computer, but we recommend eventually using a cloud service (Digital Ocean, Linode, etc) because it allows your planet to be accessed from anywhere on multiple devices. Hosting your planet in the cloud also allows it to always be online and ready for automatic updates. You are welcome to run from your personal computer and switch to the cloud later...all without losing any data!
+
+There is a guide for [hosting your planet on DigitalOcean](@/using/operations/hosting.md) and [hosting your planet on Linode](https://jeremytunnell.com/2021/01/09/how-to-install-urbit-on-a-linode-vps), but any cloud hosting service should work.
+
+### Get your keyfile {#keyfile}
+
+If you received an email invite to Urbit, the master ticket should be a .pdf file in the passport folder inside the archive that you downloaded. **If you bought your planet or someone sent you one you probably do not have a master ticket, and you probably don't need one.  Do not issue a new master ticket unless you are sure you need to.**
+
+1. Connect to [Bridge](https://bridge.urbit.org). (Bridge is like an Urbit wallet)
+2. Enter the name of your planet and the associated master ticket if you have one. Click the "Metamask, Mnemonic, Hardware Wallet..." button if you don't have a master ticket.
+3. Once you're logged in, click the "OS" option.
+4. Click the "Download Arvo Keyfile" button. If this is grayed out, click on "Reset Networking Keys", then click on "Reset Networking Keys" on the following page, validate the transaction using your wallet, and then click "Send Trasaction". Once the transaction is complete, the "Download Arvo Keyfile" button should be available for you to press. You should receive a `.key` file that contains the secret needed to boot your planet. Hold onto this file.
+
+### Run the boot command {#the-dojo}
+
+Navigate to your `urbit` directory.
+
+Open your keyfile (it is just a text file) and copy the key inside.  Paste it into the following command, with `sampel-palnet` replaced by the name of your planet.  **Do not include the tilde in your planet name.**
+
+```sh
+./urbit -w sampel-palnet -G rAnDoMkEy
+```
+
+Or you can copy the keyfile into the current directory and run:
+
+```sh
+./urbit -w sampel-palnet -k ./my-planet.key
+```
+
+Either command will create a directory called `sampel-palnet/` and begin booting your planet. It may take a few minutes.
+
+When your planet is finished booting, you will see `~sampel-palnet:dojo>` (Dojo: the Urbit command line).
+
+Get your password to log into landscape (the Urbit web interface) by typing:
+
+```sh
++code
+```
+
+To shut down your planet, use `Ctrl-D`.
+
+To start your planet up again, run the following from your `urbit` directory.
+
+```sh
+./urbit sampel-palnet
+```
+
+Note that `sampel-palnet/` is the path of a folder, which we just created in your `urbit` directory. This folder is called your planet's **pier**, and it holds all of your data.
+
+Never boot multiple instances of your planet at the same time. You can prevent this from happening on accident by only ever keeping a single copy of your pier.
+
+**Important:** once a key has been used to boot a planet onto the network, it cannot be used to boot that planet again later - doing so will cause communication problems with other planets. For this reason you should **delete the keyfile from your machine once your planet has booted successfully**. If you do use the same key twice, you'll need to reset your planet to restore its functionality.
+
+Delete the keyfile with the command below:
+
+```sh
+rm ./my-planet.key
+```
+
+## Setup {#setup}
+
+The first thing you generally want to do with a new planet is to **mount** it. A planet being mounted means that it can be seen by Linux, allowing files to be shared between it and your planet. To mount your planet, type `|mount %` at the Dojo prompt.
+
+```
+|mount %
+>=
+```
+
+The `>=` output means that a command was successful. Now you can see your planet's files in its directory.
+
+To understand what happened with this command, read more about Urbit’s filesystem (called “clay”) [here](@/docs/tutorials/arvo/clay.md).
+
+## Updating {#updating}
+
+By default, planets have a sponsor — a star that provides updates and routing services. To see who you receive updates from, enter `|ota` in the dojo. You will see something like this:
+
+```
+~sampel-palnet:dojo> |ota
+OTAs enabled from %kids on ~dopzod
+use |ota %disable or |ota ~sponsor %kids to reset it
+> |ota
+>=
+```
+
+If for some reason your sponsor (in this case, `~dopzod`) is not responding, read instructions on [escaping your sponsor](/using/operations/using-bridge.md#escaping-your-sponsor).
+
+
+## Next Steps
+
+Now that you’re up and running, take some time to deepen your understanding by checking out some of our other guides:
+
+- [Host your Ship in the Cloud](@/using/operations/hosting.md): Follow this guide to set your ship up to run as a cloud server, accessible from anywhere.
+- [Read the Operations Manual](@/using/operations/using-your-ship.md): Become an expert pilot by learning to use your ship.
+- [Learn to Develop on Urbit](@/using/develop.md): Learn how to contribute to or develop on Urbit.

--- a/content/using/planet.md
+++ b/content/using/planet.md
@@ -3,6 +3,7 @@ title = "Setting up Your Planet"
 weight = 1
 description = "Getting started with a permanent Urbit identity."
 template = "page_indiced.html"
+aliases = ["/using/install.md#boot-your-planet", "/using/install.md#the-dojo"]
 +++
 
 A planet is a permanent Urbit identity. It can never be taken from you, and its reputation will be tied to your own. If you're not yet familiar with the Urbit network, please follow the [Getting Started guide](/using/install), which will explain the basics and walk you through using a free identity. This guide explains the next steps.

--- a/content/using/planet.md
+++ b/content/using/planet.md
@@ -5,7 +5,7 @@ description = "Getting started with a permanent Urbit identity."
 template = "page_indiced.html"
 +++
 
-A planet is a permanent Urbit identity. It can never be taken from you, and its reputation will be tied to your own. If you're not yet familiar with the Urbit network, please follow the [Getting Started guide](/using/install), which will explain the basics and walk you through using a free identity. This guide explains the next steps.
+A planet is a permanent Urbit identity. Like all Urbit identities, they can never be taken away from you. Unlike comets which are free, planets are designed for use well into the future. If you're not yet familiar with the Urbit network, please follow the [Getting Started guide](/using/install), which will explain the basics and walk you through using a free identity. This guide explains the next steps.
 
 ### Purchase a planet {#purchase}
 

--- a/content/using/planet.md
+++ b/content/using/planet.md
@@ -3,7 +3,7 @@ title = "Setting up Your Planet"
 weight = 1
 description = "Getting started with a permanent Urbit identity."
 template = "page_indiced.html"
-aliases = ["/using/install.md#boot-your-planet", "/using/install.md#the-dojo"]
+aliases = ["@/using/install.md#boot-your-planet", "@/using/install.md#the-dojo"]
 +++
 
 A planet is a permanent Urbit identity. It can never be taken from you, and its reputation will be tied to your own. If you're not yet familiar with the Urbit network, please follow the [Getting Started guide](/using/install), which will explain the basics and walk you through using a free identity. This guide explains the next steps.

--- a/content/using/planet.md
+++ b/content/using/planet.md
@@ -3,7 +3,6 @@ title = "Setting up Your Planet"
 weight = 1
 description = "Getting started with a permanent Urbit identity."
 template = "page_indiced.html"
-aliases = ["@/using/install.md#boot-your-planet", "@/using/install.md#the-dojo"]
 +++
 
 A planet is a permanent Urbit identity. It can never be taken from you, and its reputation will be tied to your own. If you're not yet familiar with the Urbit network, please follow the [Getting Started guide](/using/install), which will explain the basics and walk you through using a free identity. This guide explains the next steps.


### PR DESCRIPTION
In this PR I have taken the current language in the install guide and split it into two pages: "Getting Started" and "Setting up your Planet" — I think this gets people on board faster, while still making the requisite information available. I think there's still work to be done in the planet guide, but I haven't touched much of anything in there. I have updated some of the language in the "Getting Started" guide to be less technical, more results-oriented. I've also added a little tab switcher to the OS chooser, which I think ameliorates some of the earlier problems about which OS should come first (though I do still think the Mac tab should be first).

I don't know what's going on with the `content/docs` directory; let me know if you know how to fix that.
