### PR TITLE
Minor fix to anchor styling

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -661,6 +661,7 @@ a.zola-anchor {
 	background-color: black;
 	color: white;
     }
+    &:after {content: '¶'}
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/templates/anchor-link.html
+++ b/templates/anchor-link.html
@@ -1,2 +1,2 @@
 <!-- original at https://github.com/getzola/zola/blob/29b073640e26d96ab167c88ca70b18660f176cb4/docs/sass/_docs.scss#L48 -->
-<a class="zola-anchor" href="#{{ id }}" aria-label="Anchor link for: {{ id }}">¶</a>
+<a class="zola-anchor" href="#{{ id }}" aria-label="Anchor link for: {{ id }}"></a>


### PR DESCRIPTION
Basically, this moves the pilcrow in the :after selector.
This is to prevent the pilcrow from appearing in the text of a heading when you select it.

Honestly, should've caught this earlier but ¯\\\_(ツ)_/¯