### PR TITLE
adding -p ames_port to local install instructions pt 2

### DIFF
--- a/content/getting-started/planet.md
+++ b/content/getting-started/planet.md
@@ -48,18 +48,26 @@ If you received an email invite to Urbit, the master ticket should be a .pdf fil
 
 ### Run the boot command {#the-dojo}
 
-Navigate to your `urbit` directory.
+For other ships on the network to communicate with your ship, the computer it's
+running on needs to be able to receive inbound UDP traffic. Therefore, it's
+important when running your ship locally to use the `-p ames_port` flag (replace
+`ames_port` with a public port number from 49152 to 65535) to specify on which
+port you'll receive UDP traffic, and to forward inbound UDP traffic arriving at
+your router on that port to your computer.
 
-Open your keyfile (it is just a text file) and copy the key inside.  Paste it into the following command, with `sampel-palnet` replaced by the name of your planet.  **Do not include the tilde in your planet name.**
+Navigate to your `urbit` directory. Open your keyfile (it is just a text file)
+and copy the key inside. Paste it into the following command, except with
+`ames_port` replaced with a public port number, and `sampel-palnet` replaced by
+the name of your planet. **Do not include the tilde in your planet name.**
 
 ```sh
-./urbit -w sampel-palnet -G rAnDoMkEy
+./urbit -p ames_port -w sampel-palnet -G rAnDoMkEy 
 ```
 
 Or you can copy the keyfile into the current directory and run:
 
 ```sh
-./urbit -w sampel-palnet -k ./my-planet.key
+./urbit -p ames_port -w sampel-palnet -k ./my-planet.key 
 ```
 
 Either command will create a directory called `sampel-palnet/` and begin booting your planet. It may take a few minutes.
@@ -74,10 +82,10 @@ Get your password to log into landscape (the Urbit web interface) by typing:
 
 To shut down your planet, use `Ctrl-D`.
 
-To start your planet up again, run the following from your `urbit` directory.
+To start your planet up again, run the following from your `urbit` directory, with `ames_port` replaced with the public port number you used when first booting your ship.
 
 ```sh
-./urbit sampel-palnet
+./urbit -p ames_port sampel-palnet
 ```
 
 Note that `sampel-palnet/` is the path of a folder, which we just created in your `urbit` directory. This folder is called your planet's **pier**, and it holds all of your data.


### PR DESCRIPTION
This is just #460 adapted to the new install directions. Not being terribly proficient with git, I wasn't sure how to handle the merge conflict when the page it was originally committed to having been split in two and most of the language being changed.

Notably, this only alters the instructions for planets - I left the instructions for comets the same. This is the only compromise I can think of that leaves the directions people new to Urbit are most likely to follow (the comet ones) as simple as possible, while addressing the fact that some people have issues with their Ames port. I fear that asking a new person to set up port forwarding to run a comet is just going to make a lot of people decide not to bother running Urbit at all. Most people don't know what that is or how to do it, and every hurdle we put up has attrition implications.

If it were possible to have some kind of data that tells us what percentage of people have Ames port issues, this would be an easier decision to make, but I don't see any easy way to go about that. @joemfb 's [suggestion](https://github.com/urbit/urbit.org/pull/460#issuecomment-736758545) on having your sponsor figure this out for you is the only reasonable suggestion I'm aware of.