### PR TITLE
config: fix rss feeds

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,7 @@ compile_sass = true
 # Whether to generate a RSS feed automatically
 generate_feed = true
 build_search_index = true
+feed_filename = "rss.xml"
 
 [markdown]
 # A list of directories used to search for additional `.sublime-syntax` files.

--- a/templates/rss.xml
+++ b/templates/rss.xml
@@ -7,7 +7,7 @@
     <generator>Zola</generator>
     <language>{{ config.default_language }}</language>
     <atom:link href="{{ feed_url | safe }}" rel="self" type="application/rss+xml"/>
-    <lastBuildDate>{{ last_build_date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
+    <lastBuildDate>{{ last_updated | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
     {% for page in pages %}
     <item>
       <title>{{ page.title }}</title>


### PR DESCRIPTION
As per [breaking changes in 0.11.0](https://github.com/getzola/zola/blob/master/CHANGELOG.md#breaking-1), RSS config variable and RSS template variable updated to reflect latest behaviour.

Fixes #602