### PR TITLE
allow code blocks in docs to expand wider

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -314,6 +314,15 @@ nav ul.docs {
     line-height: 30px;
 }
 
+.doc {
+    > *:not(pre) {
+        @extend .measure-wide;
+    }
+    pre {
+        max-width: 60em;
+    }
+}
+
     // pagination
 nav.previous, nav.next {
     max-width: 40% !important;
@@ -452,6 +461,11 @@ pre {
     padding: 1.25rem;
     overflow-x: scroll;
     @extend .bg-gray5;
+
+    code {
+        overflow: scroll;
+        white-space: pre;
+    }
 }
 
 code, .code, .mono {

--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -465,6 +465,7 @@ pre {
     code {
         overflow: scroll;
         white-space: pre;
+        padding: 0;
     }
 }
 

--- a/templates/doc.html
+++ b/templates/doc.html
@@ -17,7 +17,7 @@
 <!-- header -->
 <!-- content -->
 {% include "partials/navigation-docs.html" %}
-<article class="mt4 mb6 full c4-12-lg measure-wide">
+<article class="mt4 mb6 full c4-12-lg doc">
   <!-- header -->
   <h1>{{ page.title }}</h1>
   <!-- body -->

--- a/templates/sections/docs.html
+++ b/templates/sections/docs.html
@@ -17,7 +17,7 @@
 <!-- header -->
 <!-- content -->
 {% include "partials/navigation-docs.html" %}
-<article class="mt4 mb6 full c4-12-lg measure-wide">
+<article class="mt4 mb6 full c4-12-lg doc">
   <!-- header -->
   <h1>{{ section.title }}</h1>
   <!-- body -->

--- a/templates/sections/docs/chapters.html
+++ b/templates/sections/docs/chapters.html
@@ -17,7 +17,7 @@
 <!-- header -->
 <!-- content -->
 {% include "partials/navigation-docs.html" %}
-<article class="mt4 mb6 full c4-12-lg measure-wide">
+<article class="mt4 mb6 full c4-12-lg doc">
 <!-- header -->
 <h1>{{ section.title }}</h1>
 <!-- body -->


### PR DESCRIPTION
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/3999320/116163576-def33a80-a6ac-11eb-88d8-50a5da943746.png">

Fixes https://github.com/urbit/urbit.org/issues/605