### PR TITLE
blog post: naive rollups

### DIFF
--- a/content/blog/rollups.md
+++ b/content/blog/rollups.md
@@ -12,16 +12,17 @@ Anybody who has used Ethereum smart contracts recently is aware that it has
 gotten _expensive_. There's all sorts of proposed solutions out there to make it
 affordable again-Ethereum 2.0 being the big one-but there's also a variety of
 complicated and clever mechanisms and proposals each with their own trade-offs
-that are collectively referred to as "layer 2 solutions". This is in contrast to
+that are collectively referred to as "layer 2 solutions" (see [further
+resources](#resources) for more information about these). This is in contrast to
 the first and original computational layer of Ethereum called "layer 1", where
 the brunt of the gas crisis is being felt.
 
 The standard personal vehicle for a human on Urbit is the
-[planet](@/docs/glossary/planet.md), for which we've long suggested a typical
-price of 10-20 $USD. Unfortunately, with the ongoing Ethereum gas crisis, along
+[planet](@/docs/glossary/planet.md), the cost of which we've generally guessed to be
+around 10-20 $USD. Unfortunately, with the ongoing Ethereum gas crisis, along
 with the rising price of Ethereum itself, the gas cost of acquiring a planet
 ends up being far more than the cost of the planet itself - perhaps as much as
-$100! This additional cost goes to the miners - in other words, there is no
+$100 at time of wriitng! This additional cost goes to the miners - in other words, there is no
 financial benefit to this for anybody working on Urbit or whoever you purchased
 address space. Tlon has always covered gas costs for [Urbit
 ID](@/docs/glossary/azimuth.md) up to a certain extent, but today's transactions
@@ -36,44 +37,51 @@ ownership.
 
 This post is primarily a short explainer for what these changes mean for the
 typical non-technical planet owner or those in the market for a planet, as well
-as a status update on where we're at in development. This will not be a
-technical explanation at all - those who want those details will find them
-linked at the end. This is also primarily aimed at those who currently self-host
-or wish to self-host their urbit. For anybody utilizing a hosted service, this
-matter will all be handled by your provider. We also have a [separate
-section](#stars) below addressed at [star](@/docs/glossary/star.md) owners, and
-those who wish to build a ["gateway" to layer 2](#rollers). Lastly, we emphasize
-that this system is 100% opt-in - if you are satisfied with the current
-experience of Urbit ID, then nothing changes for you whatsoever.
+as a status update on where we're at in development. We only offer minimal
+technical details on how this is done, mostly at [the end](#technical). This is
+also primarily aimed at those who currently self-host or plan to self-host their
+urbit. For anybody utilizing a hosted service, this matter will all be handled
+by your provider. We also have a [separate section](#stars) below addressed at
+[star](@/docs/glossary/star.md) owners, and those who wish to build a ["gateway"
+to layer 2](#rollers). Lastly, we emphasize that this system is 100% opt-in - if
+you are satisfied with the current experience of Urbit ID, then nothing changes
+for you whatsoever.
 
 Perhaps the most pressing question held by anybody reading this is - when will
-it be ready? We don't want to give a specific timeline, but rest assured that
-completing this upgrade is a top priority, much of the back-end is approaching
-completion, and we are confident in a release well before the end of 2021.
+it be ready? It's not reasonable to give a timeline on difficult engineering
+work, but rest assured that completing this upgrade is a top priority. Much
+of the back-end is approaching completion, and we are confident in a release
+well before the end of 2021.
 
-### Pros and cons
+### Naive rollups
 
 Our layer 2 solution, designed primarily by Tlon lead engineer `~wicdev-wisryt`,
 is known as "naive rollups" and we will be using this term interchangeably with
 "layer 2" - though it is important to note that there are many layer 2 solutions
-out there. As we're avoiding technicality here, we're only going to explain what
+utilized by projects other than Urbit. As we're avoiding technicality here, we're only going to explain what
 the user experience will be like - namely the advantages and disadvantages of
 utilizing our layer 2 solution, and how that affects the management of your
 [ship](@/docs/glossary/ship.md).
 
-The primary advantage to using naive rollups is that the gas cost for all Urbit
-ID-related actions will be dramatically reduced. It will be reduced by so much
-that we expect that Tlon will pay for all gas costs ourselves (assuming you
-access layer 2 through us - more on that later) unless you are submitting an
-unusually large number of transactions. That means that the cost you see for a
-planet on a reseller that supports layer 2 ought to be the final cost - no
-hidden gas charges to worry about at the end. We expect that we will not be
-building the only "gateway" (tentatively referred to as a "roller") to layer 2 -
-in fact, anybody can set up their own roller. We cannot make any guarantees on
-the final costs for those.
+Very briefly, a rollup is a way to combine many transactions into one, and we
+are building infrastructure so that any Urbit ship may be utilized as a "roller". A
+roller will collect Urbit ID transactions, compute their effects, and post the
+result of transactions onto the Ethereum blockchain. Anybody may set up their
+ship to [act as a roller](#rollers). Tlon will be launching our own public
+roller, but as Urbit is a decentralized network, by no means will we have a monopoly.
 
-There are a few trade-offs for this, but none of them really sacrifice any of
-the core value propositions of Urbit ID.
+#### Pros and cons
+
+The primary advantage to using naive rollups is that the gas cost for Urbit
+ID-related actions will be dramatically reduced. It will be reduced by so much
+that we expect that ordinary usage of Tlon's roller will not cost the end user
+anything - submitting the transactions to our roller will be free, and we will
+bear the gas cost of posting the results to the blockchain. That means that the
+cost you see for a planet on a market that utilizes Tlon's roller ought to be
+the final cost.
+
+There are a few trade-offs for this, but none of them really sacrifice the core
+value propositions of Urbit ID.
 
 The biggest one is that ships on layer 2 are essentially completely isolated
 from the rest of the Ethereum ecosystem. They can no longer interact with smart
@@ -86,49 +94,54 @@ where all ships currently exist), but they do not yet exist, and we cannot
 promise that such a thing will be available in a timely manner. Anybody moving a
 ship to layer 2, or buying a ship on layer 2, should assume that they will
 remain on layer 2 for the foreseeable future. We do not expect this to be
-permanent, but it is a fairly substantial drawback for the time being.
+permanent, but it is perhaps the most significant drawback for the time being.
 
-The last real disadvantage is that transactions will no longer be "instant".
-Effectively, this was already the case on layer 1 - unless you paid a lot of
-gas, you could wait hours or even days for your transaction to clear. But the
-way we are saving on gas is essentially by "bundling" or "rolling up" many
-transactions into one, and submitting them as a single transaction. The more
-transactions in the rollup, the better the savings. This bundling is not the
-only factor at play here though - costs are reduced other ways, but this is a
-technical detail we leave to the end. Tlon has not finalized the details on how
-our roller will work, but it will probably be something like waiting until a
-sufficient backlog of transactions have been submitted to make it economical to
-bundle them up, or just submitting every set time period, whichever arrives
-first. We do not see this as a big issue - we view Urbit ID as digital land, and
-a few hours to acquire land, or waiting for your new personal computer to be
-delievered, is still lightning fast in comparison to the real world.
+Another one is that transactions may no longer be "instant". Effectively, this
+was already the case on layer 1 - unless you paid a lot of gas, you could wait
+hours or even days for your transaction to clear. But the way we are saving on
+gas is essentially by "bundling" or "rolling up" many transactions into one, and
+submitting them as a single transaction. The more transactions in the rollup,
+the better the savings. This bundling is not the only factor at play here
+though - costs are reduced other ways, but this is a technical detail we leave
+[to the end](#technical). It is possible to use layer 2 to submit single
+transactions (and this will still save on gas costs!), so utilization of layer 2
+should not incur any delay over layer 1 when utilized in this fashion.
 
-What is this main value proposition that is not being lost? You still own your
-Urbit ID as a non-fungible token on the Ethereum blockchain. It belongs to you
-forever. This ownership is still just as secure and decentralized as it was on
-layer 1. We consider these principles to be uncompromisable, and maintaining
-these guarantees was totally central in choosing our solution. Furthermore,
-despite the fact that you will probably be relying on a third party roller to
-submit your transactions - no security will be lost. A roller is something like
-an Ethereum node - the worst that they can do is ignore your request, but they
-cannot maliciously alter it.
+Tlon has not finalized the details on how our roller will work, but it will
+probably involve waiting until a sufficient backlog of transactions have been
+submitted to make it economical to bundle them up, or just submitting every set
+time period, whichever arrives first. We do not see this as a big issue - we
+view Urbit ID as "digital land", and a few hours to acquire land, or waiting for
+your new personal computer to be delievered, is still lightning fast in
+comparison to the real world.
+
+What is this main value proposition that is not being lost? Your ship still
+belongs to you forever, and this is guaranteed by very strong cryptographic and
+game-theoretic guarantees comparable to the guarantees that exist on layer 1. We
+consider this principle to be uncompromisable, and maintaining ultimate
+sovereignty over your ship was totally central in choosing our solution.
+We summarize the new security model [below](#technical), and `~wicdev-wisryt`
+goes into greater detail in the [resources](#resources).
 
 ### Changes to User Experience
 
-Currently, the primary way one manages their Urbit ID, namely performing tasks
-such as transferring ships, setting networking keys, or setting
+The primary way one manages their Urbit ID, namely performing tasks such as
+transferring ships, setting networking keys, or setting
 [proxies](@/docs/glossary/proxies.md), is with a web interface called
 [Bridge](@/docs/glossary/bridge.md) found at
 [bridge.urbit.org](https://bridge.urbit.org). If you already own a planet,
 you've probably used Bridge before - perhaps only a single time.
 
-Bridge will be getting a facelift to enable easy interfacing with layer 2 -
-along with loud warnings about what is being gained and lost by utilizing
-layer 2. From here, you will be able to transfer your planet to layer 2, and
-once there, perform all the usual actions you can on layer 1. The main
-difference will be an additional choice of roller for your transactions, which
-will primarily determine a time delay on when your transaction will be submitted
-(and potentially an ETH cost, though as we've said, Tlon's will be free).
+Bridge will be getting a facelift to enable easy interfacing with layer 2,
+including loud warnings about what is being gained and lost by doing so. From
+here you will be able to transfer your ship to layer 2, and once there,
+perform all the usual actions you can on layer 1.
+
+The main difference for layer 2 transactions on Bridge will be an additional
+choice of roller. Tlon's will be free for ordinary, non-time-sensitive usage.
+You could use your own ship for a fast single transaction with a more marginal
+reduction in gas cost. We expect that planet markets may wish to set up their
+own rollers, and they could also be a service offered by a star.
 
 Every planet has a sponsor star, which distributes [OTA
 updates](@/docs/glossary/ota-updates.md) to their sponsored planets, as well as
@@ -139,8 +152,9 @@ in terms of how sponsorship works.
 When you buy a planet, any reputable seller will inform you whether or not it is
 on layer 1 or layer 2.
 
-And that's it! If you'd like to know how things will be changing for stars, what
-goes into setting up a roller, and links to technical details, read on.
+And that's it! If you'd like to know how things will be changing for
+[stars](#stars), what goes into [setting up a roller](#rollers), and additional
+[technical details](#technical), read on.
 
 ### Changes to stars {#stars}
 
@@ -150,27 +164,25 @@ reasons, and [moons](@/docs/glossary/moon.md) and
 [comets](@/docs/glossary/comet.md) never interacted with Ethereum anyways, so
 they are completely out of the picture.
 
-Stars will be able to remain on layer 1 if they wish with no action required.
-For star owners that wish to take advantage of the cheaper gas costs, there are
-two possible modes: ownership of the star on layer 2, or setting the
-spawn proxy to layer 2 with ownership remaining on layer 1.
+Stars will be able to remain on layer 1 with no action required. For star owners
+that wish to take advantage of the cheaper gas costs, there are two possible
+modes: ownership of the star on layer 2, or setting the spawn proxy to layer 2
+with ownership remaining on layer 1.
 
-The first mode-a star which is owned on layer 2-has the same advantages and disadvantages as a
-layer 1 planet: cheaper gas costs, at the expense of not being able to interact
-with layer 1 Ethereum smart contracts, potentially slower transaction speed, and
-not being able to return to layer 1 (at least for now). Planets spawned by a
-layer 2 star will also necessarily be on layer 2 - there is no way to spawn a
-layer 1 planet from a layer 2 star, though any planets which had been spawned on
-layer 1 before the star had migrated to layer 2 will remain on layer 1.
+The first mode-a star which is owned on layer 2-has the same advantages and
+disadvantages as a layer 1 planet. Planets spawned by a layer 2 star will also
+necessarily be on layer 2 - there is no way to spawn a layer 1 planet from a
+layer 2 star, though any planets which had been spawned on layer 1 before the
+star had migrated to layer 2 will remain on layer 1.
 
 The second mode-ownership on layer 1, with spawn proxy on layer 2-is only a
 little more complicated. Such a star will change its networking keys, transfer
 between wallets, and set its management proxy all on layer 1, with the
 corresponding higher gas prices. However, it will be able to spawn planets on
-layer 2-and _only_ on layer 2-with the corresponding cheaper/free gas prices.
-Like moving ownership to layer 2, this will be a one-way journey for now.
-Planets spawned before moving the spawn proxy to layer 2 will remain on layer 1,
-but from then on, all planets spawned by that star will exist on layer 2.
+layer 2-and _only_ on layer 2-with the corresponding layer 2 tradeoffs. Like
+moving ownership to layer 2, this will be a one-way journey for now. Planets
+spawned before moving the spawn proxy to layer 2 will remain on layer 1, but
+from then on, all planets spawned by that star will live on layer 2.
 
 In either scenario, stars will still be able to create [invite
 pools](@using/id/creating-an-invite-pool.md), which will now consist entirely of
@@ -189,28 +201,23 @@ submitted at regular intervals, once a sufficient number of transactions have
 been received (as more transactions means greater savings), manually, or some
 combination of the above.
 
-As mentioned before, Tlon will be maintaining its own roller, but we plan to
-release documentation on how to set up your own concurrently with the release of
-our layer 2 solution. Other rollers may offer shorter waittimes. We expect that
-planet markets may wish to set up their own rollers, and they could also be a
-service offered by a star. You could even utilize your own ship as a roller to
-submit your own single transactions if so desired - we estimate that a single
-transaction submitted on layer 2 will cost about 20% of the gas that it
-currently would on layer 1, so this is not without use.
+Tlon plans to release documentation on how to set up your own concurrently with
+the release of our layer 2 solution.
 
 Malicious rollers could potentially exist, but the worst they ought to be able
 to do is simply not submit your transaction. The security factors for rollers
-are outside of the scope of this post, but will be addressed in future
-documentation on rollers.
+are briefly addressed [below](#technical), and elaborated upon in the
+[resources](#resources), but you can expect full technical documentation on
+these factors to be included in the roller documentation.
 
 (Question: will rollers need to live on L2?)
 
 ### Changes to Azimuth
 
-[Azimuth](@/docs/glossary/azimuth.md) are the Ethereum smart contracts governing
-Urbit ID. They will require a few changes to accommodate the new system. Some of
-this has been implicit above, but to be clear, we will only be making a few
-minor alterations:
+[Azimuth](@/docs/glossary/azimuth.md) is the set of Ethereum smart contracts
+governing Urbit ID. They will require a few changes to accommodate the new
+system. Some of this has been implicit above, but to be clear, we will only be
+making a few minor alterations:
  - Once a star's spawn proxy is set to the layer 2 address, it can't be switched
    back, and they can no longer spawn layer 1 planets.
  - Galaxies cannot be deposited to layer 2.
@@ -218,7 +225,7 @@ minor alterations:
 yet to be worked out, but again, nothing will change for those who wish to
 remain on layer 1.
 
-### Technical details
+### Technical details {#technical}
 
 What's really going on behind the scenes here? The short version of it is that
 rollers will be utilized to perform the smart contract logic that is ordinarily
@@ -229,6 +236,24 @@ and the results of that contract will be put on the Ethereum blockchain. Because
 [Urbit OS](@/docs/glossary/arvo.md) is deterministic, and some of the formal
 properties of Hoon, Hoon turns out to be a great language for writing smart
 contracts.
+
+In layer 1, the Ethereum Virutal Machine guarantees the validity of state
+transitions, while for layer 2 transactions, each Urbit node guarantees the
+validity of the state transitions.
+
+In the layer 1 model, the source of truth of a state transition was:
+ 1. Post a transaction to the Ethereum blockchain
+ 2. Ethereum Virtual Machine checks and enforces the validity of the resulting
+    state transition
+ 3. Your urbit downloads the new state from an Ethereum node
+ 4. Your urbit gets a final decision on whether the new state is valid.
+ 
+In practice, the fourth step is never used in layer 1. The main change to our
+security model is that we are cutting out step 2 and beefing up step 4. Your
+ship will now perform validation of the transactions posted to the Ethereum
+blockchain, rather than the Ethereum Virtual Machine.
+
+#### Further Resources {#resources}
 
 We want to keep this post brief and non-technical, so that's all we'll say about
 it for now. To find out more, you have a few directions to go on. We held a

--- a/content/blog/rollups.md
+++ b/content/blog/rollups.md
@@ -1,123 +1,90 @@
 +++
 title = "The Gang Solves the Gas Crisis"
-date = 2021-05-06
+date = 2021-05-14
 description = "How we're making Urbit ID affordable again"
 [extra]
 author = "Jonathan Paprocki"
 ship = "~datnut-pollen"
-image = ""
+image = "https://media.urbit.org/site/posts/essays/gas.jpeg"
 +++
 
+![gas station](https://media.urbit.org/site/posts/essays/gas.jpeg)
+
 Anybody who has used Ethereum smart contracts recently is aware that it has
-gotten _expensive_. There's all sorts of proposed solutions out there to make it
-affordable again-Ethereum 2.0 being the big one-but there's also a variety of
-complicated and clever mechanisms and proposals each with their own trade-offs
+gotten _expensive_. There are a large quantity of
+complicated and clever techniques each with their own trade-offs
 that are collectively referred to as "layer 2 solutions" (see [further
 resources](#resources) for more information about these). This is in contrast to
-the first and original computational layer of Ethereum called "layer 1", where
-the brunt of the gas crisis is being felt.
+the base computational layer of Ethereum called "layer 1", which is what constitutes most Ethereum usage and where [Urbit ID](@/docs/glossary/azimuth.md)’s smart contracts currently exist.
 
-The standard personal vehicle for a human on Urbit is the
-[planet](@/docs/glossary/planet.md), the cost of which we've generally guessed to be
-around 10-20 $USD. Unfortunately, with the ongoing Ethereum gas crisis, along
-with the rising price of Ethereum itself, the gas cost of acquiring a planet
-ends up being far more than the cost of the planet itself - perhaps as much as
-$100 at time of wriitng! This additional cost goes to the miners - in other words, there is no
-financial benefit to this for anybody working on Urbit or whoever you purchased
-address space. Tlon has always covered gas costs for [Urbit
-ID](@/docs/glossary/azimuth.md) up to a certain extent, but today's transactions
-rarely meet that threshold. A couple of years ago the transactions needed to
-spawn a planet, transfer it to a new wallet, and set its keys and proxies was
-less than a dollar. We'd like to return to that state, and in fact make it even cheaper.
+Tlon has always covered gas costs for Urbit ID up to a set limit, and this was easy a couple of years ago when the cost of transactions required to get a [planet](@/docs/glossary/planet.md) up and running came out to less than a dollar. Unfortunately the ongoing Ethereum gas crisis, along with the rising price of Ethereum itself, has made this impossible. We’ve seen gas costs to set up a planet as high as several hundred US dollars at time of writing!
 
-In response to the gas crisis, we have spent the last several months developing
-a simple, in-house layer 2 solution by which we can return to these prices
-without sacrificing any of the main value propositions of Urbit address
-ownership.
+In response to the gas crisis, Tlon has spent the last several months developing
+a simple, in-house layer 2 solution which we anticipate will reduce typical gas costs by 65x or more.
 
-This post is primarily a short explainer for what these changes mean for the
-typical non-technical planet owner or those in the market for a planet, as well
-as a status update on where we're at in development. We only offer minimal
-technical details on how this is done, mostly at [the end](#technical). This is
-also primarily aimed at those who currently self-host or plan to self-host their
+This post is primarily a short non-technical explainer of the end-user experience of our solution aimed at planet and [star](@/docs/glossary/star.md) owners and those in the market for one, as well as a status update on where we're at in development. At [the end](#technical) we give some minimal technical details and resources to help you dig deeper should you wish. 
+This is also primarily aimed at those who currently self-host or plan to self-host their
 urbit. For anybody utilizing a hosted service, this matter will all be handled
-by your provider. We also have a [separate section](#stars) below addressed at
-[star](@/docs/glossary/star.md) owners, and those who wish to build a ["gateway"
-to layer 2](#rollers). Lastly, we emphasize that this system is 100% opt-in - if
-you are satisfied with the current experience of Urbit ID, then nothing changes
-for you whatsoever.
+by your provider. There is a [separate section](#stars) addressed specifically at star owners, and another [section](#rollers) for those who wish to set up their urbit to accept and submit layer 2 transactions. We’d like to emphasize that this system is 100% opt-in—if you are satisfied with the current experience of Urbit ID, then nothing changes for you whatsoever.
 
-Perhaps the most pressing question held by anybody reading this is - when will
+Perhaps the most pressing question held by anybody reading this is—when will
 it be ready? It's not reasonable to give a timeline on difficult engineering
 work, but rest assured that completing this upgrade is a top priority. Much
-of the back-end is approaching completion, and we are confident in a release
-well before the end of 2021.
+of the back-end is approaching completion, and we are confident in a release before the end of Q3 and hopefully much sooner.
 
 ### Naive rollups
 
 Our layer 2 solution, designed primarily by Tlon lead engineer `~wicdev-wisryt`,
 is known as "naive rollups" and we will be using this term interchangeably with
-"layer 2" - though it is important to note that there are many layer 2 solutions
-utilized by projects other than Urbit. As we're avoiding technicality here, we're only going to explain what
-the user experience will be like - namely the advantages and disadvantages of
-utilizing our layer 2 solution, and how that affects the management of your
-[ship](@/docs/glossary/ship.md).
+"layer 2"—though it is important to note that there are many layer 2 solutions
+utilized by projects other than Urbit. As we're avoiding technicality here, we’re focusing primarily on the advantages and disadvantages of utilizing our layer 2 solution, and how that affects the management of your [ship](@/docs/glossary/ship.md).
 
 Very briefly, a rollup is a way to combine many transactions into one, and we
 are building infrastructure so that any Urbit ship may be utilized as a "roller". A
-roller will collect Urbit ID transactions, compute their effects, and post the
-result of transactions onto the Ethereum blockchain. Anybody may set up their
-ship to [act as a roller](#rollers). Tlon will be launching our own public
-roller, but as Urbit is a decentralized network, by no means will we have a monopoly.
+roller will collect layer 2 Urbit ID transactions, compute their effects, and post the
+result of the transactions onto the Ethereum blockchain. Anybody may set up a
+ship to [act as a roller](#rollers). Tlon will be launching our own publicly accessible roller, but as Urbit is a decentralized network, by no means will we have a monopoly.
 
 #### Pros and cons
 
 The primary advantage to using naive rollups is that the gas cost for Urbit
-ID-related actions will be dramatically reduced. It will be reduced by so much
-that we expect that ordinary usage of Tlon's roller will not cost the end user
-anything - submitting the transactions to our roller will be free, and we will
-bear the gas cost of posting the results to the blockchain. That means that the
-cost you see for a planet on a market that utilizes Tlon's roller ought to be
+ID-related actions will be dramatically reduced. It will be reduced sufficiently that we expect that a few transactions per ship per week (plenty for ordinary usage) submitted to Tlon's roller will not cost the end user anything. There are no gas costs associated with submitting a layer 2 transaction to a roller, and Tlon will bear the gas cost of posting the results to the blockchain. That means that the cost you see for a planet on a market that utilizes Tlon's roller ought to be
 the final cost.
 
 There are a few trade-offs for this, but none of them really sacrifice the core
 value propositions of Urbit ID.
 
-The biggest one is that ships on layer 2 are essentially completely isolated
+The most substantial one is that ships on layer 2 are essentially completely isolated
 from the rest of the Ethereum ecosystem. They can no longer interact with smart
-contracts (of which there are very few, but there might be more in the future)
-that have not been explicitly designed to work with naive rollups.
+contracts designed to work with Urbit ID or non-fungible tokens (which are how Urbit IDs are represented) in general. It is also not possible to write new Ethereum smart contracts that work with layer 2 ships.
 
-Compounding that factor, the journey to layer 2 is one-way only - at
-least for now. There are theoretical ways a ship may move back to layer 1 (i.e.
-where all ships currently exist), but they do not yet exist, and we cannot
-promise that such a thing will be available in a timely manner. Anybody moving a
-ship to layer 2, or buying a ship on layer 2, should assume that they will
+Compounding that factor, the journey to layer 2 is one-way only—at
+least for now. There are theoretical ways a ship may be moved back to layer 1, but they do not yet exist, and we cannot promise that such a thing will be available in a timely manner. Anybody moving a ship to layer 2, or buying a ship on layer 2, should assume that they will
 remain on layer 2 for the foreseeable future. We do not expect this to be
 permanent, but it is perhaps the most significant drawback for the time being.
 
 Another one is that transactions may no longer be "instant". Effectively, this
-was already the case on layer 1 - unless you paid a lot of gas, you could wait
+was already the case on layer 1—unless you paid a lot of gas, you could wait
 hours or even days for your transaction to clear. But the way we are saving on
 gas is essentially by "bundling" or "rolling up" many transactions into one, and
 submitting them as a single transaction. The more transactions in the rollup,
 the better the savings. This bundling is not the only factor at play here
-though - costs are reduced other ways, but this is a technical detail we leave
-[to the end](#technical). It is possible to use layer 2 to submit single
+though—costs are reduced other ways, but this is a technical detail 
+[discussed later in this post](#technical). It is possible to use layer 2 to submit single
 transactions (and this will still save on gas costs!), so utilization of layer 2
 should not incur any delay over layer 1 when utilized in this fashion.
 
 Tlon has not finalized the details on how our roller will work, but it will
 probably involve waiting until a sufficient backlog of transactions have been
 submitted to make it economical to bundle them up, or just submitting every set
-time period, whichever arrives first. We do not see this as a big issue - we
+time period, whichever arrives first. We do not see this as a big issue—we
 view Urbit ID as "digital land", and a few hours to acquire land, or waiting for
-your new personal computer to be delievered, is still lightning fast in
-comparison to the real world.
+your new personal computer to be delivered, is still lightning fast in
+comparison to the real world. We also have ideas on methods that will allow you to get on the network before the transfer has been confirmed, but that is outside of the scope of this article.
 
-What is this main value proposition that is not being lost? Your ship still
-belongs to you forever, and this is guaranteed by very strong cryptographic and
-game-theoretic guarantees comparable to the guarantees that exist on layer 1. We
+Our layer 2 preserves the main value proposition of Urbit ID, which is that your ship 
+belongs to you forever, and that this is assured by very strong cryptographic methods and
+game-theoretic arguments comparable to the ones that exist on layer 1. We
 consider this principle to be uncompromisable, and maintaining ultimate
 sovereignty over your ship was totally central in choosing our solution.
 We summarize the new security model [below](#technical), and `~wicdev-wisryt`
@@ -137,20 +104,17 @@ including loud warnings about what is being gained and lost by doing so. From
 here you will be able to transfer your ship to layer 2, and once there,
 perform all the usual actions you can on layer 1.
 
-The main difference for layer 2 transactions on Bridge will be an additional
-choice of roller. Tlon's will be free for ordinary, non-time-sensitive usage.
-You could use your own ship for a fast single transaction with a more marginal
-reduction in gas cost. We expect that planet markets may wish to set up their
-own rollers, and they could also be a service offered by a star.
+The main difference for layer 2 transactions on Bridge will be the additional
+choice of a roller to submit transactions to. Tlon's will be free for ordinary, non-time-sensitive usage.
+You could use your own ship for a fast single transaction for a little more gas. We expect that planet markets and stars may wish to set up their own rollers as well.
 
 Every planet has a sponsor star, which distributes [OTA
-updates](@/docs/glossary/ota-updates.md) to their sponsored planets, as well as
-assisting with peer discovery. Both layer 1 and layer 2 planets will be able to
-sponsored by either layer 1 or layer 2 stars. So effectively nothing will change
+updates](@/docs/glossary/ota-updates.md) to their sponsored planets and assists with peer discovery. Both layer 1 and layer 2 planets will be able to be
+sponsored by either layer 1 or layer 2 stars, meaning that nothing will change
 in terms of how sponsorship works.
 
-When you buy a planet, any reputable seller will inform you whether or not it is
-on layer 1 or layer 2.
+When you buy a ship, any reputable seller will inform you whether or not it is
+on layer 1 or layer 2. Anyone running an urbit will be able to verify this information, and we expect for tools to exist to make this information publicly available (see [this grant](https://grants.urbit.org/bounties/1101665172-network-explorer-data-pipeline-http-api).
 
 And that's it! If you'd like to know how things will be changing for
 [stars](#stars), what goes into [setting up a roller](#rollers), and additional
@@ -169,24 +133,19 @@ that wish to take advantage of the cheaper gas costs, there are two possible
 modes: ownership of the star on layer 2, or setting the spawn proxy to layer 2
 with ownership remaining on layer 1.
 
-The first mode-a star which is owned on layer 2-has the same advantages and
-disadvantages as a layer 1 planet. Planets spawned by a layer 2 star will also
+The first mode—a star which is owned on layer 2—has the same advantages and
+disadvantages as a layer 2 planet. Planets spawned by a layer 2 star will also
 necessarily be on layer 2 - there is no way to spawn a layer 1 planet from a
-layer 2 star, though any planets which had been spawned on layer 1 before the
-star had migrated to layer 2 will remain on layer 1.
+layer 2 star, though any planets which were spawned on layer 1 before the
+star migrated to layer 2 will remain on layer 1.
 
-The second mode-ownership on layer 1, with spawn proxy on layer 2-is only a
-little more complicated. Such a star will change its networking keys, transfer
+The second mode—ownership on layer 1, with spawn proxy on layer 2—is only slightly more complicated. Such a star will change its networking keys, transfer
 between wallets, and set its management proxy all on layer 1, with the
-corresponding higher gas prices. However, it will be able to spawn planets on
-layer 2-and _only_ on layer 2-with the corresponding layer 2 tradeoffs. Like
+corresponding higher gas cost. However, it will be able to spawn planets on
+layer 2—and _only_ on layer 2—with the corresponding layer 2 tradeoffs. Like
 moving ownership to layer 2, this will be a one-way journey for now. Planets
 spawned before moving the spawn proxy to layer 2 will remain on layer 1, but
-from then on, all planets spawned by that star will live on layer 2.
-
-In either scenario, stars will still be able to create [invite
-pools](@using/id/creating-an-invite-pool.md), which will now consist entirely of
-layer 2 planets.
+from then on, all planets spawned by that star will live on layer 2. Finally, stars in this second mode may transition to the first mode, but not vice versa.
 
 ### Creating a roller {#rollers}
 
@@ -201,7 +160,7 @@ submitted at regular intervals, once a sufficient number of transactions have
 been received (as more transactions means greater savings), manually, or some
 combination of the above.
 
-Tlon plans to release documentation on how to set up your own concurrently with
+Tlon plans to release documentation on how to set up your own roller concurrently with
 the release of our layer 2 solution.
 
 Malicious rollers could potentially exist, but the worst they ought to be able
@@ -210,48 +169,36 @@ are briefly addressed [below](#technical), and elaborated upon in the
 [resources](#resources), but you can expect full technical documentation on
 these factors to be included in the roller documentation.
 
-(Question: will rollers need to live on L2?)
-
 ### Changes to Azimuth
 
 [Azimuth](@/docs/glossary/azimuth.md) is the set of Ethereum smart contracts
 governing Urbit ID. They will require a few changes to accommodate the new
 system. Some of this has been implicit above, but to be clear, we will only be
-making a few minor alterations:
+making a couple minor alterations:
  - Once a star's spawn proxy is set to the layer 2 address, it can't be switched
    back, and they can no longer spawn layer 1 planets.
- - Galaxies cannot be deposited to layer 2.
- - When depositing to layer 2, proxies are reset. Some other minor details are
-yet to be worked out, but again, nothing will change for those who wish to
-remain on layer 1.
+ - Galaxies and their proxies cannot be deposited to layer 2.
+Some other minor details are yet to be worked out, but again, nothing will change for those who wish to remain on layer 1.
 
 ### Technical details {#technical}
 
-What's really going on behind the scenes here? The short version of it is that
-rollers will be utilized to perform the smart contract logic that is ordinarily
-performed on Ethereum, and only the final resulting state of the computation
-will be submitted to the Ethereum blockchain. In other words, when you submit
-transactions to a roller, they will be running a "Hoon smart contract" on it,
-and the results of that contract will be put on the Ethereum blockchain. Because
-[Urbit OS](@/docs/glossary/arvo.md) is deterministic, and some of the formal
-properties of Hoon, Hoon turns out to be a great language for writing smart
-contracts.
+What's really going on behind the scenes here? Briefly, only the data of the Urbit ID transactions will be posted on-chain, while computation and state storage will now happen on your ship.
 
-In layer 1, the Ethereum Virutal Machine guarantees the validity of state
-transitions, while for layer 2 transactions, each Urbit node guarantees the
-validity of the state transitions.
+In layer 1, the [Ethereum Virtual Machine (EVM)](https://ethereum.org/en/developers/docs/evm/) guarantees the validity of state transitions, while for layer 2 transactions, each Urbit node guarantees the validity of the state transitions.
 
-In the layer 1 model, the source of truth of a state transition was:
- 1. Post a transaction to the Ethereum blockchain
- 2. Ethereum Virtual Machine checks and enforces the validity of the resulting
-    state transition
- 3. Your urbit downloads the new state from an Ethereum node
- 4. Your urbit gets a final decision on whether the new state is valid.
+Changes to the state of Urbit ID on layer 1 works as follows:
+ 1. A transaction is posted to the Ethereum blockchain.
+ 2. The EVM calculates the resulting state transition and checks its validity, then updates the state.
+ 3. Your urbit downloads the new state from an Ethereum node.
+ 4. Your urbit makes the final decision on whether the new state is valid.
  
-In practice, the fourth step is never used in layer 1. The main change to our
+In practice, the fourth step is never used in layer 1. The primary change to our
 security model is that we are cutting out step 2 and beefing up step 4. Your
 ship will now perform validation of the transactions posted to the Ethereum
-blockchain, rather than the Ethereum Virtual Machine.
+blockchain, rather than the EVM.
+
+Since [Urbit OS](@/docs/glossary/arvo.md) is deterministic, and Hoon has some nice formal
+properties, it turns out to be a great language for writing smart contracts. Thus we are effectively swapping the Ethereum smart contract with a “Hoon smart contract” run locally on your ship. 
 
 #### Further Resources {#resources}
 
@@ -263,10 +210,11 @@ explains why we decided to utilize our own design rather than other known layer
 2 solutions such as [Optimistic
 rollups](https://docs.ethhub.io/ethereum-roadmap/layer-2-scaling/optimistic_rollups/),
 [ZK-rollups](https://docs.ethhub.io/ethereum-roadmap/layer-2-scaling/zk-rollups/),
-etc, or other blockchains. For those who would rather read, see
+etc, or other blockchains. He also plans to do a more technical walkthrough video sometime before release. For those who would rather read, see
 `~wicdev-wisryt`'s [RFC: Naive rollup for cheaper Urbit ID
 transactions](https://groups.google.com/a/urbit.org/g/dev/c/p6rP_WsxLS0/m/hQBX0modAwAJ)
 post on the `urbit-dev` mailing list. Lastly, the primary working branch on
 Github for the Urbit side of naive rollups is
 [here](https://github.com/urbit/urbit/tree/philip/naive), though it is not the
 only place code is accumulating.
+

--- a/content/blog/rollups.md
+++ b/content/blog/rollups.md
@@ -1,0 +1,247 @@
++++
+title = "The Gang Solves the Gas Crisis"
+date = 2021-05-06
+description = "How we're making Urbit ID affordable again"
+[extra]
+author = "Jonathan Paprocki"
+ship = "~datnut-pollen"
+image = ""
++++
+
+Anybody who has used Ethereum smart contracts recently is aware that it has
+gotten _expensive_. There's all sorts of proposed solutions out there to make it
+affordable again-Ethereum 2.0 being the big one-but there's also a variety of
+complicated and clever mechanisms and proposals each with their own trade-offs
+that are collectively referred to as "layer 2 solutions". This is in contrast to
+the first and original computational layer of Ethereum called "layer 1", where
+the brunt of the gas crisis is being felt.
+
+The standard personal vehicle for a human on Urbit is the
+[planet](@/docs/glossary/planet.md), for which we've long suggested a typical
+price of 10-20 $USD. Unfortunately, with the ongoing Ethereum gas crisis, along
+with the rising price of Ethereum itself, the gas cost of acquiring a planet
+ends up being far more than the cost of the planet itself - perhaps as much as
+$100! This additional cost goes to the miners - in other words, there is no
+financial benefit to this for anybody working on Urbit or whoever you purchased
+address space. Tlon has always covered gas costs for [Urbit
+ID](@/docs/glossary/azimuth.md) up to a certain extent, but today's transactions
+rarely meet that threshold. A couple of years ago the transactions needed to
+spawn a planet, transfer it to a new wallet, and set its keys and proxies was
+less than a dollar. We'd like to return to that state, and in fact make it even cheaper.
+
+In response to the gas crisis, we have spent the last several months developing
+a simple, in-house layer 2 solution by which we can return to these prices
+without sacrificing any of the main value propositions of Urbit address
+ownership.
+
+This post is primarily a short explainer for what these changes mean for the
+typical non-technical planet owner or those in the market for a planet, as well
+as a status update on where we're at in development. This will not be a
+technical explanation at all - those who want those details will find them
+linked at the end. This is also primarily aimed at those who currently self-host
+or wish to self-host their urbit. For anybody utilizing a hosted service, this
+matter will all be handled by your provider. We also have a [separate
+section](#stars) below addressed at [star](@/docs/glossary/star.md) owners, and
+those who wish to build a ["gateway" to layer 2](#rollers). Lastly, we emphasize
+that this system is 100% opt-in - if you are satisfied with the current
+experience of Urbit ID, then nothing changes for you whatsoever.
+
+Perhaps the most pressing question held by anybody reading this is - when will
+it be ready? We don't want to give a specific timeline, but rest assured that
+completing this upgrade is a top priority, much of the back-end is approaching
+completion, and we are confident in a release well before the end of 2021.
+
+### Pros and cons
+
+Our layer 2 solution, designed primarily by Tlon lead engineer `~wicdev-wisryt`,
+is known as "naive rollups" and we will be using this term interchangeably with
+"layer 2" - though it is important to note that there are many layer 2 solutions
+out there. As we're avoiding technicality here, we're only going to explain what
+the user experience will be like - namely the advantages and disadvantages of
+utilizing our layer 2 solution, and how that affects the management of your
+[ship](@/docs/glossary/ship.md).
+
+The primary advantage to using naive rollups is that the gas cost for all Urbit
+ID-related actions will be dramatically reduced. It will be reduced by so much
+that we expect that Tlon will pay for all gas costs ourselves (assuming you
+access layer 2 through us - more on that later) unless you are submitting an
+unusually large number of transactions. That means that the cost you see for a
+planet on a reseller that supports layer 2 ought to be the final cost - no
+hidden gas charges to worry about at the end. We expect that we will not be
+building the only "gateway" (tentatively referred to as a "roller") to layer 2 -
+in fact, anybody can set up their own roller. We cannot make any guarantees on
+the final costs for those.
+
+There are a few trade-offs for this, but none of them really sacrifice any of
+the core value propositions of Urbit ID.
+
+The biggest one is that ships on layer 2 are essentially completely isolated
+from the rest of the Ethereum ecosystem. They can no longer interact with smart
+contracts (of which there are very few, but there might be more in the future)
+that have not been explicitly designed to work with naive rollups.
+
+Compounding that factor, the journey to layer 2 is one-way only - at
+least for now. There are theoretical ways a ship may move back to layer 1 (i.e.
+where all ships currently exist), but they do not yet exist, and we cannot
+promise that such a thing will be available in a timely manner. Anybody moving a
+ship to layer 2, or buying a ship on layer 2, should assume that they will
+remain on layer 2 for the foreseeable future. We do not expect this to be
+permanent, but it is a fairly substantial drawback for the time being.
+
+The last real disadvantage is that transactions will no longer be "instant".
+Effectively, this was already the case on layer 1 - unless you paid a lot of
+gas, you could wait hours or even days for your transaction to clear. But the
+way we are saving on gas is essentially by "bundling" or "rolling up" many
+transactions into one, and submitting them as a single transaction. The more
+transactions in the rollup, the better the savings. This bundling is not the
+only factor at play here though - costs are reduced other ways, but this is a
+technical detail we leave to the end. Tlon has not finalized the details on how
+our roller will work, but it will probably be something like waiting until a
+sufficient backlog of transactions have been submitted to make it economical to
+bundle them up, or just submitting every set time period, whichever arrives
+first. We do not see this as a big issue - we view Urbit ID as digital land, and
+a few hours to acquire land, or waiting for your new personal computer to be
+delievered, is still lightning fast in comparison to the real world.
+
+What is this main value proposition that is not being lost? You still own your
+Urbit ID as a non-fungible token on the Ethereum blockchain. It belongs to you
+forever. This ownership is still just as secure and decentralized as it was on
+layer 1. We consider these principles to be uncompromisable, and maintaining
+these guarantees was totally central in choosing our solution. Furthermore,
+despite the fact that you will probably be relying on a third party roller to
+submit your transactions - no security will be lost. A roller is something like
+an Ethereum node - the worst that they can do is ignore your request, but they
+cannot maliciously alter it.
+
+### Changes to User Experience
+
+Currently, the primary way one manages their Urbit ID, namely performing tasks
+such as transferring ships, setting networking keys, or setting
+[proxies](@/docs/glossary/proxies.md), is with a web interface called
+[Bridge](@/docs/glossary/bridge.md) found at
+[bridge.urbit.org](https://bridge.urbit.org). If you already own a planet,
+you've probably used Bridge before - perhaps only a single time.
+
+Bridge will be getting a facelift to enable easy interfacing with layer 2 -
+along with loud warnings about what is being gained and lost by utilizing
+layer 2. From here, you will be able to transfer your planet to layer 2, and
+once there, perform all the usual actions you can on layer 1. The main
+difference will be an additional choice of roller for your transactions, which
+will primarily determine a time delay on when your transaction will be submitted
+(and potentially an ETH cost, though as we've said, Tlon's will be free).
+
+Every planet has a sponsor star, which distributes [OTA
+updates](@/docs/glossary/ota-updates.md) to their sponsored planets, as well as
+assisting with peer discovery. Both layer 1 and layer 2 planets will be able to
+sponsored by either layer 1 or layer 2 stars. So effectively nothing will change
+in terms of how sponsorship works.
+
+When you buy a planet, any reputable seller will inform you whether or not it is
+on layer 1 or layer 2.
+
+And that's it! If you'd like to know how things will be changing for stars, what
+goes into setting up a roller, and links to technical details, read on.
+
+### Changes to stars {#stars}
+
+Both planets and stars will be able to move to layer 2.
+[Galaxies](@/docs/glossary/galaxy.md) must remain on layer 1 for technical
+reasons, and [moons](@/docs/glossary/moon.md) and
+[comets](@/docs/glossary/comet.md) never interacted with Ethereum anyways, so
+they are completely out of the picture.
+
+Stars will be able to remain on layer 1 if they wish with no action required.
+For star owners that wish to take advantage of the cheaper gas costs, there are
+two possible modes: ownership of the star on layer 2, or setting the
+spawn proxy to layer 2 with ownership remaining on layer 1.
+
+The first mode-a star which is owned on layer 2-has the same advantages and disadvantages as a
+layer 1 planet: cheaper gas costs, at the expense of not being able to interact
+with layer 1 Ethereum smart contracts, potentially slower transaction speed, and
+not being able to return to layer 1 (at least for now). Planets spawned by a
+layer 2 star will also necessarily be on layer 2 - there is no way to spawn a
+layer 1 planet from a layer 2 star, though any planets which had been spawned on
+layer 1 before the star had migrated to layer 2 will remain on layer 1.
+
+The second mode-ownership on layer 1, with spawn proxy on layer 2-is only a
+little more complicated. Such a star will change its networking keys, transfer
+between wallets, and set its management proxy all on layer 1, with the
+corresponding higher gas prices. However, it will be able to spawn planets on
+layer 2-and _only_ on layer 2-with the corresponding cheaper/free gas prices.
+Like moving ownership to layer 2, this will be a one-way journey for now.
+Planets spawned before moving the spawn proxy to layer 2 will remain on layer 1,
+but from then on, all planets spawned by that star will exist on layer 2.
+
+In either scenario, stars will still be able to create [invite
+pools](@using/id/creating-an-invite-pool.md), which will now consist entirely of
+layer 2 planets.
+
+### Creating a roller {#rollers}
+
+![gasprices](https://media.urbit.org/site/posts/essays/gasprices.jpeg)
+
+Rollers are urbit nodes which users submit transactions to to be "rolled up"
+into a bundle to be submitted to the Ethereum blockchain. The business logic for
+a roller runs on the urbit node itself. Thus, anybody with an urbit ship may set
+it up to act as a roller. While the details of how rollers work are still being
+hammered out, one should expect that one can either set transactions to be
+submitted at regular intervals, once a sufficient number of transactions have
+been received (as more transactions means greater savings), manually, or some
+combination of the above.
+
+As mentioned before, Tlon will be maintaining its own roller, but we plan to
+release documentation on how to set up your own concurrently with the release of
+our layer 2 solution. Other rollers may offer shorter waittimes. We expect that
+planet markets may wish to set up their own rollers, and they could also be a
+service offered by a star. You could even utilize your own ship as a roller to
+submit your own single transactions if so desired - we estimate that a single
+transaction submitted on layer 2 will cost about 20% of the gas that it
+currently would on layer 1, so this is not without use.
+
+Malicious rollers could potentially exist, but the worst they ought to be able
+to do is simply not submit your transaction. The security factors for rollers
+are outside of the scope of this post, but will be addressed in future
+documentation on rollers.
+
+(Question: will rollers need to live on L2?)
+
+### Changes to Azimuth
+
+[Azimuth](@/docs/glossary/azimuth.md) are the Ethereum smart contracts governing
+Urbit ID. They will require a few changes to accommodate the new system. Some of
+this has been implicit above, but to be clear, we will only be making a few
+minor alterations:
+ - Once a star's spawn proxy is set to the layer 2 address, it can't be switched
+   back, and they can no longer spawn layer 1 planets.
+ - Galaxies cannot be deposited to layer 2.
+ - When depositing to layer 2, proxies are reset. Some other minor details are
+yet to be worked out, but again, nothing will change for those who wish to
+remain on layer 1.
+
+### Technical details
+
+What's really going on behind the scenes here? The short version of it is that
+rollers will be utilized to perform the smart contract logic that is ordinarily
+performed on Ethereum, and only the final resulting state of the computation
+will be submitted to the Ethereum blockchain. In other words, when you submit
+transactions to a roller, they will be running a "Hoon smart contract" on it,
+and the results of that contract will be put on the Ethereum blockchain. Because
+[Urbit OS](@/docs/glossary/arvo.md) is deterministic, and some of the formal
+properties of Hoon, Hoon turns out to be a great language for writing smart
+contracts.
+
+We want to keep this post brief and non-technical, so that's all we'll say about
+it for now. To find out more, you have a few directions to go on. We held a
+[Developer Call](@/events/developer-call-scaling-azimuth/) where
+`~wicdev-wisryt` outlines the design in much more technical detail, and also
+explains why we decided to utilize our own design rather than other known layer
+2 solutions such as [Optimistic
+rollups](https://docs.ethhub.io/ethereum-roadmap/layer-2-scaling/optimistic_rollups/),
+[ZK-rollups](https://docs.ethhub.io/ethereum-roadmap/layer-2-scaling/zk-rollups/),
+etc, or other blockchains. For those who would rather read, see
+`~wicdev-wisryt`'s [RFC: Naive rollup for cheaper Urbit ID
+transactions](https://groups.google.com/a/urbit.org/g/dev/c/p6rP_WsxLS0/m/hQBX0modAwAJ)
+post on the `urbit-dev` mailing list. Lastly, the primary working branch on
+Github for the Urbit side of naive rollups is
+[here](https://github.com/urbit/urbit/tree/philip/naive), though it is not the
+only place code is accumulating.

--- a/content/blog/rollups.md
+++ b/content/blog/rollups.md
@@ -232,7 +232,7 @@ contracts.
 
 We want to keep this post brief and non-technical, so that's all we'll say about
 it for now. To find out more, you have a few directions to go on. We held a
-[Developer Call](@/events/developer-call-scaling-azimuth/) where
+[Developer Call](@/events/2021-03-04-developer-call-scaling-azimuth.md) where
 `~wicdev-wisryt` outlines the design in much more technical detail, and also
 explains why we decided to utilize our own design rather than other known layer
 2 solutions such as [Optimistic

--- a/content/faq.md
+++ b/content/faq.md
@@ -45,6 +45,8 @@ Planets are intended for everyday use by individuals, and there are 4.3 billion 
 
 ### Why is is currently expensive to acquire a planet? {#gas-prices}
 
+For the latest on this topic, see our recent blog post: [The Gang Solves the Gas Crisis](@/blog/rollups.md).
+
 As of early 2021, if you try to acquire a planet from a market, you will likely encounter an enormous "gas price" fee. Ethereum is going through some growing pains, and this is an issue for every
 smart contract on the network. This fee is unrelated to Urbit specifically, rather it results from how Ethereum transactions are paid for. The gas fee does not go to the person selling you the planet, nor to the market, nor to anybody associated with Urbit - it goes to the "miners" processing all Ethereum transactions.
 


### PR DESCRIPTION
Draft of a blog post on the current state of naive rollups. I attempted to write
for the least technical audience, aimed primarily on end user experience, with
links to the more technical stuff we've put out at the end.

The included image and title are provisionary. I couldn't help myself, IASIP is
my favorite show. Still needs a few more images.

Hope to get feedback from the infra/docs/L2 meetings next week, do some edits,
and publish late next week.