### PR TITLE
life and rift alterations

### DIFF
--- a/content/using/id/guide-to-breaches.md
+++ b/content/using/id/guide-to-breaches.md
@@ -6,27 +6,32 @@ template = "doc.html"
 
 An important concept on the [Ames](@/docs/arvo/ames/ames.md) network is that of continuity. Continuity refers to how ships remember the order of their own network messages and the network messages of others -- these messages are numbered, starting from zero. A _breach_ is when ships on the network agree to forget about this sequence and treat one or more ships like they are brand new.
 
-There are two kinds of breaches: **personal breaches** and **network breaches**.
+There are two kinds of breaches: (personal) **breaches** and **network breaches**.
 
-## Personal Breaches
+## Breaches
 
-Ships on the Ames network sometimes need to reset their continuity. A personal breach is when an individual ship announces to the network: "I forgot who I am, let's start over from scratch." That is, it clears its own event log and sends an announcement to the network, asking all ships that have communicated with it to reset its networking information in their state. This makes it as though the ship was just started for the first time again, since everyone on the network has forgotten about it.
+Ships on the Ames network sometimes need to reset their continuity. A breach is
+when an individual ship announces to the network: "I forgot who I am, let's
+start over from scratch." That is, it clears its own event log and sends an
+announcement to the network, asking all ships that have communicated with it to
+reset its networking information in their state. This makes it as though the
+ship was just started for the first time again, since everyone on the network
+has forgotten about it.
 
-Personal breaches often fix connectivity issues, but should only be used as a
-last resort. Before performing a personal breach, look at alternative fixes in
-the [Ship Troubleshooting](../ship-troubleshooting) guide. Also reach out for
-help in the Help channel in the Urbit Community group
-`~bitbet-bolbel/urbit-community`, or, failing that, in the
-`#ship-starting-support` channel in our [Discord
+Breaches often fix connectivity issues, but should only be used as a last
+resort. Before performing a breach, look at alternative fixes in the [Ship
+Troubleshooting](../ship-troubleshooting) guide. Also reach out for help in the
+Help channel in the Urbit Community group `~bitbet-bolbel/urbit-community`, or,
+failing that, in the `#ship-starting-support` channel in our [Discord
 server](https://discord.gg/n9xhMdz) to see if there is another option.
 
-There are two types of personal breaches - one where your Ethereum ownership address
+There are two types of breaches - one where your Ethereum ownership address
 remains the same, and one where you are switching to a new Ethereum ownership
-address. We make the emphasis about the Ethereum _ownership_ address as
-changing your [proxies](@/docs/glossary/proxies.md) does not require a breach.
+address. We make the emphasis about the Ethereum _ownership_ address as changing
+your [proxies](@/docs/glossary/proxies.md) does not require a breach.
 
 If you will be keeping the same Ethereum ownership address and would like to perform a
-personal breach, follow the steps below.
+breach, follow the steps below.
 
 - Go to [bridge.urbit.org](https://bridge.urbit.org) and log into your identity.
 - Click on `OS: Urbit OS Settings` at the bottom, then click `Reset Networking Keys`.
@@ -63,13 +68,13 @@ you are transferring to another address you own. The process here is slightly di
 
 ## Network Breaches
 
-A network breach is an event where all ships on the network are required to
-update to a new continuity era. Network breaches happen when an Arvo update is
-released that is too large to release over the air. The current continuity era
-is given by an integer in Ames, our networking vane, that is incremented when a
-network breaches; only ships with the same such value are able to communicate
-with one another. The most recent network breach occurred in December 2020, and
-we expect it to be the final one.
+Network breaches were events where all ships on the network were required to
+update to a new continuity era. Network breaches happened when an Arvo update
+was released that could not be implemented via an [OTA
+update](@/docs/glossary/ota-updates.md). The continuity era is given by an
+integer in Ames that is incremented when the network breaches. Only ships with
+the same such value are able to communicate with one another. The most recent
+network breach occurred in December 2020, and we expect it to be the final one.
 
 If another network breach does occur, we will provide accompanying documentation
 on what to do to transfer your ship and all of its data to the new era.

--- a/content/using/id/guide-to-breaches.md
+++ b/content/using/id/guide-to-breaches.md
@@ -24,14 +24,18 @@ Troubleshooting](../ship-troubleshooting) guide. Also reach out for help in the
 Help channel in the Urbit Community group `~bitbet-bolbel/urbit-community`, or,
 failing that, in the `#ship-starting-support` channel in our [Discord
 server](https://discord.gg/n9xhMdz) to see if there is another option.
+Connectivity issues are typically related to a bug, and you may be able to help
+us fix it by emailing us at `support@urbit.org`.
 
-There are two types of breaches - one where your Ethereum ownership address
-remains the same, and one where you are switching to a new Ethereum ownership
-address. We make the emphasis about the Ethereum _ownership_ address as changing
-your [proxies](@/docs/glossary/proxies.md) does not require a breach.
+There are two separate sequences of actions you need to take in order to breach.
+One flow is for when you wish to keep Ethereum ownership address of the ship the
+same, and the other is for when you are transferring the ship to a new Ethereum
+ownership address. We make the emphasis about the Ethereum _ownership_ address
+as changing your [proxies](@/docs/glossary/proxies.md) does not require a
+breach.
 
-If you will be keeping the same Ethereum ownership address and would like to perform a
-breach, follow the steps below.
+If you will be keeping your ship at the same Ethereum ownership address and
+would like to perform a breach, follow the steps below.
 
 - Go to [bridge.urbit.org](https://bridge.urbit.org) and log into your identity.
 - Click on `OS: Urbit OS Settings` at the bottom, then click `Reset Networking Keys`.
@@ -43,7 +47,7 @@ breach, follow the steps below.
 - Delete your keyfile after successfully booting.
 - Rejoin your favorite chat channels and subscriptions.
 
-If you are switching to a new Ethereum ownership address you will have the
+If you are transferring a ship to a new Ethereum ownership address you will have the
 choice as to whether or not you want to breach. This is to cover the case when
 you are transferring to another address you own. The process here is slightly different.
 
@@ -74,7 +78,7 @@ was released that could not be implemented via an [OTA
 update](@/docs/glossary/ota-updates.md). The continuity era is given by an
 integer in Ames that is incremented when the network breaches. Only ships with
 the same such value are able to communicate with one another. The most recent
-network breach occurred in December 2020, and we expect it to be the final one.
+network breach occurred in December 2020, and we expect it to have been the final one.
 
 If another network breach does occur, we will provide accompanying documentation
 on what to do to transfer your ship and all of its data to the new era.

--- a/content/using/id/guide-to-breaches.md
+++ b/content/using/id/guide-to-breaches.md
@@ -61,30 +61,15 @@ you are transferring to another address you own. The process here is slightly di
 - Delete your keyfile after successfully booting.
 - Rejoin your favorite chat channels and subscriptions.
 
-Performing a personal breach on your ship increments an integer value called
-your ship's _life_ by one, which refers to your ship's [Azimuth](@/docs/azimuth/azimuth.md) _key
-revision number_. This value is utilized by
-Ames and Jael to ensure that you are
-communicating with a ship created using its most recent set of keys. Your
-ship's life is written at the end of the name of its keyfile, e.g.
-`sampel-palnet-4.key`. Changing the Etherum address that holds the Urbit ID,
-called _reticketing_, increments a number called the ship's _rift_ by one in
-addition to incrementing your ship's life.
-Rift refers to your ship's Azimuth _continuity number_.
-
-You can check your current life and rift number by running the
-`+keys our` generator in Dojo. You can inspect another ship's life and rift can be checked by
-running `+keys ~sampel-palnet`.
-
-
 ## Network Breaches
 
-A network breach is an event where all ships on the network are required to update to a new continuity era. Network breaches happen when an Arvo update is released that is too large to release over the air. The current continuity era is given by a value in Ames, our networking vane, that is incremented when a network breaches; only ships with the same such value are able to communicate with one another.
+A network breach is an event where all ships on the network are required to
+update to a new continuity era. Network breaches happen when an Arvo update is
+released that is too large to release over the air. The current continuity era
+is given by an integer in Ames, our networking vane, that is incremented when a
+network breaches; only ships with the same such value are able to communicate
+with one another. The most recent network breach occurred in December 2020, and
+we expect it to be the final one.
 
-If a network breach is happening, follow the steps below.
-
-- Delete your old Urbit binary.
-- Delete or archive your old pier.
-- Download the new Urbit binary by following the instructions in the [Install page](@/getting-started/_index.md).
-- Create a new pier by booting your ship with your key, according to the instructions on the install page. (Note: You do _not_ need to use a new key to boot into a new continuity era.)
-- Rejoin your favorite chat channels and subscriptions.
+If another network breach does occur, we will provide accompanying documentation
+on what to do to transfer your ship and all of its data to the new era.

--- a/content/using/os/getting-started.md
+++ b/content/using/os/getting-started.md
@@ -216,7 +216,7 @@ When this happens, back up any files you'd like to save, shut down your urbit, a
 
 You can check your ship's _life_ and _rift_ number by running `+keys our` in
 dojo. You can inspect another ship's life and rift number by running `+keys
-~sampel-palnet`. For information on what life and rift are, see [Guide to Breaches](@/using/id/guide-to-breaches.md).
+~sampel-palnet`. For information on what life and rift are, see [Life and Rift](@/docs/azimuth/life-and-rift.md).
 
 ## DNS proxying {#dns-proxying}
 


### PR DESCRIPTION
Addresses https://github.com/urbit/docs/issues/980

Related to https://github.com/urbit/docs/pull/1074 and it should be merged before this PR

This removes mention of life and rift from the guide to breaches. These are technical terms that I don't think the average user needs to know, and the using guide is supposed to be for the average user.

How to check a ship's life and rift is mentioned on the getting started guide, which I think is fine, but I've redirected the link in it from the guide to breaches to the new page on life and rift I've written.