### PR TITLE
Fix eyre docs

### DIFF
--- a/content/docs/arvo/eyre/_index.md
+++ b/content/docs/arvo/eyre/_index.md
@@ -14,18 +14,18 @@ An overview of Eyre and its capabilities.
 
 Details of Eyre's external API including the channel system's JSON API.
 
-## [Internal API Reference](@/docs/arvo/eyre/tasks.md)
+## [Internal API Reference](/docs/arvo/eyre/tasks)
 
 The `task`s Eyre takes and the `gift`s it returns.
 
-## [Scry Reference](@/docs/arvo/eyre/scry.md)
+## [Scry Reference](/docs/arvo/eyre/scry)
 
 The scry endpoints of Eyre.
 
-## [Data Types](@/docs/arvo/eyre/data-types.md)
+## [Data Types](/docs/arvo/eyre/data-types)
 
 Reference documentation of the various data types used by Eyre.
 
-## [Examples](@/docs/arvo/eyre/examples.md)
+## [Examples](/docs/arvo/eyre/examples)
 
 Practical examples of the different ways of using Eyre.

--- a/content/docs/arvo/eyre/data-types.md
+++ b/content/docs/arvo/eyre/data-types.md
@@ -4,16 +4,15 @@ weight = 5
 template = "doc.html"
 +++
 
-# Introduction
-
 This document describes the data types used by Eyre as defined in `/sys/lull.hoon`. It's separated into two sections:
 
-- [Eyre](#eyre) - Eyre-specific data types.
-- [HTTP](#http) - HTTP data types shared between Eyre and Iris.
+[Eyre](#eyre) - Eyre-specific data types.
 
-# Eyre
+[HTTP](#http) - HTTP data types shared between Eyre and Iris.
 
-## `$origin`
+## Eyre
+
+### `$origin`
 
 ```hoon
 +$  origin  @torigin
@@ -21,7 +20,7 @@ This document describes the data types used by Eyre as defined in `/sys/lull.hoo
 
 A single CORS origin as used in an HTTP Origin header and the [$cors-registry](#cors-registry).
 
-## `$cors-registry`
+### `$cors-registry`
 
 ```hoon
 +$  cors-registry
@@ -33,7 +32,7 @@ A single CORS origin as used in an HTTP Origin header and the [$cors-registry](#
 
 CORS origins categorised by approval status. The `requests` `set` contains all [$origin](#origin)s Eyre has received in the headers of HTTP requests that have not been explicitly approved or rejected. The `approved` and `rejected` `set`s are those that have been explicitly approved or rejected.
 
-## `$outstanding-connection`
+### `$outstanding-connection`
 
 ```hoon
 +$  outstanding-connection
@@ -46,7 +45,7 @@ CORS origins categorised by approval status. The `requests` `set` contains all [
 
 An HTTP connection that is currently open. The [$action](#action) is how it's being handled (e.g. by a Gall app, the channel system, etc). The [$inbound-request](#inbound-request) is the original request which opened the connection. The `response-header` contains the status code and headers. The `bytes-sent` is the total bytes sent so far in response.
 
-## `$authentication-state`
+### `$authentication-state`
 
 ```hoon
 +$  authentication-state  sessions=(map @uv session)
@@ -54,7 +53,7 @@ An HTTP connection that is currently open. The [$action](#action) is how it's be
 
 This represents the authentication state of all sessions. It maps session cookies (without the `urbauth-<ship>=` prefix) to [$session](#session)s.
 
-## `$session`
+### `$session`
 
 ```hoon
 +$  session
@@ -65,7 +64,7 @@ This represents the authentication state of all sessions. It maps session cookie
 
 This represents server-side data about a session. The `expiry-time` is when the `session` expires and `channels` is the `set` of [$channel](#channel) names opened by the session.
 
-## `$channel-state`
+### `$channel-state`
 
 ```hoon
 +$  channel-state
@@ -76,7 +75,7 @@ This represents server-side data about a session. The `expiry-time` is when the 
 
 The state used by the channel system. The `session` is a `map` between channel names and [$channel](#channel)s and the `duct-to-key` `map`s `duct`s to `channel` names.
 
-## `$timer`
+### `$timer`
 
 ```hoon
 +$  timer
@@ -87,7 +86,7 @@ The state used by the channel system. The `session` is a `map` between channel n
 
 A reference to a timer so it can be cancelled or updated. The `date` is when it will fire and the `duct` is what set the timer.
 
-## `$channel-event`
+### `$channel-event`
 
 ```hoon
 +$  channel-event
@@ -100,7 +99,7 @@ A reference to a timer so it can be cancelled or updated. The `date` is when it 
 
 An unacknowledged event in the channel system.
 
-## `$channel`
+### `$channel`
 
 ```hoon
 +$  channel
@@ -116,7 +115,7 @@ An unacknowledged event in the channel system.
 
 This is the state of a particular channel in the channel system. The `state` is either the expiration time or the duct currently listening. The `next-id` is the next event ID to be used in the event stream. The `last-ack` is the date of the last client ack and is used for clog calculations in combination with `unacked`. The `events` queue contains all unacked events - `id` is the server-set event ID, `request-id` is the client-set request ID and the [$channel-event](#channel-event) is the event itself. The `unacked` `map` contains the unacked event count per `request-id` and is used for clog calculations. The `subscriptions` `map` contains gall subscriptions by `request-id`. The `heartbeat` is the SSE heartbeat [$timer](#timer).
 
-## `$binding`
+### `$binding`
 
 ```hoon
 +$  binding
@@ -127,7 +126,7 @@ This is the state of a particular channel in the channel system. The `state` is 
 
 A `binding` is a rule to match a URL `path` and optional `site` domain which can then be tied to an [$action](#action). A `path` of `/foo` will also match `/foo/bar`, `/foo/bar/baz`, etc. If the `site` is `~` it will be determined implicitly. A binding must be unique.
 
-## `$action`
+### `$action`
 
 ```hoon
 +$  action
@@ -143,7 +142,7 @@ A `binding` is a rule to match a URL `path` and optional `site` domain which can
 
 The action to take when a [$binding](#binding) matches an incoming HTTP request.
 
-## `$generator`
+### `$generator`
 
 ```hoon
 +$  generator
@@ -155,7 +154,7 @@ The action to take when a [$binding](#binding) matches an incoming HTTP request.
 
 This refers to a generator on a local ship that can handle requests. Note that serving generators via Eyre is not fully implmented and should not be used.
 
-## `$http-config`
+### `$http-config`
 
 ```hoon
 +$  http-config
@@ -168,7 +167,7 @@ This refers to a generator on a local ship that can handle requests. Note that s
 
 The configuration of the runtime HTTP server itself. The `secure` field contains the PEM-encoded RSA private key and certificate or certificate chain when using HTTPS, and otherwise is `~` when using plain HTTP. The `proxy` field is not currently used. The `log` field turns on HTTP(S) access logs but is not currently implemented. The `redirect` field turns on 301 redirects to upgrade HTTP to HTTPS if the `key` and `cert` are set in `secure`.
 
-## `$http-rule`
+### `$http-rule`
 
 ```hoon
 +$  http-rule
@@ -179,7 +178,7 @@ The configuration of the runtime HTTP server itself. The `secure` field contains
 
 This is for updating the server configuration. In the case of `%cert`, a `cert` of `~` clears the HTTPS cert & key, otherwise `cert` contains the PEM-encoded RSA private key and certificate or certificate chain. In the case of `%turf`, a `%put` `action` sets a domain name and a `%del` `action` removes it. The [$turf](#turf) contains the domain name.
 
-## `$address`
+### `$address`
 
 ```hoon
 +$  address
@@ -190,7 +189,7 @@ This is for updating the server configuration. In the case of `%cert`, a `cert` 
 
 A client IP address.
 
-## `$inbound-request`
+### `$inbound-request`
 
 ```hoon
 +$  inbound-request
@@ -201,11 +200,11 @@ A client IP address.
   ==
 ```
 
-An inbound HTTP request and metadata. The `authenticated` field says whether the request was made with a valid session cookie. The `secure` field says whether it was made with HTTPS. The [$address](#address) is the IP address from which the request originated, except if it came from localhost and included a `Forwarded` header, in which case it's the address specified in that header. The [$request:http](#request-http) contains the HTTP request itself.
+An inbound HTTP request and metadata. The `authenticated` field says whether the request was made with a valid session cookie. The `secure` field says whether it was made with HTTPS. The [$address](#address) is the IP address from which the request originated, except if it came from localhost and included a `Forwarded` header, in which case it's the address specified in that header. The [$request:http](#requesthttp) contains the HTTP request itself.
 
-# HTTP
+## HTTP
 
-## `$header-list:http`
+### `$header-list:http`
 
 ```hoon
 +$  header-list  (list [key=@t value=@t])
@@ -213,7 +212,7 @@ An inbound HTTP request and metadata. The `authenticated` field says whether the
 
 An ordered list of HTTP headers. The `key` is the header name e.g `'Content-Type'` and the `value` is the value e.g. `text/html`.
 
-## `$method:http`
+### `$method:http`
 
 ```hoon
 +$  method
@@ -230,7 +229,7 @@ An ordered list of HTTP headers. The `key` is the header name e.g `'Content-Type
 
 An HTTP method.
 
-## `$request:http`
+### `$request:http`
 
 ```hoon
 +$  request
@@ -241,9 +240,9 @@ An HTTP method.
   ==
 ```
 
-A single HTTP request. The [$method:http](#method-http) is the HTTP method, the `url` is the unescaped URL, the [$header-list:http](#header-list-http) contains the HTTP headers of the request and the `body` is the actual data. An `octs` is just `[p=@ud q=@]` where `p` is the byte-length of `q`, the data.
+A single HTTP request. The [$method:http](#methodhttp) is the HTTP method, the `url` is the unescaped URL, the [$header-list:http](#header-listhttp) contains the HTTP headers of the request and the `body` is the actual data. An `octs` is just `[p=@ud q=@]` where `p` is the byte-length of `q`, the data.
 
-## `$response-header:http`
+### `$response-header:http`
 
 ```hoon
 +$  response-header
@@ -252,9 +251,9 @@ A single HTTP request. The [$method:http](#method-http) is the HTTP method, the 
   ==
 ```
 
-The status code and [$header-list:http](#header-list-http) of an HTTP response.
+The status code and [$header-list:http](#header-listhttp) of an HTTP response.
 
-## `$http-event:http`
+### `$http-event:http`
 
 ```hoon
 +$  http-event
@@ -277,7 +276,7 @@ Urbit treats Earth's HTTP servers as pipes, where Urbit sends or receives one or
 
 Calculation of control headers such as `'Content-Length'` or `'Transfer-Encoding'` should be performed at a higher level; this structure is merely for what gets sent to or received from Earth.
 
-## `$simple-payload:http`
+### `$simple-payload:http`
 
 ```hoon
 +$  simple-payload
@@ -287,4 +286,4 @@ Calculation of control headers such as `'Content-Length'` or `'Transfer-Encoding
 --
 ```
 
-A simple, one-event response used for generators. The [$reponse-header:http](#response-header-http) contains the status code and HTTP headers. The `octs` in the `data` contains the body of the response and is a `[p=@ud q=@]` where `p` is the byte-length of `q`, the data.
+A simple, one-event response used for generators. The [$reponse-header:http](#response-headerhttp) contains the status code and HTTP headers. The `octs` in the `data` contains the body of the response and is a `[p=@ud q=@]` where `p` is the byte-length of `q`, the data.

--- a/content/docs/arvo/eyre/data-types.md
+++ b/content/docs/arvo/eyre/data-types.md
@@ -51,7 +51,7 @@ An HTTP connection that is currently open. The [$action](#action) is how it's be
 +$  authentication-state  sessions=(map @uv session)
 ```
 
-This represents the authentication state of all sessions. It maps session cookies (without the `urbauth-<ship>=` prefix) to [$session](#session)s.
+This represents the authentication state of all sessions. It maps session cookies (without the `urbauth-{SHIP}=` prefix) to [$session](#session)s.
 
 ### `$session`
 

--- a/content/docs/arvo/eyre/examples.md
+++ b/content/docs/arvo/eyre/examples.md
@@ -4,29 +4,17 @@ weight = 6
 template = "doc.html"
 +++
 
-# Contents
-
-- [Introduction](#introduction)
-- [Authenticating](#authenticating)
-- [Using the Channel System](#using-the-channel-system)
-- [Scrying](#scrying)
-- [Direct HTTP Handling With Gall Agents](#direct-http-handling-with-gall-agents)
-- [Generators](#generators)
-- [Managing CORS Origins](#managing-cors-origins)
-
-# Introduction
-
 This documents contains practical examples of the various ways of interacting with Eyre.
 
-General documentation of the `task`s and methods described here are available in the [External API Reference](@/docs/arvo/eyre/external-api-ref.md) document and the [Internal API Reference](@/docs/arvo/eyre/tasks.md) document.
+General documentation of the `task`s and methods described here are available in the [External API Reference](/docs/arvo/eyre/external-api-ref) document and the [Internal API Reference](/docs/arvo/eyre/tasks) document.
 
-# Authenticating
+## Authenticating
 
-In most cases we must obtain a valid session cookie by [authenticating](@/docs/arvo/eyre/external-api-ref.md#authentication) with our web login code (which can be obtained by running `+code` in the dojo) before we can use Eyre's interfaces (such as the channel system or scry interface).
+In most cases we must obtain a valid session cookie by [authenticating](/docs/arvo/eyre/external-api-ref#authentication) with our web login code (which can be obtained by running `+code` in the dojo) before we can use Eyre's interfaces (such as the channel system or scry interface).
 
 Here we'll try authenticating with the default fakezod code.
 
-Using `curl` in the unix terminal, we'll make an HTTP POST request with `"password=<code>"` in the body:
+Using `curl` in the unix terminal, we'll make an HTTP POST request with `"password=CODE"` in the body:
 
 ```
 curl -i localhost:8080/~/login -X POST -d "password=lidlut-tabwed-pillex-ridrup"
@@ -44,9 +32,9 @@ set-cookie: urbauth-~zod=0v3.j2062.1prp1.qne4e.goq3h.ksudm; Path=/; Max-Age=6048
 
 The `urbauth-....` cookie can be now be included in subsequent requests (e.g. to the channel system) by providing it in a Cookie HTTP header.
 
-# Using The Channel System
+## Using The Channel System
 
-Here we'll look at a practical example of Eyre's channel system. You can refer to the [Channels](@/docs/arvo/eyre/external-api-ref.md#channels) section of the [External API Reference](@/docs/arvo/eyre/external-api-ref.md) document for relevant details.
+Here we'll look at a practical example of Eyre's channel system. You can refer to the [Channels](/docs/arvo/eyre/external-api-ref#channels) section of the [External API Reference](/docs/arvo/eyre/external-api-ref) document for relevant details.
 
 First, we must obtain a session cookie by [authenticating](#authenticating). You will be copying the entry of the `set-cookie` field into the `--cookie` field in subsequent commands.
 
@@ -54,7 +42,7 @@ Now that we have our cookie, we can try poking an app & simultaneously opening a
 
 We'll do this with an HTTP PUT request, and we'll include the cookie we obtained when we authenticated in the `Cookie` header. The URL path we'll make the request to will be `http://localhost:8080/~/channel/mychannel`. The last part of the path is the channel `UID` - the name for our new channel. Normally you'd use the current unix time plus a hash to ensure uniqueness, but in this case we'll just use `mychannel` for simplicity.
 
-The data will be a JSON array containing a [poke](@/docs/arvo/eyre/external-api-ref.md#poke) `action`:
+The data will be a JSON array containing a [poke](/docs/arvo/eyre/external-api-ref#poke) `action`:
 
 ```
 curl --header "Content-Type: application/json" \
@@ -76,7 +64,7 @@ Now we can connect to the `mychannel` channel we opened. We do this with an HTTP
 curl -i --cookie "urbauth-~zod=0v3.j2062.1prp1.qne4e.goq3h.ksudm" http://localhost:8080/~/channel/my-channel
 ```
 
-Eyre will respond with an HTTP status code of 200 and a `content-type` of `text/event-stream`, indicating an SSE (Server Sent Event) stream. It will also send us any pending events on the channel - in this case the poke ack as a [poke](@/docs/arvo/eyre/external-api-ref.md#poke-ack) `response` for our original poke:
+Eyre will respond with an HTTP status code of 200 and a `content-type` of `text/event-stream`, indicating an SSE (Server Sent Event) stream. It will also send us any pending events on the channel - in this case the poke ack as a [poke](/docs/arvo/eyre/external-api-ref#poke-ack) `response` for our original poke:
 
 ```
 HTTP/1.1 200 ok
@@ -97,7 +85,7 @@ Normally this event stream would be handled by an EventSource object or similar 
 
 Leaving the event stream connection open, in another shell session on unix we'll try subscribing to the watch path of a Gall agent - the `/updates` watch path of `graph-store` in this case.
 
-We'll do this in the same way as the initial poke, except this time it will be a [subscribe](@/docs/arvo/eyre/external-api-ref.md#subscribe) `action`:
+We'll do this in the same way as the initial poke, except this time it will be a [subscribe](/docs/arvo/eyre/external-api-ref#subscribe) `action`:
 
 ```
 curl --header "Content-Type: application/json" \
@@ -109,21 +97,21 @@ curl --header "Content-Type: application/json" \
 
 Notice we've incremented the `id` to `2`. Eyre doesn't require IDs to be sequential, merely numerical and unique, but sequential IDs are typically the most practical.
 
-Back in the event stream, we'll see a positive watch ack as a [subscribe](@/docs/arvo/eyre/external-api-ref.md#watch-ack) `response`, meaning the subscription has been successful:
+Back in the event stream, we'll see a positive watch ack as a [subscribe](/docs/arvo/eyre/external-api-ref#watch-ack) `response`, meaning the subscription has been successful:
 
 ```
 id: 1
 data: {"ok":"ok","id":2,"response":"subscribe"}
 ```
 
-Now we'll try trigger an event on our event stream. In fakezod's Landscape, create a new chat channel named "test". You should see the `add-graph` `graph-update` come through on our channel in a [diff](@/docs/arvo/eyre/external-api-ref.md#diff) `response`:
+Now we'll try trigger an event on our event stream. In fakezod's Landscape, create a new chat channel named "test". You should see the `add-graph` `graph-update` come through on our channel in a [diff](/docs/arvo/eyre/external-api-ref#diff) `response`:
 
 ```
 id: 2
 data: {"json":{"graph-update":{"add-graph":{"graph":{},"resource":{"name":"test-1183","ship":"zod"},"mark":"graph-validator-chat","overwrite":false}}},"id":2,"response":"diff"}
 ```
 
-All events we receive must be `ack`ed so Eyre knows we've successfully received them. To do this we'll send an [ack](@/docs/arvo/eyre/external-api-ref.md#ack) `action` which specifies the `event-id` of the event in question - `2` in this case:
+All events we receive must be `ack`ed so Eyre knows we've successfully received them. To do this we'll send an [ack](/docs/arvo/eyre/external-api-ref#ack) `action` which specifies the `event-id` of the event in question - `2` in this case:
 
 ```
 curl --header "Content-Type: application/json" \
@@ -135,7 +123,7 @@ curl --header "Content-Type: application/json" \
 
 This same pattern would be repeated for all subsequent events. Note that when you `ack` one event, you also implicitly `ack` all previous events, so in this case event `1` will also be `ack`ed.
 
-When we're finished, we can unsubscribe from `graph-store` `/update`. We do this by sending Eyre a [unsubscribe](@/docs/arvo/eyre/external-api-ref.md#unsubscribe) `action`, and specify the request ID of the original `subscribe` `action` in the `subscription` field - `2` in our case:
+When we're finished, we can unsubscribe from `graph-store` `/update`. We do this by sending Eyre a [unsubscribe](/docs/arvo/eyre/external-api-ref#unsubscribe) `action`, and specify the request ID of the original `subscribe` `action` in the `subscription` field - `2` in our case:
 
 ```
 curl --header "Content-Type: application/json" \
@@ -147,7 +135,7 @@ curl --header "Content-Type: application/json" \
 
 Unlike `poke` and `subscribe` actions, Eyre doesn't acknowledge `unsubscribe`s, but we'll now have stopped receiving updates from `graph-store`.
 
-Finally, let's close the channel itself. We can do this simply by sending Eyre a [delete](@/docs/arvo/eyre/external-api-ref.md#delete-channel) `action`:
+Finally, let's close the channel itself. We can do this simply by sending Eyre a [delete](/docs/arvo/eyre/external-api-ref#delete-channel) `action`:
 
 ```
 curl --header "Content-Type: application/json" \
@@ -159,9 +147,9 @@ curl --header "Content-Type: application/json" \
 
 With our channel deleted, we can now close the connection on the client side.
 
-# Scrying
+## Scrying
 
-Here we'll look at performing scries through Eyre. You can refer to the [Scry](@/docs/arvo/eyre/external-api-ref.md#scry) section of the [External API Reference](@/docs/arvo/eyre/external-api-ref.md) document for relevant details.
+Here we'll look at performing scries through Eyre. You can refer to the [Scry](/docs/arvo/eyre/external-api-ref#scry) section of the [External API Reference](/docs/arvo/eyre/external-api-ref) document for relevant details.
 
 First we must obtain a session cookie by [authenticating](#authenticating).
 
@@ -213,13 +201,13 @@ content-type: text/html
 <html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>There was an error while handling the request for /foo/bar/baz.json.</p><code>no scry result</code></body></html>
 ```
 
-# Direct HTTP Handling With Gall Agents
+## Direct HTTP Handling With Gall Agents
 
 In many cases you'll just want to interact with Gall agents through the JSON API of the channel system, but it's also possible to bypass all that and just deal with HTTP requests directly. Here we'll take a look at how that practically works.
 
-You can refer to the [%connect](@/docs/arvo/eyre/tasks.md#connect) section of the [Internal API Reference](@/docs/arvo/eyre/tasks.md) document for relevant details.
+You can refer to the [%connect](/docs/arvo/eyre/tasks#connect) section of the [Internal API Reference](/docs/arvo/eyre/tasks) document for relevant details.
 
-Here's a Gall agent that demonstrates this method. It binds the URL path `/foo`, serves `<h1>Hello, World!</h1>` for GET requests and a `405` error for all others. It also prints debug information to the terminal as various things happen.
+Here's a Gall agent that demonstrates this method. It binds the URL path `/foo`, serves `Hello, World!` for GET requests and a `405` error for all others. It also prints debug information to the terminal as various things happen.
 
 Note that this example does a lot of things manually for demonstrative purposes. In practice you'd likely want to use a library like `/lib/server.hoon` to cut down on boilerplate code.
 
@@ -336,7 +324,7 @@ activated app home/eyre-agent
 [unlinked from [p=~zod q=%eyre-agent]]
 ```
 
-Now, first we need to bind a URL to our app. In the `++ on-poke` arm, our agent will send a [%connect](@/docs/arvo/eyre/tasks.md#connect) `task` to Eyre when poked with `%bind`:
+Now, first we need to bind a URL to our app. In the `++ on-poke` arm, our agent will send a [%connect](/docs/arvo/eyre/tasks#connect) `task` to Eyre when poked with `%bind`:
 
 ```hoon
   %noun
@@ -436,11 +424,11 @@ Eyre subscribed to /http-response/~.eyre_0v3.1knjk.l544e.5uds6.fn9l2.f8929.
 
 This is a very rudimentary app but it demonstrates the basic mechanics of dealing with HTTP requests and serving responses.
 
-# Generators
+## Generators
 
 Here we'll look at running a generator via Eyre. Eyre doesn't have a mediated JSON API for generators, instead it just passes through the HTTP request and returns the HTTP response composed by the generator.
 
-You can refer to the [%serve](@/docs/arvo/eyre/tasks.md#serve) section of the [Internal API Reference](@/docs/arvo/eyre/tasks.md) document for relevant details.
+You can refer to the [%serve](/docs/arvo/eyre/tasks#serve) section of the [Internal API Reference](/docs/arvo/eyre/tasks) document for relevant details.
 
 Here's a very simple generator that will just echo back the body of the request (if available) along with the current datetime. You can save it in the `/gen` directory and `|commit %home`.
 
@@ -475,7 +463,7 @@ The sample of the second nested gate must be:
 [authenticated=? =request:http]
 ```
 
-The return type of the generator must be [simple-payload:http](@/docs/arvo/eyre/data-types.md#simple-payload-http). If you look at our example generator you'll see it meets these requirements.
+The return type of the generator must be [$simple-payload:http](/docs/arvo/eyre/data-types#simple-payloadhttp). If you look at our example generator you'll see it meets these requirements.
 
 Because generators return the entire HTTP message as a single `simple-payload`, Eyre can calculate the `content-length` itself and automatically add the header.
 
@@ -485,7 +473,7 @@ In order to make our generator available, we must bind it to a URL path. To do t
 [%serve =binding =generator]
 ```
 
-The [binding](@/docs/arvo/eyre/data-types.md#binding) specifies the site and URL path, and the [generator](@/docs/arvo/eyre/data-types.md#generator) specifies the `desk`, the `path` to the generator, and arguments. Note that the passing of arguments to the generator by Eyre is not currently implemented, so you can just leave that as `~` since it won't do anything.
+The [$binding](/docs/arvo/eyre/data-types#binding) specifies the site and URL path, and the [$generator](/docs/arvo/eyre/data-types#generator) specifies the `desk`, the `path` to the generator, and arguments. Note that the passing of arguments to the generator by Eyre is not currently implemented, so you can just leave that as `~` since it won't do anything.
 
 Let's bind our generator to the `/mygen` URL path with the `|pass` command in the dojo:
 
@@ -516,9 +504,9 @@ Content-Length: 41
 blah blah blah
 ```
 
-# Managing CORS Origins
+## Managing CORS Origins
 
-Here we'll look at approving and rejecting a CORS origin by passing Clay a [%approve-origin](@/docs/arvo/eyre/tasks.md#approve-origin) `task` and [%reject-origin](@/docs/arvo/eyre/tasks.md#reject-origin) `task` respectively.
+Here we'll look at approving and rejecting a CORS origin by passing Clay a [%approve-origin](/docs/arvo/eyre/tasks#approve-origin) `task` and [%reject-origin](/docs/arvo/eyre/tasks#reject-origin) `task` respectively.
 
 In this example we'll use more manual methods for demonstrative purposes but note there are also the `|cors-approve` and `|cors-reject` generators to approve/reject origins from the dojo, and the `+cors-registry` generator for viewing the CORS configuration.
 
@@ -528,7 +516,7 @@ First, using `|pass` in the dojo, let's approve the origin `http://foo.example` 
 |pass [%e [%approve-origin 'http://foo.example']]
 ```
 
-Now if we scry for the [approved](@/docs/arvo/eyre/scry.md#cors-approved) CORS `set`:
+Now if we scry for the [approved](/docs/arvo/eyre/scry#cors-approved) CORS `set`:
 
 ```
 > .^(approved=(set @t) %ex /=//=/cors/approved)
@@ -566,7 +554,7 @@ Now we'll try rejecting an `origin`. Back in the dojo, let's `|pass` Eyre a `%re
 |pass [%e [%reject-origin 'http://bar.example']]
 ```
 
-If we scry for the [rejected](@/docs/arvo/eyre/scry.md#cors-rejected) CORS `set`:
+If we scry for the [rejected](/docs/arvo/eyre/scry#cors-rejected) CORS `set`:
 
 ```
 > .^(rejected=(set @t) %ex /=//=/cors/rejected)
@@ -615,7 +603,7 @@ Connection: close
 Server: urbit/vere-1.5
 ```
 
-Now if we scry for the [requests](@/docs/arvo/eyre/scry.md#cors-requests) CORS `set`:
+Now if we scry for the [requests](/docs/arvo/eyre/scry#cors-requests) CORS `set`:
 
 ```
 > .^(requests=(set @t) %ex /=//=/cors/requests)

--- a/content/docs/arvo/eyre/external-api-ref.md
+++ b/content/docs/arvo/eyre/external-api-ref.md
@@ -4,31 +4,9 @@ weight = 2
 template = "doc.html"
 +++
 
-# Contents
+This document contains reference information about Eyre's external APIs including [the channel system](#channels) and [scries](#scry). Each section will also have practical examples in the [Examples](/docs/arvo/eyre/examples) document.
 
-- [Introduction](#introduction)
-- [Authentication](#authentication)
-- [Channels](#channels)
-  - [HTTP Requests](#http-requests)
-  - [Actions](#actions)
-    - [Poke](#poke)
-    - [Subscribe](#subscribe)
-    - [Ack](#ack)
-    - [Unsubscribe](#unsubscribe)
-    - [Delete Channel](#delete-channel)
-  - [Responses](#responses)
-    - [Poke Ack](#poke-ack)
-    - [Watch Ack](#watch-ack)
-    - [Diff](#diff)
-    - [Quit](#quit)
-- [Scry](#scry)
-- [Spider](#spider)
-
-# Introduction
-
-This document contains reference information about Eyre's external APIs including [the channel system](#channels) and [scries](#scry). Each section will also have practical examples in the [Examples](@/docs/arvo/eyre/examples.md) document.
-
-# Authentication
+## Authentication
 
 To use Eyre's channel system, run threads or perform scries you must first obtain a session cookie by authenticating with the following HTTP request:
 
@@ -36,7 +14,7 @@ To use Eyre's channel system, run threads or perform scries you must first obtai
 | ----------- | -------------------------------------- | ---------- | ----------------------------------------------------------------------------------- |
 | `POST`      | `password=lidlut-tabwed-pillex-ridrup` | `/~/login` | The password is your web login code which can be obtained with `+code` in the dojo. |
 
-See the [examples](@/docs/arvo/eyre/examples.md#authenticating) for an example of how to do this using the curl.
+See the [examples](/docs/arvo/eyre/examples#authenticating) for an example of how to do this using the curl.
 
 Eyre's response will include a `set-cookie` header like:
 
@@ -50,7 +28,7 @@ The `urbauth-{...}` cookie provided must be included in a `cookie` header with a
 cookie: urbauth-~zod=0v4.ilskp.psv00.t09r0.l8rps.3n97v
 ```
 
-# Channels
+## Channels
 
 Eyre's channel system is the primary way of interacting with Gall agents from outside of Urbit.
 
@@ -73,9 +51,9 @@ All the events that Eyre sends you on a channel must be [ack](#ack)ed so that Ey
 
 When you're finished with a channel, you can send Eyre a [delete action](#delete-channel) to close it.
 
-See the [Using the Channel System](@/docs/arvo/eyre/examples.md#using-the-channel-system) section of the [Examples](@/docs/arvo/eyre/examples.md) document for a practical example.
+See the [Using the Channel System](/docs/arvo/eyre/examples#using-the-channel-system) section of the [Examples](/docs/arvo/eyre/examples) document for a practical example.
 
-## HTTP Requests
+### HTTP Requests
 
 [Actions](#actions) are sent to Eyre in HTTP PUT requests:
 
@@ -102,7 +80,7 @@ This is for poking a Gall agent.
 | `mark`   | String    | `'helm-hi'`   | Type of data. Must correspond to a mark definition in `/mar`. |
 | `json`   | Any       | `'hello'`     | Actual payload. Any JSON type, determined by app.             |
 
-**Example**
+#### Example
 
 ```json
 {
@@ -115,7 +93,7 @@ This is for poking a Gall agent.
 }
 ```
 
-**Response**
+#### Response
 
 Eyre will send a [poke ack](#poke-ack) as an SSE event on the channel event stream.
 
@@ -131,7 +109,7 @@ This is for subscribing to a watch `path` of a Gall agent.
 | `app`    | String    | `'graph-store'` | Name of the gall agent to which you're subscribing. |
 | `path`   | String    | `'/updates'`    | The path to watch. Depends on the app.              |
 
-**Example**
+#### Example
 
 ```json
 {
@@ -143,7 +121,7 @@ This is for subscribing to a watch `path` of a Gall agent.
 }
 ```
 
-**Response**
+#### Response
 
 Eyre will send back a [watch ack](#watch-ack). If subscribing was successful, you will also begin receiving any [diff](#diff)s sent by the Gall agent on the specified `path`.
 
@@ -157,7 +135,7 @@ This is for acknowledging an SSE event. If you `ack` one event, you also implici
 | `action`   | String    | `'ack'`       | The kind of action.                                      |
 | `event-id` | Number    | `7`           | ID of SSE event up to which you're acknowledging receipt |
 
-**Example**
+#### Example
 
 ```json
 {
@@ -167,7 +145,7 @@ This is for acknowledging an SSE event. If you `ack` one event, you also implici
 }
 ```
 
-**Response**
+#### Response
 
 Eyre will not respond to an `ack` action.
 
@@ -181,7 +159,7 @@ This is for unsubscribing from a Gall agent watch `path` to which you've previou
 | `action`       | String    | `unsubscribe` | The kind of action.                                        |
 | `subscription` | Number    | `2`           | Request ID of the initial `subscribe` action from earlier. |
 
-**Example**
+#### Example
 
 ```json
 {
@@ -191,7 +169,7 @@ This is for unsubscribing from a Gall agent watch `path` to which you've previou
 }
 ```
 
-**Response**
+#### Response
 
 Eyre will not respond to an `unsubscribe` action.
 
@@ -204,7 +182,7 @@ This is for deleting the channel itself.
 | `id`     | Number    | `5`           | ID for keeping track of sent messages. |
 | `action` | String    | `'delete'`    | The kind of action.                    |
 
-**Example**
+#### Example
 
 ```json
 {
@@ -213,7 +191,7 @@ This is for deleting the channel itself.
 }
 ```
 
-**Response**
+#### Response
 
 Eyre will not respond to a `delete` action.
 
@@ -223,7 +201,7 @@ Eyre will not respond to a `delete` action.
 
 This acknowledgement comes in response to a [poke](#poke) action. A poke ack with an `ok` key means the poke succeeded. A poke ack with an `err` key means the poke failed.
 
-**Positive Poke Ack**
+#### Positive Poke Ack
 
 | Key        | JSON Type | Example Value | Description                                  |
 | ---------- | --------- | ------------- | -------------------------------------------- |
@@ -231,7 +209,7 @@ This acknowledgement comes in response to a [poke](#poke) action. A poke ack wit
 | `id`       | Number    | `1`           | Request ID of the `poke` being acknowledged. |
 | `response` | String    | `'poke'`      | The kind of action being acknowledged.       |
 
-**Example**
+#### Example
 
 ```json
 {
@@ -241,7 +219,7 @@ This acknowledgement comes in response to a [poke](#poke) action. A poke ack wit
 }
 ```
 
-**Negative Poke Ack**
+#### Negative Poke Ack
 
 | Key        | JSON Type | Example Value    | Description                                                           |
 | ---------- | --------- | ---------------- | --------------------------------------------------------------------- |
@@ -249,7 +227,7 @@ This acknowledgement comes in response to a [poke](#poke) action. A poke ack wit
 | `id`       | Number    | `1`              | Request ID of the `poke` being acknowledged.                          |
 | `response` | String    | `'poke'`         | The kind of action being acknowledged.                                |
 
-**Example**
+#### Example
 
 ```json
 {
@@ -259,7 +237,7 @@ This acknowledgement comes in response to a [poke](#poke) action. A poke ack wit
 }
 ```
 
-**Action Required**
+#### Action Required
 
 You must ack the event.
 
@@ -267,7 +245,7 @@ You must ack the event.
 
 This acknowledgement comes in response to a [subscribe](#subscribe) action. A watch ack with an `ok` key means the subscription was successful. A watch ack with an `err` key means the subscription failed.
 
-**Positive Watch Ack**
+#### Positive Watch Ack
 
 | Key        | JSON Type | Example Value | Description                                   |
 | ---------- | --------- | ------------- | --------------------------------------------- |
@@ -275,7 +253,7 @@ This acknowledgement comes in response to a [subscribe](#subscribe) action. A wa
 | `id`       | Number    | `2`           | Request ID of the initial `subscribe` action. |
 | `response` | String    | `'subscribe'` | The kind of action being acknowledged.        |
 
-**Example**
+#### Example
 
 ```json
 {
@@ -285,7 +263,7 @@ This acknowledgement comes in response to a [subscribe](#subscribe) action. A wa
 }
 ```
 
-**Negative Watch Ack**
+#### Negative Watch Ack
 
 | Key        | JSON Type | Example Value    | Description                                                           |
 | ---------- | --------- | ---------------- | --------------------------------------------------------------------- |
@@ -293,7 +271,7 @@ This acknowledgement comes in response to a [subscribe](#subscribe) action. A wa
 | `id`       | Number    | `2`              | Request ID of the initial `subscribe` action.                         |
 | `response` | String    | `'subscribe'`    | The kind of action being acknowledged.                                |
 
-**Example**
+#### Example
 
 ```json
 {
@@ -303,7 +281,7 @@ This acknowledgement comes in response to a [subscribe](#subscribe) action. A wa
 }
 ```
 
-**Action Required**
+#### Action Required
 
 You must ack the event.
 
@@ -317,7 +295,7 @@ All `fact`s sent by a Gall agent on the `path` to which you've subscribed are de
 | `id`       | Number    | `3`              | Request ID of the initial `subscribe` action from earlier.   |
 | `response` | String    | `'diff'`         | The kind of response. All `fact`s are marked `'diff'`.       |
 
-**Example**
+#### Example
 
 ```json
 {
@@ -327,7 +305,7 @@ All `fact`s sent by a Gall agent on the `path` to which you've subscribed are de
 }
 ```
 
-**Action Required**
+#### Action Required
 
 You must [ack](#ack) each `diff` that comes in the event stream.
 
@@ -340,7 +318,7 @@ A `quit` comes in when a subscription has been ended. You may be intentionally k
 | `id`       | Number    | `4`           | Request ID of the initial `subscribe` action. |
 | `response` | String    | `'quit'`      | The kind of response.                         |
 
-**Example**
+#### Example
 
 ```json
 {
@@ -349,11 +327,11 @@ A `quit` comes in when a subscription has been ended. You may be intentionally k
 }
 ```
 
-**Action Required**
+#### Action Required
 
 You must ack the event and you may wish to try and re[subscribe](#subscribe).
 
-# Scry
+## Scry
 
 A scry is a read-only request for some data.
 
@@ -374,8 +352,8 @@ The `{mark}` is the type you want returned. It needn't just be `json` as with th
 
 If your session cookie is invalid or missing, Eyre will respond with a 403 Forbidden status. If the scry endpoint cannot be found, Eyre will respond with a 404 Missing status. If the `mark` conversions can't be done, Eyre will respond with a 500 Internal Server Error status. Otherwise, Eyre will respond with a 200 OK status with the requested data in the body of the HTTP response.
 
-See the [Scrying](@/docs/arvo/eyre/examples.md#scrying) section of the [Examples](@/docs/arvo/eyre/examples.md) document for a practical example.
+See the [Scrying](/docs/arvo/eyre/examples#scrying) section of the [Examples](/docs/arvo/eyre/examples) document for a practical example.
 
-# Spider
+## Spider
 
-See the [HTTP API](@/docs/userspace/threads/http-api.md) section of the [Threads](@/docs/userspace/threads/overview.md) documentation.
+See the [HTTP API](/docs/userspace/threads/http-api) section of the [Threads](/docs/userspace/threads/overview) documentation.

--- a/content/docs/arvo/eyre/eyre.md
+++ b/content/docs/arvo/eyre/eyre.md
@@ -8,54 +8,54 @@ Eyre is the webserver vane.
 
 HTTP messages come in from outside and Eyre produces HTTP messages in response. In general, apps do not call Eyre; rather, Eyre calls apps. Eyre has a number of ways to handle such HTTP requests which we'll briefly describe.
 
-# Authentication
+## Authentication
 
-Most types of requests require the client provide a valid session cookie which is obtained by authenticating with your ship's web login code. Authentication is documented in the [Authentication](@/docs/arvo/eyre/external-api-ref.md#authentication) section of the [External API Reference](@/docs/arvo/eyre/external-api-ref.md) documentation.
+Most types of requests require the client provide a valid session cookie which is obtained by authenticating with your ship's web login code. Authentication is documented in the [Authentication](/docs/arvo/eyre/external-api-ref#authentication) section of the [External API Reference](/docs/arvo/eyre/external-api-ref) documentation.
 
-# The Channel System
+## The Channel System
 
 Eyre's channel system is the primary way of interacting with Gall agents from outside of Urbit. It provides a simple JSON API that allows you to send data to apps and subscribe for updates from apps. Updates come back on a SSE ([Server Sent Event](https://html.spec.whatwg.org/#server-sent-events)) stream which you can easily handle with an EventSource object in Javascript or the equivalent in whichever language you prefer.
 
 The channel system is designed to be extremely simple with just a handful of `action` and `response` JSON objects to deal. Essentially it's a thin layer on top of the underlying Gall agent interface. You can poke agents, subscribe for updates, etc, just like you would from within Urbit.
 
-Detailed documentation of the channel system's JSON API is provided in the [External API Reference](@/docs/arvo/eyre/external-api-ref.md) document with corresponding examples in the [Examples](@/docs/arvo/eyre/examples.md#using-the-channel-system) document.
+Detailed documentation of the channel system's JSON API is provided in the [External API Reference](/docs/arvo/eyre/external-api-ref) document with corresponding examples in the [Examples](/docs/arvo/eyre/examples#using-the-channel-system) document.
 
-# Scrying
+## Scrying
 
 Along with the channel system, Eyre also provides a way to make read-only requests for data which are called scries. Eyre's scry interface is separate to the channel system but may be useful in conjunction with it.
 
-Details of Eyre's scry API are in the [Scry](@/docs/arvo/eyre/external-api-ref.md#scry) section of the [External API Reference](@/docs/arvo/eyre/external-api-ref.md) document.
+Details of Eyre's scry API are in the [Scry](/docs/arvo/eyre/external-api-ref#scry) section of the [External API Reference](/docs/arvo/eyre/external-api-ref) document.
 
-# Spider Threads
+## Spider Threads
 
-Spider (the Gall agent that manages threads) has an Eyre binding that allows you to run threads through Eyre. Spider's [HTTP API](@/docs/userspace/threads/http-api.md) is not part of Eyre proper, so is documented separately in the [Threads](@/docs/userspace/threads/overview.md) documentation.
+Spider (the Gall agent that manages threads) has an Eyre binding that allows you to run threads through Eyre. Spider's [HTTP API](/docs/userspace/threads/http-api) is not part of Eyre proper, so is documented separately in the [Threads](/docs/userspace/threads/overview) documentation.
 
-# Generators
+## Generators
 
 Generators, which are like Hoon scripts, can also be used through Eyre. Rather than having a predefined JSON API, they instead handle HTTP requests and return HTTP responses directly, and are therefore a more complex case that you're less likely to use.
 
-Their usage is explained in the [%serve](@/docs/arvo/eyre/tasks.md#serve) section of the [Internal API Reference](@/docs/arvo/eyre/tasks.md) documentation and a practical example is provided in the [Generators](@/docs/arvo/eyre/examples.md#generators) section of the [Examples](@/docs/arvo/eyre/examples.md) document.
+Their usage is explained in the [%serve](/docs/arvo/eyre/tasks#serve) section of the [Internal API Reference](/docs/arvo/eyre/tasks) documentation and a practical example is provided in the [Generators](/docs/arvo/eyre/examples#generators) section of the [Examples](/docs/arvo/eyre/examples) document.
 
-# Direct HTTP Handling With Gall Agents
+## Direct HTTP Handling With Gall Agents
 
 As well as the [Channel System](#the-channel-system) and [Scries](#scrying), it's also possible for Gall agents to deal directly with HTTP requests. This method is much more complicated than the channel system so you're unlikely to use it unless you want to build a custom HTTP-based API or something like that.
 
-This method is explained in the [%connect](@/docs/arvo/eyre/tasks.md#connect) section of the [Internal API Reference](@/docs/arvo/eyre/tasks.md) document and a detailed example is provided in the [Direct HTTP Handling With Gall Agents](@/docs/arvo/eyre/examples.md#direct-http-handling-with-gall-agents) section of the [Examples](@/docs/arvo/eyre/examples.md) document.
+This method is explained in the [%connect](/docs/arvo/eyre/tasks#connect) section of the [Internal API Reference](/docs/arvo/eyre/tasks) document and a detailed example is provided in the [Direct HTTP Handling With Gall Agents](/docs/arvo/eyre/examples#direct-http-handling-with-gall-agents) section of the [Examples](/docs/arvo/eyre/examples) document.
 
-# Cross-Origin Resource Sharing
+## Cross-Origin Resource Sharing
 
 Eyre supports both simple [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) requests and OPTIONS preflight requests. It has a CORS registry with three categories - `approved`, `rejected` and `requests`. Eyre will respond positively for origins in its `approved` list and negatively for all others. Eyre will add origins in requests that it doesn't have in either its `approved` or `rejected` lists to its `requests` list. Eyre always allows all methods and headers over CORS.
 
-There are three generators - `+cors-registry`, `|cors-approve`, and `|cors-reject` to view, approve, and deny origins respectively from the dojo. Eyre also has [tasks](@/docs/arvo/eyre/tasks.md) to [approve](@/docs/arvo/eyre/tasks.md#approve-origin) and [reject](@/docs/arvo/eyre/tasks.md#reject-origin) origins programmatically, and a number of [scry endpoints](@/docs/arvo/eyre/scry.md) to query them. Examples are also included in the [Managing CORS Origins](@/docs/arvo/eyre/examples.md#managing-cors-origins) section of the Examples document.
+There are three generators - `+cors-registry`, `|cors-approve`, and `|cors-reject` to view, approve, and deny origins respectively from the dojo. Eyre also has [tasks](/docs/arvo/eyre/tasks) to [approve](/docs/arvo/eyre/tasks#approve-origin) and [reject](/docs/arvo/eyre/tasks#reject-origin) origins programmatically, and a number of [scry endpoints](/docs/arvo/eyre/scry) to query them. Examples are also included in the [Managing CORS Origins](/docs/arvo/eyre/examples#managing-cors-origins) section of the Examples document.
 
-# Eyre Documentation Sections
+## Sections
 
-- [External API Reference](@/docs/arvo/eyre/external-api-ref.md) - Details of Eyre's external API including the channel system's JSON API.
+[External API Reference](/docs/arvo/eyre/external-api-ref) - Details of Eyre's external API including the channel system's JSON API.
 
-- [Internal API Reference](@/docs/arvo/eyre/tasks.md) - The `task`s Eyre takes and the `gift`s it returns.
+[Internal API Reference](/docs/arvo/eyre/tasks) - The `task`s Eyre takes and the `gift`s it returns.
 
-- [Scry Reference](@/docs/arvo/eyre/scry.md) - The scry endpoints of Eyre.
+[Scry Reference](/docs/arvo/eyre/scry) - The scry endpoints of Eyre.
 
-- [Data Types](@/docs/arvo/eyre/data-types.md) - Reference documentation of the various data types used by Eyre.
+[Data Types](/docs/arvo/eyre/data-types) - Reference documentation of the various data types used by Eyre.
 
-- [Examples](@/docs/arvo/eyre/examples.md) - Practical examples of the different ways of using Eyre.
+[Examples](/docs/arvo/eyre/examples) - Practical examples of the different ways of using Eyre.

--- a/content/docs/arvo/eyre/scry.md
+++ b/content/docs/arvo/eyre/scry.md
@@ -6,7 +6,7 @@ template = "doc.html"
 
 Here are all of Eyre's scry endpoints. There's not too many and they mostly deal with either CORS settings or aspects of the state of connections.
 
-The first few have a `care` of `x` and are a scry like `.^(<type> %ex /=//=/<some-path>)` (note the empty `desk`). The rest have no `care` and the tag replaces the `desk` like `.^(<type> %e /=<something>=)`.
+The first few have a `care` of `x` and are a scry like `.^({TYPE} %ex /=//=/{SOME-PATH})` (note the empty `desk`). The rest have no `care` and the tag replaces the `desk` like `.^({TYPE} %e /={SOMETHING}=)`.
 
 All examples are run from the dojo.
 
@@ -46,9 +46,9 @@ An `x` scry with a `path` of `/cors/approved` will return the `set` of approved 
 approved={~~http~3a.~2f.~2f.foo~.example}
 ```
 
-## `/cors/approved/<origin>`
+## `/cors/approved/{ORIGIN}`
 
-An `x` scry whose `path` is `/cors/approved/<origin>` tests whether the given origin URL is in the `approved` set of the CORS registry. The type returned is a simple `?`.
+An `x` scry whose `path` is `/cors/approved/{ORIGIN}` tests whether the given origin URL is in the `approved` set of the CORS registry. The type returned is a simple `?`.
 
 The origin URL is a `@t`, but since `@t` may not be valid in a path, it must be encoded in a `@ta` using `+scot` like `(scot %t 'foo')` rather than just `'foo'`.
 
@@ -75,9 +75,9 @@ An `x` scry with a `path` of `/cors/rejected` will return the `set` of rejected 
 rejected={~~http~3a.~2f.~2f.bar~.example}
 ```
 
-## `/cors/rejected/<origin>`
+## `/cors/rejected/{ORIGIN}`
 
-An `x` scry whose `path` is `/cors/rejected/<origin>` tests whether the given origin URL is in the `rejected` set of the CORS registry. The type returned is a simple `?`.
+An `x` scry whose `path` is `/cors/rejected/{ORIGIN}` tests whether the given origin URL is in the `rejected` set of the CORS registry. The type returned is a simple `?`.
 
 The origin URL must be a cord-encoded `@t` rather than just the plain `@t`, so you'll have to do something like `(scot %t 'foo')` rather than just `'foo'`.
 
@@ -93,11 +93,11 @@ The origin URL must be a cord-encoded `@t` rather than just the plain `@t`, so y
 %.n
 ```
 
-## `/authenticated/cookie/<cookie>`
+## `/authenticated/cookie`
 
-An `x` scry whose `path` is `/authenticated/cookies/<cookie>` tests whether the given cookie is currently valid. The type returned is a `?`.
+An `x` scry whose `path` is `/authenticated/cookie/{COOKIE}` tests whether the given cookie is currently valid. The type returned is a `?`.
 
-The cookie must be the full cookie including the `urbauth-<ship>=` part. The cookie must be a cord-encoded `@t` rather than just a plain `@t`, so you'll have to do something like `(scot %t 'foo')` rather than just `'foo'`.
+The cookie must be the full cookie including the `urbauth-{SHIP}=` part. The cookie must be a cord-encoded `@t` rather than just a plain `@t`, so you'll have to do something like `(scot %t 'foo')` rather than just `'foo'`.
 
 ### Examples
 
@@ -145,7 +145,7 @@ A scry with `bindings` in place of the `desk` in the `beak` will return all open
 
 ## `%authentication-state`
 
-A scry with `authentication-state` in place of the `desk` in the `beak` will return authentication details of all current sessions. The type returned is a [$authentication-state](/docs/arvo/eyre/data-types#authentication-state). The `p` field is the cookie sans the `urbauth-<ship>=` part.
+A scry with `authentication-state` in place of the `desk` in the `beak` will return authentication details of all current sessions. The type returned is a [$authentication-state](/docs/arvo/eyre/data-types#authentication-state). The `p` field is the cookie sans the `urbauth-{SHIP}=` part.
 
 ### Example
 

--- a/content/docs/arvo/eyre/scry.md
+++ b/content/docs/arvo/eyre/scry.md
@@ -4,35 +4,17 @@ weight = 4
 template = "doc.html"
 +++
 
-## Contents
-
-- [Introduction](#introduction)
-- [/cors](#cors) - CORS settings.
-  - [/cors/requests](#cors-requests) - Requested origins.
-  - [/cors/approved](#cors-approved) - Approved origins.
-  - [/cors/approved/\<origin\>](#cors-approved-origin) - Check if origin approved.
-  - [/cors/rejected](#cors-rejected) - Rejected origins.
-  - [/cors/rejected/\<origin\>](#cors-rejected-origin) - Check if origin rejected.
-- [/authenticated/cookie/\<cookie\>](#authenticated-cookie-cookie) - Check if cookie authenticated.
-- [bindings](#bindings) - URL path bindings.
-- [connections](#connections) - Open http connections.
-- [authentication-state](#authentication-state) - Authentication details.
-- [channel-state](#channel-state) - Details of each channel.
-- [host](#host) - Host details.
-
-# Introduction
-
 Here are all of Eyre's scry endpoints. There's not too many and they mostly deal with either CORS settings or aspects of the state of connections.
 
 The first few have a `care` of `x` and are a scry like `.^(<type> %ex /=//=/<some-path>)` (note the empty `desk`). The rest have no `care` and the tag replaces the `desk` like `.^(<type> %e /=<something>=)`.
 
 All examples are run from the dojo.
 
-# `/cors`
+## `/cors`
 
-An `x` scry with a `path` of `/cors` will return Eyre's CORS origin registry. The type returned is a [cors-registry](@/docs/arvo/eyre/data-types.md#cors-registry) which contains the `set`s of approved, rejected and requested origins.
+An `x` scry with a `path` of `/cors` will return Eyre's CORS origin registry. The type returned is a [cors-registry](/docs/arvo/eyre/data-types#cors-registry) which contains the `set`s of approved, rejected and requested origins.
 
-Example:
+### Example
 
 ```
 > .^(cors-registry:eyre %ex /=//=/cors)
@@ -46,7 +28,7 @@ Example:
 
 An `x` scry with a `path` of `/cors/requests` will return the `set` of pending origin requests. These are origins that were in an `Origin: ...` HTTP header but weren't in the existing approved or rejected sets. The type returned is a `(set origin:eyre)`.
 
-Example:
+### Example
 
 ```
 > .^(requests=(set origin:eyre) %ex /=//=/cors/requests)
@@ -57,7 +39,7 @@ requests={~~http~3a.~2f.~2f.baz~.example}
 
 An `x` scry with a `path` of `/cors/approved` will return the `set` of approved CORS origins. The type returned is a `(set origin:eyre)`.
 
-Example:
+### Example
 
 ```
 > .^(approved=(set origin:eyre) %ex /=//=/cors/approved)
@@ -70,7 +52,7 @@ An `x` scry whose `path` is `/cors/approved/<origin>` tests whether the given or
 
 The origin URL is a `@t`, but since `@t` may not be valid in a path, it must be encoded in a `@ta` using `+scot` like `(scot %t 'foo')` rather than just `'foo'`.
 
-Examples:
+### Examples
 
 ```
 > .^(? %ex /=//=/cors/approved/(scot %t 'http://foo.example'))
@@ -86,7 +68,7 @@ Examples:
 
 An `x` scry with a `path` of `/cors/rejected` will return the `set` of rejected CORS origins. The type returned is a `(set origin:eyre)`.
 
-Example:
+### Example
 
 ```
 > .^(rejected=(set origin:eyre) %ex /=//=/cors/rejected)
@@ -99,7 +81,7 @@ An `x` scry whose `path` is `/cors/rejected/<origin>` tests whether the given or
 
 The origin URL must be a cord-encoded `@t` rather than just the plain `@t`, so you'll have to do something like `(scot %t 'foo')` rather than just `'foo'`.
 
-Examples:
+### Examples
 
 ```
 > .^(? %ex /=//=/cors/rejected/(scot %t 'http://bar.example'))
@@ -111,13 +93,13 @@ Examples:
 %.n
 ```
 
-# `/authenticated/cookie/<cookie>`
+## `/authenticated/cookie/<cookie>`
 
 An `x` scry whose `path` is `/authenticated/cookies/<cookie>` tests whether the given cookie is currently valid. The type returned is a `?`.
 
 The cookie must be the full cookie including the `urbauth-<ship>=` part. The cookie must be a cord-encoded `@t` rather than just a plain `@t`, so you'll have to do something like `(scot %t 'foo')` rather than just `'foo'`.
 
-Examples:
+### Examples
 
 ```
 > .^(? %ex /=//=/authenticated/cookie/(scot %t 'urbauth-~zod=0vvndn8.bfsjj.j3614.k40ha.8fomi'))
@@ -129,11 +111,11 @@ Examples:
 %.n
 ```
 
-# `bindings`
+## `%bindings`
 
-A scry with `bindings` in place of the `desk` in the `beak` will return Eyre's URL path bindings. The type returned is a `(list [binding:eyre duct action:eyre])` (see the [binding](@/docs/arvo/eyre/data-types.md#binding) & [action](@/docs/arvo/eyre/data-types.md#action) sections of the Data Types document for details).
+A scry with `bindings` in place of the `desk` in the `beak` will return Eyre's URL path bindings. The type returned is a `(list [binding:eyre duct action:eyre])` (see the [$binding](/docs/arvo/eyre/data-types#binding) & [$action](/docs/arvo/eyre/data-types#action) sections of the Data Types document for details).
 
-Example:
+### Example
 
 ```
 > .^((list [binding:eyre duct action:eyre]) %e /=bindings=)
@@ -150,22 +132,22 @@ Example:
 ]
 ```
 
-# `connections`
+## `%connections`
 
-A scry with `bindings` in place of the `desk` in the `beak` will return all open HTTP connections that aren't fully complete. The type returned is a `(map duct outstanding-connection:eyre)` (see the [outstanding-connection](@/docs/arvo/eyre/data-types.md#outstanding-connection) section of the Data Types document for details).
+A scry with `bindings` in place of the `desk` in the `beak` will return all open HTTP connections that aren't fully complete. The type returned is a `(map duct outstanding-connection:eyre)` (see the [$outstanding-connection](/docs/arvo/eyre/data-types#outstanding-connection) section of the Data Types document for details).
 
-Example:
+### Example
 
 ```
 > .^((map duct outstanding-connection:eyre) %e /=connections=)
 {}
 ```
 
-# `authentication-state`
+## `%authentication-state`
 
-A scry with `authentication-state` in place of the `desk` in the `beak` will return authentication details of all current sessions. The type returned is a [authentication-state](@/docs/arvo/eyre/data-types.md#authentication-state). The `p` field is the cookie sans the `urbauth-<ship>=` part.
+A scry with `authentication-state` in place of the `desk` in the `beak` will return authentication details of all current sessions. The type returned is a [$authentication-state](/docs/arvo/eyre/data-types#authentication-state). The `p` field is the cookie sans the `urbauth-<ship>=` part.
 
-Example:
+### Example
 
 ```
 > .^(authentication-state:eyre %e /=authentication-state=)
@@ -176,11 +158,11 @@ Example:
 }
 ```
 
-# `channel-state`
+## `%channel-state`
 
-A scry with `channel-state` in place of the `desk` in the `beak` will return details of the state of each channel. The type returned is a [channel-state](@/docs/arvo/eyre/data-types.md#channel-state).
+A scry with `channel-state` in place of the `desk` in the `beak` will return details of the state of each channel. The type returned is a [channel-state](/docs/arvo/eyre/data-types#channel-state).
 
-Example:
+### Example
 
 ```
 > .^(channel-state:eyre %e /=channel-state=)
@@ -201,11 +183,11 @@ Example:
 ]
 ```
 
-# `host`
+## `%host`
 
 A scry with `host` in place of the `desk` in the `beak` will return host details of the ship. The type returned is a `hart:eyre`.
 
-Example:
+### Example
 
 ```
 > .^(hart:eyre %e /=host=)

--- a/content/docs/arvo/eyre/tasks.md
+++ b/content/docs/arvo/eyre/tasks.md
@@ -4,30 +4,13 @@ weight = 3
 template = "doc.html"
 +++
 
-# Contents
-
-- [Introduction](#introduction)
-- [%live](#live) - _(Internal only)_ - Notifies Eyre of HTTP(S) ports.
-- [%rule](#rule) - _(Usually internal)_ - Sets TLS cert or DNS binding.
-- [%request](#request) - _(Internal only)_ - Incoming HTTP request.
-- [%request-local](#request-local) - _(Internal only)_ - Incoming HTTP request from the local loopback port.
-- [%cancel-request](#cancel-request) - _(Internal only)_ - Notifies Eyre of a connection being closed externally.
-- [%connect](#connect) - Bind a Gall agent to a URL.
-- [%serve](#serve) - Bind a generator to a URL.
-- [%disconnect](#disconnect) - Disconnect agent or generator from URL binding.
-- [%code-changed](#code-changed) - _(Usually internal)_ - Notifies Eyre of the web login code changing.
-- [%approve-origin](#approve-origin) - Approve a CORS origin.
-- [%reject-origin](#reject-origin) - Reject a CORS origin.
-
-# Introduction
-
 This document details all the `task`s you're likely to use to interact with Eyre, as well as the `gift`s you'll receive in response.
 
-The primary way of interacting with Eyre is from the outside with HTTP requests. As a result, most of its `task`s are only used internally and you're unlikely to need to deal with them directly. The ones you may want to use in certain cases are [%connect](#connect), [%serve](#serve), [%disconnect](#disconnect), [%approve-origin](#approve-origin) and [%reject-origin](#reject-origin), and they are also demonstrated in the [Examples](@/docs/arvo/eyre/examples.md) document. The rest are just documented for completeness.
+The primary way of interacting with Eyre is from the outside with HTTP requests. As a result, most of its `task`s are only used internally and you're unlikely to need to deal with them directly. The ones you may want to use in certain cases are [%connect](#connect), [%serve](#serve), [%disconnect](#disconnect), [%approve-origin](#approve-origin) and [%reject-origin](#reject-origin), and they are also demonstrated in the [Examples](/docs/arvo/eyre/examples) document. The rest are just documented for completeness.
 
-Many of the types referenced are detailed in the [Data Types](@/docs/arvo/eyre/data-types.md) document. It may also be useful to look at the `+eyre` section of `/sys/lull.hoon` in Arvo where these `task`s, `gift`s and data structures are defined.
+Many of the types referenced are detailed in the [Data Types](/docs/arvo/eyre/data-types) document. It may also be useful to look at the `+eyre` section of `/sys/lull.hoon` in Arvo where these `task`s, `gift`s and data structures are defined.
 
-# `%live`
+## `%live`
 
 ```hoon
 [%live insecure=@ud secure=(unit @ud)]
@@ -37,11 +20,11 @@ This `task` notifies Eyre of the listening HTTPS and HTTP ports. It is automatic
 
 The `insecure` field is the HTTP port and `secure` is the optional HTTPS port.
 
-## Returns
+### Returns
 
 Eyre returns no `gift` in response to a `%live` `task`.
 
-# `%rule`
+## `%rule`
 
 ```hoon
 [%rule =http-rule]
@@ -49,13 +32,13 @@ Eyre returns no `gift` in response to a `%live` `task`.
 
 This `task` either configures HTTPS with a certificate and keypair, or configures a DNS binding. This is typically done for you by the `%acme` app, rather than done manually.
 
-The [http-rule](@/docs/arvo/eyre/data-types.md#http-rule) is either tagged with `%cert` or `%turf`. A `%cert` `http-rule` sets an HTTPS certificate and keypair or removes it if null. A `%turf` `http-rule` either adds or removes a DNS binding depending on whether the `action` is `%put` or `%del`. Note that using `%turf` will automatically cause the system to try and obtain a certificate and keypair via Letsencrypt.
+The [$http-rule](/docs/arvo/eyre/data-types#http-rule) is either tagged with `%cert` or `%turf`. A `%cert` `http-rule` sets an HTTPS certificate and keypair or removes it if null. A `%turf` `http-rule` either adds or removes a DNS binding depending on whether the `action` is `%put` or `%del`. Note that using `%turf` will automatically cause the system to try and obtain a certificate and keypair via Letsencrypt.
 
-## Returns
+### Returns
 
 Eyre returns no `gift` in response to a `%rule` `task`.
 
-# `%request`
+## `%request`
 
 ```hoon
 [%request secure=? =address =request:http]
@@ -63,13 +46,13 @@ Eyre returns no `gift` in response to a `%rule` `task`.
 
 This `task` is how Eyre receives an inbound HTTP request. It will ordinarily be sent to Eyre by the runtime so you wouldn't use it except perhaps in tests.
 
-The `secure` field says whether it's over HTTPS. The `address` is the IP address from which the request originated. The [request:http](@/docs/arvo/eyre/data-types.md#request-http) is the HTTP request itself containing the method, URL, headers, and body.
+The `secure` field says whether it's over HTTPS. The `address` is the IP address from which the request originated. The [$request:http](/docs/arvo/eyre/data-types#requesthttp) is the HTTP request itself containing the method, URL, headers, and body.
 
-## Returns
+### Returns
 
 Eyre may `pass` a `%response` `gift` on the appropriate `duct` depending on the contents of the `%request`, state of the connection, and other factors.
 
-# `%request-local`
+## `%request-local`
 
 ```hoon
 [%request-local secure=? =address =request:http]
@@ -77,11 +60,11 @@ Eyre may `pass` a `%response` `gift` on the appropriate `duct` depending on the 
 
 This `task` is how Eyre receives an inbound HTTP request over the local loopback port. It behaves the same and takes the same arguments as in the [%request](#request) example except it skips any normally required authentication. Just like for a [%request](#request) `task`, you'd not normally use this manually.
 
-## Returns
+### Returns
 
 Eyre may `pass` a `%response` `gift` on the appropriate `duct` depending on the contents of the `%request`, state of the connection, and other factors.
 
-# `%cancel-request`
+## `%cancel-request`
 
 ```hoon
 [%cancel-request ~]
@@ -91,11 +74,11 @@ This `task` is sent to Eyre by the runtime when an HTTP client closes its previo
 
 This `task` takes no arguments.
 
-## Returns
+### Returns
 
 Eyre may `pass` a `%response` `gift` on the appropriate `duct` depending on the state of the connection and other factors.
 
-# `%connect`
+## `%connect`
 
 ```hoon
 [%connect =binding app=term]
@@ -103,19 +86,19 @@ Eyre may `pass` a `%response` `gift` on the appropriate `duct` depending on the 
 
 This `task` binds a Gall agent to a URL path so it can receive HTTP requests and return HTTP responses directly.
 
-The [binding](@/docs/arvo/eyre/data-types.md#binding) contains a URL path and optional domain through which the agent will be able to take HTTP requests. The `app` is just the name of the Gall agent to bind. Note that if you bind a URL path of `/foo`, Eyre will also match `/foo/bar`, `/foo/bar/baz`, etc.
+The [$binding](/docs/arvo/eyre/data-types#binding) contains a URL path and optional domain through which the agent will be able to take HTTP requests. The `app` is just the name of the Gall agent to bind. Note that if you bind a URL path of `/foo`, Eyre will also match `/foo/bar`, `/foo/bar/baz`, etc.
 
-If an agent is bound in Eyre using this method, HTTP requests to the bound URL path are poked directly into the agent. The `cage` in the poke have a `%handle-http-request` `mark` and a `vase` of `[@ta inbound-request:eyre]` where the `@ta` is a unique `eyre-id` and the [inbound-request](@/docs/arvo/eyre/data-types.md#inbound-request) contains the HTTP request itself.
+If an agent is bound in Eyre using this method, HTTP requests to the bound URL path are poked directly into the agent. The `cage` in the poke have a `%handle-http-request` `mark` and a `vase` of `[@ta inbound-request:eyre]` where the `@ta` is a unique `eyre-id` and the [$inbound-request](/docs/arvo/eyre/data-types#inbound-request) contains the HTTP request itself.
 
 Along with the poke, Eyre will also subscribe to the `/http-response/[eyre-id]` `path` of the agent and await a response, which it will pass on to the HTTP client who made the request. Eyre expects at least two `fact`s and a `kick` on this subscription path to complete the response and close the connection (though it can take more than two `fact`s).
 
-The first `fact`'s `cage` must have a `mark` of `%http-response-header` and a `vase` containing a [response-header:http](@/docs/arvo/eyre/data-types.md#response-header-http) with the HTTP status code and headers of the response.
+The first `fact`'s `cage` must have a `mark` of `%http-response-header` and a `vase` containing a [$response-header:http](/docs/arvo/eyre/data-types#response-headerhttp) with the HTTP status code and headers of the response.
 
 The `cage` of the second and subsequent `fact`s must have a `mark` of `%http-response-data` and a `vase` containing a `(unit octs)` with the actual data of the response. An `octs` is just `[p=@ud q=@]` where `p` is the byte-length of `q`, the data. You can send an arbitrary number of these.
 
 Finally, once you've sent all the `fact`s you want, you can `kick` Eyre's subscription and it will complete the response and close the connection to the HTTP client.
 
-## Returns
+### Returns
 
 Eyre will respond with a `%bound` `gift` which says whether the binding was successful and looks like:
 
@@ -125,11 +108,11 @@ Eyre will respond with a `%bound` `gift` which says whether the binding was succ
 
 The `accepted` field says whether the binding succeeded and the `binding` is the requested binding described above.
 
-## Example
+### Example
 
-See the [Direct HTTP Handling With Gall Agents](@/docs/arvo/eyre/examples.md#direct-http-handling-with-gall-agents) section of the [Examples](@/docs/arvo/eyre/examples.md) document for an example.
+See the [Direct HTTP Handling With Gall Agents](/docs/arvo/eyre/examples#direct-http-handling-with-gall-agents) section of the [Examples](/docs/arvo/eyre/examples) document for an example.
 
-# `%serve`
+## `%serve`
 
 ```hoon
 [%serve =binding =generator]
@@ -137,9 +120,9 @@ See the [Direct HTTP Handling With Gall Agents](@/docs/arvo/eyre/examples.md#dir
 
 This `task` binds a generator to a URL path so it can receive HTTP requests and return HTTP responses.
 
-The `binding` contains the URL path and optional domain through which the generator will take HTTP requests. The [generator](@/docs/arvo/eyre/data-types.md#generator) specifies the `desk`, the `path` to the generator in Clay, and also has a field for arguments. Note that the passing of specified arguments to the generator by Eyre is not currently implemented, so you can just leave it as `~`.
+The `binding` contains the URL path and optional domain through which the generator will take HTTP requests. The [$generator](/docs/arvo/eyre/data-types#generator) specifies the `desk`, the `path` to the generator in Clay, and also has a field for arguments. Note that the passing of specified arguments to the generator by Eyre is not currently implemented, so you can just leave it as `~`.
 
-The bound generator must be a gate within a gate and the type returned must be a [simple-payload:http](@/docs/arvo/eyre/data-types.md#simple-payload-http).
+The bound generator must be a gate within a gate and the type returned must be a [$simple-payload:http](/docs/arvo/eyre/data-types#simple-payloadhttp).
 
 The sample of the first gate must be:
 
@@ -153,19 +136,19 @@ The sample of the first gate must be:
 [authenticated=? =request:http]
 ```
 
-The `?` says whether the HTTP request contained a valid session cookie and the [request:http](@/docs/arvo/eyre/data-types.md#request-http) contains the request itself.
+The `?` says whether the HTTP request contained a valid session cookie and the [$request:http](/docs/arvo/eyre/data-types#requesthttp) contains the request itself.
 
 The `simple-payload:http` returned by the generator is similar to the response described in the [%connect](#connect) section except the HTTP headers and body are all contained in the one response rather than staggered across several.
 
-## Returns
+### Returns
 
 Eyre will return a `%bound` `gift` as described at the end of the [%connect](#connect) section.
 
-## Example
+### Example
 
-See the [Generators](@/docs/arvo/eyre/examples.md#generators) section of the [Examples](@/docs/arvo/eyre/examples.md) document for an example.
+See the [Generators](/docs/arvo/eyre/examples#generators) section of the [Examples](/docs/arvo/eyre/examples) document for an example.
 
-# `%disconnect`
+## `%disconnect`
 
 ```hoon
 [%disconnect =binding]
@@ -173,13 +156,13 @@ See the [Generators](@/docs/arvo/eyre/examples.md#generators) section of the [Ex
 
 This `task` deletes a URL binding previously set by a `%connect` or `%serve` `task`.
 
-The [binding](@/docs/arvo/eyre/data-types.md#binding) is the URL path and domain of the binding you want to delete.
+The [$binding](/docs/arvo/eyre/data-types#binding) is the URL path and domain of the binding you want to delete.
 
-## Returns
+### Returns
 
 Eyre returns no `gift` in response to a `%disconnect` `task`.
 
-# `%code-changed`
+## `%code-changed`
 
 ```hoon
 [%code-changed ~]
@@ -189,11 +172,11 @@ This `task` tells Eyre that the web login code has changed, causing Eyre to thro
 
 This `task` takes no arguments.
 
-## Returns
+### Returns
 
 Eyre returns no `gift` in response to a `%code-changed` `task`.
 
-# `%approve-origin`
+## `%approve-origin`
 
 ```hoon
 [%approve-origin =origin]
@@ -201,17 +184,17 @@ Eyre returns no `gift` in response to a `%code-changed` `task`.
 
 This `task` tells Eyre to start responding positively to CORS requests for the specified `origin`.
 
-The [origin](@/docs/arvo/eyre/data-types.md#origin) is a CORS origin like `http://foo.example` you want to approve.
+The [$origin](/docs/arvo/eyre/data-types#origin) is a CORS origin like `http://foo.example` you want to approve.
 
-## Returns
+### Returns
 
 Eyre returns no `gift` in response to a `%approve-origin` `task`.
 
-## Example
+### Example
 
-See the [Managing CORS Origins](@/docs/arvo/eyre/examples.md#managing-cors-origins) section of the [Examples](@/docs/arvo/eyre/examples.md) document for an example.
+See the [Managing CORS Origins](/docs/arvo/eyre/examples#managing-cors-origins) section of the [Examples](/docs/arvo/eyre/examples) document for an example.
 
-# `%reject-origin`
+## `%reject-origin`
 
 ```hoon
 [%reject-origin =origin]
@@ -219,12 +202,12 @@ See the [Managing CORS Origins](@/docs/arvo/eyre/examples.md#managing-cors-origi
 
 This `task` tells Eyre to start responding negatively to CORS requests for the specified `origin`.
 
-The [origin](@/docs/arvo/eyre/data-types.md#origin) is a CORS origin like `http://foo.example` you want want to reject.
+The [$origin](/docs/arvo/eyre/data-types#origin) is a CORS origin like `http://foo.example` you want want to reject.
 
-## Returns
+### Returns
 
 Eyre returns no `gift` in response to a `%reject-origin` `task`.
 
-## Example
+### Example
 
-See the [Managing CORS Origins](@/docs/arvo/eyre/examples.md#managing-cors-origins) section of the [Examples](@/docs/arvo/eyre/examples.md) document for an example.
+See the [Managing CORS Origins](/docs/arvo/eyre/examples#managing-cors-origins) section of the [Examples](/docs/arvo/eyre/examples) document for an example.


### PR DESCRIPTION
Fix eyre docs so they work sanely in the new framework

Removes contents sections, restructures headers, fixes links, fixes issues rendering angle brackets

@drbeefsupreme 