### PR TITLE
rss: fix link building

### DIFF
--- a/lib/rss.js
+++ b/lib/rss.js
@@ -24,17 +24,15 @@ const generateRSSFeed = () => {
           fs.readFileSync(path.join(dir, post.name)),
           options
         );
+        const leadingDir = dir.substr(dir.indexOf("content") + 8);
+        const name = post.name.replace(/.md$/, "");
+
         return {
           title: pageData.title,
           descripton: pageData.description || "",
           author: pageData.extra.author || "",
           date: pageData.date,
-          link: path.join(
-            "https://urbit.org/",
-            dir.substr(dir.indexOf("content") + 7),
-            "/",
-            post.name.replace(/.md$/, "")
-          ),
+          link: `https://urbit.org/${leadingDir}/${name}`,
           content: pageContent,
         };
       });


### PR DESCRIPTION
`path.join` was causing mishaps with link protocols, and really just for file paths.