### PR TITLE
docs, contentarea: insert toc inside contentarea

### DIFF
--- a/components/ContentArea.js
+++ b/components/ContentArea.js
@@ -1,5 +1,6 @@
 import Section from "./Section";
 import { useState, useEffect } from "react";
+import { TableOfContents } from "./TableOfContents";
 
 export default function ContentArea(props) {
   const [shortcut, setShortcut] = useState("");
@@ -50,6 +51,9 @@ export default function ContentArea(props) {
               <div className="pb-32" />
             </div>
           )}
+          <TableOfContents
+            key={props.params.slug?.join("/") || Math.random()}
+          />
         </div>
       </div>
     </div>

--- a/components/TableOfContents.js
+++ b/components/TableOfContents.js
@@ -8,7 +8,7 @@ export const TableOfContents = ({ staticPosition, noh3s }) => {
     <nav
       className={
         (staticPosition ? "static" : "sticky") +
-        " min-h-0 overflow-y-auto w-52 flex-shrink-0 pb-24 hidden lg:block"
+        " min-h-0 overflow-y-auto w-52 flex-shrink-0 pb-24 hidden lg:block pl-4"
       }
       style={{ top: "8rem", height: "calc(100vh - 16rem)" }}
     >

--- a/pages/community/[[...slug]].js
+++ b/pages/community/[[...slug]].js
@@ -76,6 +76,7 @@ export default function UsingLayout({ posts, data, params, search, markdown }) {
           title={data.title}
           search={search}
           section={"Community"}
+          params={params}
         >
           <div className={markdownStyles["markdown"]}>
             <article

--- a/pages/docs/[[...slug]].js
+++ b/pages/docs/[[...slug]].js
@@ -17,7 +17,6 @@ import ContentArea from "../../components/ContentArea";
 import Sidebar from "../../components/Sidebar";
 import markdownStyles from "../../styles/markdown.module.css";
 import { decode } from "html-entities";
-import { TableOfContents } from "../../components/TableOfContents";
 
 const breadcrumbs = (posts, paths) => {
   const results = [
@@ -144,6 +143,7 @@ export default function DocsLayout({
           title={data.title}
           search={search}
           section="Urbit Documentation"
+          params={params}
         >
           <div className={markdownStyles["markdown"]}>
             <article
@@ -175,7 +175,6 @@ export default function DocsLayout({
             )}
           </div>
         </ContentArea>
-        <TableOfContents key={params.slug?.join("/") || "docs"} />
       </div>
     </>
   );

--- a/pages/getting-started/[[...slug]].js
+++ b/pages/getting-started/[[...slug]].js
@@ -93,6 +93,7 @@ export default function UsingLayout({ posts, data, params, search, markdown }) {
           title={data.title}
           search={search}
           section={"Getting Started"}
+          params={params}
         >
           <div className={markdownStyles["markdown"]}>
             <article

--- a/pages/getting-started/[[...slug]].js
+++ b/pages/getting-started/[[...slug]].js
@@ -7,7 +7,6 @@ import { join } from "path";
 import { buildPageTree, getPage } from "../../lib/lib";
 import Markdown from "../../components/Markdown";
 import ContentArea from "../../components/ContentArea";
-import { TableOfContents } from "../../components/TableOfContents";
 import Sidebar from "../../components/Sidebar";
 import markdownStyles from "../../styles/markdown.module.css";
 import { decode } from "html-entities";
@@ -101,7 +100,6 @@ export default function UsingLayout({ posts, data, params, search, markdown }) {
             ></article>
           </div>
         </ContentArea>
-        <TableOfContents key={params.slug?.join("/") || "getting-started"} />
       </div>
     </>
   );

--- a/pages/understanding-urbit/[[...slug]].js
+++ b/pages/understanding-urbit/[[...slug]].js
@@ -106,6 +106,7 @@ export default function UnderstandingLayout({
           title={data.title}
           search={search}
           section={"Understanding Urbit"}
+          params={params}
         >
           <div className={markdownStyles["markdown"]}>
             <article

--- a/pages/using/[[...slug]].js
+++ b/pages/using/[[...slug]].js
@@ -8,7 +8,6 @@ import { join } from "path";
 import { getDocs, formatDate, buildPageTree, getPage } from "../../lib/lib";
 import Markdown from "../../components/Markdown";
 import ContentArea from "../../components/ContentArea";
-import { TableOfContents } from "../../components/TableOfContents";
 import Sidebar from "../../components/Sidebar";
 import markdownStyles from "../../styles/markdown.module.css";
 import { decode } from "html-entities";
@@ -121,7 +120,6 @@ export default function UsingLayout({ posts, data, params, search, markdown }) {
             ></article>
           </div>
         </ContentArea>
-        <TableOfContents key={params.slug?.join("/") || "using"} />
       </div>
     </>
   );

--- a/pages/using/[[...slug]].js
+++ b/pages/using/[[...slug]].js
@@ -113,6 +113,7 @@ export default function UsingLayout({ posts, data, params, search, markdown }) {
           title={data.title}
           search={search}
           section={"Operator's Manual"}
+          params={params}
         >
           <div className={markdownStyles["markdown"]}>
             <article


### PR DESCRIPTION
Places the table of contents inside the content area so the scroll bar extends full page and the header on docs-style pages is full width.