### PR TITLE
update stdlib cork code, fix example

### DIFF
--- a/content/docs/hoon/reference/stdlib/2n.md
+++ b/content/docs/hoon/reference/stdlib/2n.md
@@ -19,7 +19,7 @@ Build `f` such that `(f x) .= (b (a x))`.
 #### Source
 
 ```hoon
-    ++  cork  |*([a=_|=(* **) b=gate] (corl b a))
+++  cork  |*([a=$-(* *) b=$-(* *)] (corl b a))
 ```
 
 #### Examples
@@ -27,13 +27,12 @@ Build `f` such that `(f x) .= (b (a x))`.
 ```
     > (:(cork dec dec dec) 20)
     17
-
-    > =mal (mo (limo a+15 b+23 ~))
-    > ((cork ~(got by mal) dec) %a)
-    14
-
-    > ((cork ~(got by mal) dec) %b)
-    22
+    
+    > `@ub`(bex (met 0 23))
+    0b10.0000
+    
+    > `@ub`((cork (cury met 0) bex) 23)
+    0b10.0000
 ```
 
 ---
@@ -52,11 +51,12 @@ Build `f` such that
 #### Source
 
 ```hoon
-    ++  corl
-      |*  [a=gate b=_|=(* **)]
-      =<  +:|.((a (b)))      ::  span check
-      |*  c=_+<.b
-      (a (b c))
+++  corl                                                ::  compose backwards
+  |*  [a=$-(* *) b=$-(* *)]
+  =<  +:|.((a (b)))      ::  type check
+  =+  c=+<.b
+  |@  ++  $  (a (b c))
+  --
 ```
 
 #### Examples


### PR DESCRIPTION
The code was out of date and the example no longer worked (`+mo` no longer
exists, and using `my` instead results in a `mull-grow` error)