### PR TITLE
add marks section to clay docs

### DIFF
--- a/content/docs/arvo/clay/clay.md
+++ b/content/docs/arvo/clay/clay.md
@@ -5,7 +5,6 @@ template = "doc.html"
 aliases = ["/docs/learn/arvo/clay/"]
 +++
 
-
 Our filesystem.
 
 `%clay` is version-controlled, referentially-transparent, and global.
@@ -56,3 +55,7 @@ Details of the various `task`s you can use to interact with Clay.
 [Examples](/docs/arvo/clay/examples)
 
 Example usage of the various Clay `task`s.
+
+[Marks](/docs/arvo/clay/marks/marks)
+
+Details of `mark`s as well as a guide to writing them and their usage.

--- a/content/docs/arvo/clay/marks/_index.md
+++ b/content/docs/arvo/clay/marks/_index.md
@@ -1,0 +1,23 @@
++++
+title = "Marks"
+weight = 10
+sort_by = "weight"
+template = "sections/docs/chapters.html"
+insert_anchor_links = "right"
++++
+
+[Overview](/docs/arvo/clay/marks/marks)
+
+Overview of `mark`s.
+
+[Writing Marks](/docs/arvo/clay/marks/writing-marks)
+
+A practical walk-through of writing a `mark` file.
+
+[Using Marks](/docs/arvo/clay/marks/using-marks)
+
+Details of using `mark` conversion gates and `mark` cores in your own code.
+
+[Examples](/docs/arvo/clay/marks/examples)
+
+The example code used in the Writing Marks guide.

--- a/content/docs/arvo/clay/marks/examples.md
+++ b/content/docs/arvo/clay/marks/examples.md
@@ -1,0 +1,248 @@
++++
+title = "Examples"
+weight = 4
+template = "doc.html"
++++
+
+These are the files used in the [Writing Marks](/docs/arvo/clay/marks/writing-marks) guide.
+
+## `/lib/csv/hoon`
+
+```hoon
+|%
+++  validate                                             ::  All rows same length?
+  |=  csv=(list (list @t))
+  ^-  ?
+  =/  result
+    %+  roll  csv
+    |=  [row=(list @t) =flag ref=(unit @ud)]
+    ?.  flag
+      [flag ref]
+    ?~  ref
+      [flag `(lent row)]
+    ?.  =(u.ref (lent row))
+      [%.n ref]
+    [flag ref]
+  flag.result
+++  en-csv                                              ::  csv -> atom (to mime)
+  |=  csv=(list (list @t))
+  |^  ^-  @t
+  (cat 3 (crip (join '\0a' (turn csv en-row))) '\0a')
+  ++  en-row                                            ::  encode row
+    |=  row=(list @t)
+    ^-  @t
+    (crip (join ',' (turn row en-field)))
+  ++  en-field                                          ::  encode field
+    |=  field=@t
+    ^-  @t
+    %+  rash
+      field
+    %+  cook
+      |=  =tape
+      ^-  @t
+      ?~  tape  ''
+      ?:  =('"' i.tape)
+        (cat 3 (crip tape) '"')
+      (crip tape)
+    ;~  pose
+      (full (star ;~(less (mask "\",\0a\0d") next)))
+      ;~  plug
+        (easy '"')
+        (star ;~(pose (cold '""' doq) next))
+      ==
+    ==
+  --
+++  de-csv                                               ::  atom -> csv (from mime)
+  |=  dat=@t
+  |^  ^-  (list (list @t))
+  =/  parsed  (parse dat)
+  ?.  (validate parsed)
+    ~|(%mixed-col-count !!)
+  parsed
+  ++  parse                                              ::  parse cord
+    |=  dat=@t
+    |^  ^-  (list (list @t))
+    %+  rash
+      dat
+    %+  most
+      ;~(pose (jest '\0d\0a') (mask "\0a\0d"))
+    (most com parse-field)
+    ++  parse-field                                      ::  parse field from cord
+      |^
+      %+  cook
+        |=(a=tape (crip a))
+      ;~(pose unenclosed enclosed)
+      ++  unenclosed                                     ::  unquoted field
+        ;~  sfix
+          (star ;~(less (mask "\",\0a\0d") next))
+          ;~  pose
+            ;~  plug
+              ;~(pose (jest '\0d\0a') (mask "\0a\0d"))
+              ;~(less next (easy ~))
+            ==
+            ;~(less doq (easy ~))
+          ==
+        ==
+      ++  enclosed                                       ::  quoted field
+        |^
+        ;~  sfix
+          (ifix [prefix suffix] content)
+          ;~  pose
+            ;~(simu (mask ",\0a\0d") (easy ~))
+            ;~  plug
+              ;~(pose (jest '\0d\0a') (mask "\0a\0d"))
+              ;~(less next (easy ~))
+            ==
+            ;~(less next (easy ~))
+          ==
+        ==
+        ++  content                                      ::  quoted field contents
+          %-  star
+          ;~  pose
+            (cold '"' (jest '""'))
+            %+  cold  '\0a'
+            ;~(pose (jest '\0d\0a') (just '\0d'))
+            ;~(less doq next)
+          ==
+        ++  prefix  ;~(pose ;~(plug (star ace) doq) doq) ::  quoted field prefix
+        ++  suffix  ;~(pose ;~(plug doq (star ace)) doq) ::  quoted field suffix
+        --
+      --
+    --
+  --
+++  csv-join
+  |=  [ali=(urge:clay (list @t)) bob=(urge:clay (list @t))]
+  ^-  (unit (urge:clay (list @t)))
+  |^
+  =.  ali  (clean ali)
+  =.  bob  (clean bob)
+  |-  ^-  (unit (urge:clay (list @t)))
+  ?~  ali  `bob
+  ?~  bob  `ali
+  ?-    -.i.ali
+      %&
+    ?-    -.i.bob
+        %&
+      ?:  =(p.i.ali p.i.bob)
+        %+  bind  $(ali t.ali, bob t.bob)
+        |=(cud=(urge:clay (list @t)) [i.ali cud])
+      ?:  (gth p.i.ali p.i.bob)
+        %+  bind  $(p.i.ali (sub p.i.ali p.i.bob), bob t.bob)
+        |=(cud=(urge:clay (list @t)) [i.bob cud])
+      %+  bind  $(ali t.ali, p.i.bob (sub p.i.bob p.i.ali))
+      |=(cud=(urge:clay (list @t)) [i.ali cud])
+    ::
+        %|
+      ?:  =(p.i.ali (lent p.i.bob))
+        %+  bind  $(ali t.ali, bob t.bob)
+        |=(cud=(urge:clay (list @t)) [i.bob cud])
+      ?:  (gth p.i.ali (lent p.i.bob))
+        %+  bind  $(p.i.ali (sub p.i.ali (lent p.i.bob)), bob t.bob)
+        |=(cud=(urge:clay (list @t)) [i.bob cud])
+      ~
+    ==
+  ::
+      %|
+    ?-  -.i.bob
+        %|
+      ?.  =(i.ali i.bob)
+        ~
+      %+  bind  $(ali t.ali, bob t.bob)
+      |=(cud=(urge:clay (list @t)) [i.ali cud])
+    ::
+        %&
+      ?:  =(p.i.bob (lent p.i.ali))
+        %+  bind  $(ali t.ali, bob t.bob)
+        |=(cud=(urge:clay (list @t)) [i.ali cud])
+      ?:  (gth p.i.bob (lent p.i.ali))
+        %+  bind  $(ali t.ali, p.i.bob (sub p.i.bob (lent p.i.ali)))
+        |=(cud=(urge:clay (list @t)) [i.ali cud])
+      ~
+    ==
+  ==
+  ++  clean                                          ::  clean
+    |=  wig=(urge:clay (list @t))
+    ^-  (urge:clay (list @t))
+    ?~  wig  ~
+    ?~  t.wig  wig
+    ?:  ?=(%& -.i.wig)
+      ?:  ?=(%& -.i.t.wig)
+        $(wig [[%& (add p.i.wig p.i.t.wig)] t.t.wig])
+      [i.wig $(wig t.wig)]
+    ?:  ?=(%| -.i.t.wig)
+      $(wig [[%| (welp p.i.wig p.i.t.wig) (welp q.i.wig q.i.t.wig)] t.t.wig])
+    [i.wig $(wig t.wig)]
+  --
+--
+```
+
+## `/mar/csv/hoon`
+
+```hoon
+/+  *csv
+|_  csv=(list (list @t))
+++  grab
+  |%
+  ++  mime  |=((pair mite octs) (de-csv q.q))
+  ++  noun
+    |=  n=*
+    ^-  (list (list @t))
+    =/  result  ((list (list @t)) n)
+    ?>  (validate result)
+    result
+  --
+++  grow
+  |%
+  ++  mime
+    ?>  (validate csv)
+    [/text/csv (as-octs:mimes:html (en-csv csv))]
+  ++  noun
+    ?>  (validate csv)
+    csv
+  --
+++  grad
+  |%
+  ++  form  %csv-diff
+  ++  diff
+    |=  bob=(list (list @t))
+    ^-  (urge:clay (list @t))
+    ?>  (validate csv)
+    ?>  (validate bob)
+    (lusk:differ csv bob (loss:differ csv bob))
+  ++  pact
+    |=  dif=(urge:clay (list @t))
+    ^-  (list (list @t))
+    =/  result  (lurk:differ csv dif)
+    ?>  (validate result)
+    result
+  ++  join
+    |=  $:  ali=(urge:clay (list @t))
+            bob=(urge:clay (list @t))
+        ==
+    ^-  (unit (urge:clay (list @t)))
+    (csv-join ali bob)
+  ++  mash
+    |=  $:  [ship desk (urge:clay (list @t))]
+            [ship desk (urge:clay (list @t))]
+        ==
+    ^-  (urge:clay (list @t))
+    ~|(%csv-mash !!)
+  --
+--
+```
+
+## `/mar/csv-diff/hoon`
+
+```hoon
+|_  dif=(urge:clay (list @t))
+++  grab
+  |%
+  ++  noun  (urge:clay (list @t))
+  --
+++  grow
+  |%
+  ++  noun  dif
+  --
+++  grad  %noun
+--
+```

--- a/content/docs/arvo/clay/marks/examples.md
+++ b/content/docs/arvo/clay/marks/examples.md
@@ -6,7 +6,7 @@ template = "doc.html"
 
 These are the files used in the [Writing Marks](/docs/arvo/clay/marks/writing-marks) guide.
 
-## `/lib/csv/hoon`
+## `/lib/csv-mark/hoon`
 
 ```hoon
 |%

--- a/content/docs/arvo/clay/marks/examples.md
+++ b/content/docs/arvo/clay/marks/examples.md
@@ -6,7 +6,7 @@ template = "doc.html"
 
 These are the files used in the [Writing Marks](/docs/arvo/clay/marks/writing-marks) guide.
 
-## `/lib/csv-mark/hoon`
+## `/lib/csv/hoon`
 
 ```hoon
 |%

--- a/content/docs/arvo/clay/marks/marks.md
+++ b/content/docs/arvo/clay/marks/marks.md
@@ -34,7 +34,7 @@ Here's its basic structure in an informal pseudocode:
   ++  mash: (<diff-type>, <diff-type>) -> <diff-type>
 ```
 
-These types are basically what you would expect. In `+grab` and `+grow`, only a `+noun` arm is mandatory, the rest are optional. In `+grad`, all arms are mandatory unless revision control is delegated to another `mark`, which we'll discuss later.
+These types are basically what you would expect. In `+grab`, only a `+noun` arm is mandatory, the rest are optional. The `+grow` arm itself is optional, as are any arms within it. In `+grad`, all arms are mandatory unless revision control is delegated to another `mark`, which we'll discuss later.
 
 In general, for a particular `mark`, the `+grab` and `+grow` entries should be inverses of each other. They needn't be symmetrical though - you may want to be able to convert from your `mark` to `%json` but not from `%json` to your `mark`, for example.
 
@@ -44,7 +44,7 @@ In `+grad`, `+diff` takes two instances of a `mark` and produces a diff of them 
 
 Alternately, instead of `+form`, `+diff`, `+pact`, `+join`, and `+mash`, a `mark` can provide the same functionality by defining `+grad` to be the name of another `mark` to which we wish to delegate the revision control responsibilities. Then, before running any of those functions, Clay will convert to the other `mark`, and convert back afterward. For example, the `%hoon` `mark` is revision-controlled in the same way as `%txt`, so its `+grad` is simply `++ grad %txt`. Of course, `+txt` must be defined in `+grow` and `+grab` as well.
 
-We mentioned that `+noun` is the only mandatory arm in `+grab` and `+grow`, but there are a couple of others that, while not mandatory, are of particular interest.
+We mentioned that `+noun` is the only mandatory arm in `+grab`, but there are a couple of others that, while not mandatory, are of particular interest.
 
 The first is a `+mime` arm for converting to and from the `%mime` `mark`. When you `|commit` a file to a `desk` mounted to Unix, Clay will receive the data as a `%mime` `mark`, and then convert it to the `mark` matching the file extension. It will perform the same operation in reverse when mounting a `desk` to Unix. For this reason, any `mark` you wish to be able to access from the Unix filesystem should have `%mime` conversion routines. In certain cases (such as the scry interface), Eyre will also need to convert your `mark` to a `%mime` in order to encode it in an HTTP response, so you may require a `+mime` arm for that reason as well.
 

--- a/content/docs/arvo/clay/marks/marks.md
+++ b/content/docs/arvo/clay/marks/marks.md
@@ -8,7 +8,9 @@ Clay is a typed filesystem, and we call these file types `mark`s. When talking a
 
 For example, a `%txt` `mark` defines the type of a `%txt` file as a `wain` (a `(list @t)`). It defines a conversion function to a `%mime` `mark` to allow it to be serialized and sent to a browser or to the Unix filesystem. It also includes Hunt-McIlroy diff, patch, and merge algorithms. Conversion functions will be different for different `mark`s, as will things like diff algorithms. An image file like a `%png`, for example, just replaces the old blob of data with the new one rather than implementing a complex binary diff and patch algorithm, so how these functions are implemented depends on the file type and use case.
 
-More formally, a `mark` is a door (a core with a sample) with three arms: `+grab`, `+grow`, and `+grad`. The door's sample defines its type. In `+grab` is a series of functions to convert from other `mark`s to the given `mark`. In `+grow` is a series of functions to convert from the given `mark` to other `mark`s. In `+grad` is `+diff`, `+pact`, `+join`, `+mash`, and `+form`.
+`mark` files are stored in the `/mar` directory. The `path` of the `%txt` `mark`, for example, is `/mar/txt/hoon`.
+
+A `mark` is a door (a core with a sample) with three arms: `+grab`, `+grow`, and `+grad`. The door's sample defines its type. In `+grab` is a series of functions to convert from other `mark`s to the given `mark`. In `+grow` is a series of functions to convert from the given `mark` to other `mark`s. In `+grad` is `+diff`, `+pact`, `+join`, `+mash`, and `+form`.
 
 Here's its basic structure in an informal pseudocode:
 

--- a/content/docs/arvo/clay/marks/marks.md
+++ b/content/docs/arvo/clay/marks/marks.md
@@ -1,0 +1,57 @@
++++
+title = "Overview"
+weight = 1
+template = "doc.html"
++++
+
+Clay is a typed filesystem, and we call these file types `mark`s. When talking about Hoon and Arvo we'll often talk of types like `@ud`, `(list @t)`, etc. A `mark` will specify such a type for its files, but it does more than just that - it also defines conversion routines to and from other `mark`s, as well as diff, patch, and merge routines.
+
+For example, a `%txt` `mark` defines the type of a `%txt` file as a `wain` (a `(list @t)`). It defines a conversion function to a `%mime` `mark` to allow it to be serialized and sent to a browser or to the Unix filesystem. It also includes Hunt-McIlroy diff, patch, and merge algorithms. Conversion functions will be different for different `mark`s, as will things like diff algorithms. An image file like a `%png`, for example, just replaces the old blob of data with the new one rather than implementing a complex binary diff and patch algorithm, so how these functions are implemented depends on the file type and use case.
+
+More formally, a `mark` is a door (a core with a sample) with three arms: `+grab`, `+grow`, and `+grad`. The door's sample defines its type. In `+grab` is a series of functions to convert from other `mark`s to the given `mark`. In `+grow` is a series of functions to convert from the given `mark` to other `mark`s. In `+grad` is `+diff`, `+pact`, `+join`, `+mash`, and `+form`.
+
+Here's its basic structure in an informal pseudocode:
+
+```
+|_  <mark-type>
+++  grab:
+  ++  noun: <noun> -> <mark-type>
+  ++  mime: <mime> -> <mark-type>
+  ++  txt: <txt> -> <mark-type>
+  ...
+++  grow:
+  ++  noun: <mark-type> -> <noun>
+  ++  mime: <mark-type> -> <mime>
+  ++  txt: <mark-type> -> <txt>
+  ...
+++  grad
+  ++  form: <diff-mark>
+  ++  diff: (<mark-type>, <mark-type>) -> <diff-type>
+  ++  pact: (<mark-type>, <diff-type>) -> <mark-type>
+  ++  join: (<diff-type>, <diff-type>) -> <diff-type> or NULL
+  ++  mash: (<diff-type>, <diff-type>) -> <diff-type>
+```
+
+These types are basically what you would expect. In `+grab` and `+grow`, only a `+noun` arm is mandatory, the rest are optional. In `+grad`, all arms are mandatory unless revision control is delegated to another `mark`, which we'll discuss later.
+
+In general, for a particular `mark`, the `+grab` and `+grow` entries should be inverses of each other. They needn't be symmetrical though - you may want to be able to convert from your `mark` to `%json` but not from `%json` to your `mark`, for example.
+
+In `+grad`, `+diff` takes two instances of a `mark` and produces a diff of them whose `mark` is given by `+form`. `+pact` takes an instance of a `mark` and patches it with the given diff. In general, if `+diff` called with A and B produces diff D, then `+pact` called with A and D should produce B.
+
+`+join` takes two diffs and attempts to merge them into a single diff. If there are conflicts, it produces null. `+mash` takes two diffs and forces a merge, even if there are conflicts. How your `+mash` function force-merges conflicting diffs is up to you. The `%txt` `mark` annotates any conflicts, for example, but there may be other ways. If `+join` of two diffs does not produce null, then `+mash` of the same diffs should produce the same result. Note that `+mash` is not used by Clay in its ordinary filesystem operations, so you may wish to leave it as a dummy arm that crashes if called.
+
+Alternately, instead of `+form`, `+diff`, `+pact`, `+join`, and `+mash`, a `mark` can provide the same functionality by defining `+grad` to be the name of another `mark` to which we wish to delegate the revision control responsibilities. Then, before running any of those functions, Clay will convert to the other `mark`, and convert back afterward. For example, the `%hoon` `mark` is revision-controlled in the same way as `%txt`, so its `+grad` is simply `++ grad %txt`. Of course, `+txt` must be defined in `+grow` and `+grab` as well.
+
+We mentioned that `+noun` is the only mandatory arm in `+grab` and `+grow`, but there are a couple of others that, while not mandatory, are of particular interest.
+
+The first is a `+mime` arm for converting to and from the `%mime` `mark`. When you `|commit` a file to a `desk` mounted to Unix, Clay will receive the data as a `%mime` `mark`, and then convert it to the `mark` matching the file extension. It will perform the same operation in reverse when mounting a `desk` to Unix. For this reason, any `mark` you wish to be able to access from the Unix filesystem should have `%mime` conversion routines. In certain cases (such as the scry interface), Eyre will also need to convert your `mark` to a `%mime` in order to encode it in an HTTP response, so you may require a `+mime` arm for that reason as well.
+
+The second case of interest is the `+json` arm for converting to and from a `%json` `mark`. If, for example, you want to write a Gall agent to which you can subscribe through Eyre's channel system, it must produce data with a `mark` containing `%json` conversion routines. If it doesn't, Eyre will not be able to deliver the data to the subscribed HTTP client in the SSE stream.
+
+## Sections
+
+[Writing Marks](/docs/arvo/clay/marks/writing-marks) - A practical walk-through of writing a `mark` file.
+
+[Using Marks](/docs/arvo/clay/marks/using-marks) - Details of using `mark` conversion gates and `mark` cores in your own code.
+
+[Examples](/docs/arvo/clay/marks/examples) - The example code used in the Writing Marks guide.

--- a/content/docs/arvo/clay/marks/using-marks.md
+++ b/content/docs/arvo/clay/marks/using-marks.md
@@ -1,0 +1,240 @@
++++
+title = "Using Marks"
+weight = 3
+template = "doc.html"
++++
+
+In the last document, [Writing Marks](/docs/arvo/clay/marks/writing-marks), we walked through writing `mark` files and touched on how Clay handles them. They needn't just be left to background Vane processes though, you can also use them yourself in your code.
+
+There are two kinds of cores that Clay can build for you: A `mark` conversion gate and a `mark` core. Each has two kinds: Statically typed and dynamically typed. Clay has a `care` for producing each of these:
+
+- `%b` - Build a dynamically typed `mark` core.
+- `%c` - Build a dynamically typed `mark` conversion gate.
+- `%e` - Build a statically typed `mark` core.
+- `%f` - Build a statically typed `mark` conversion gate.
+
+You can either use these by `%pass`ing Clay a [%warp task](/docs/arvo/clay/tasks#warp) with the appropriate `care`, or else with a [Clay scry](/docs/arvo/clay/scry). In the examples here we've used the latter.
+
+## mark conversion gates
+
+`mark` conversion gates simply convert from one `mark` to another.
+
+### Static
+
+A static `mark` conversion gate looks like `$-(a b)`, where `a` is the type of the `mark` you're converting _from_, and `b` is type of the `mark` you're converting _to_. For example, a `mark` conversion gate from `%txt` to `%mime` would look like `$-(wain mime)`. You'd simply feed it a `wain` and get a `$mime` in return.
+
+#### Example
+
+We get our `%txt` to `%mime` `mark` conversion gate with a `%f` scry like so:
+
+```
+> =txt-to-mime .^($-(wain mime) %cf /===/txt/mime)
+```
+
+Note we had to specify the type of the gate as `$-(wain mime)` in the scry - if the type returned by the scry doesn't match that specification it'll fail. This is where a statically typed `mark` conversion gate differs from the dynamically typed gate, which we'll discuss later.
+
+Now that we have our conversion gate, we can just call it with a valid `wain` and we'll get our `$mime` in return:
+
+```
+> (txt-to-mime ~['foo'])
+[p=/text/plain q=[p=3 q=7.303.014]]
+```
+
+### Dynamic
+
+A dynamically typed `mark` conversion gate is called a `$tube:clay`, and looks like:
+
+```hoon
++$  tube  $-(vase vase)
+```
+
+As you can see from the type definition, it takes and returns a `vase` rather than needing the types explicitly defined. Rather than failing on a type mismatch when the scry is performed, it'll instead fail when it's actually run and fed a `vase` of the wrong type. Apart from handling `vase`s, it otherwise behaves the same as a statically typed `mark` conversion gate.
+
+#### Example
+
+We get our `%txt` to `%mime` `$tube` with a `%c` scry like so:
+
+```
+> =txt-mime-tube .^(tube:clay %cc /===/txt/mime)
+```
+
+And then we can again feed it the `wain` that a `%txt` `mark` wants, only this time it's wrapped in a `vase`:
+
+```
+> !<  mime  (txt-mime-tube !>(~['foo']))
+[p=/text/plain q=[p=3 q=7.303.014]]
+```
+
+We then get our `$mime` back, but also in a `vase`.
+
+## mark cores
+
+While a `mark` conversion gate is built from functions defined in `+grab` and `+grow`, a `mark` core gives you everything in `+grad` so you can create diffs, merge diffs, patch files, etc. An extra arm `+vale` is also included that lets you convert a `noun` to the type the `%mark` takes by running the `+noun` arm of `+grab` in the original `mark` file.
+
+### Static
+
+A statically typed `mark` core is a `(nave:clay a b)` where `a` is the type of the `mark` and `b` is the type for diffs (which is the type of the `mark` specified in `+form:grad`). For example, a static `mark` core for a `%txt` `mark` looks like `(nave:clay wain (urge:clay cord))`.
+
+`+nave:clay` looks like this in full:
+
+```hoon
+++  nave
+  |$  [typ dif]
+  $_
+  ^?
+  |%
+  ++  diff  |~([old=typ new=typ] *dif)
+  ++  form  *mark
+  ++  join  |~([a=dif b=dif] *(unit (unit dif)))
+  ++  mash
+    |~  [a=[ship desk dif] b=[ship desk dif]]
+    *(unit dif)
+  ++  pact  |~([typ dif] *typ)
+  ++  vale  |~(noun *typ)
+  --
+```
+
+In brief, the arms of the core do the following:
+
+- `+form` - `mark` for diffs.
+- `+vale` - Clam `noun` to the `mark`'s type.
+- `+diff` - Create diff of two files.
+- `+pact` - Patch a file with a diff.
+- `+join` - Merge two diffs, returning `~` if there's a conflict.
+- `+mash` - Force merge of two diffs.
+
+#### Examples
+
+First we get the `%txt` `mark` core with a `%e` scry:
+
+```
+> =txt-nave .^((nave:clay wain (urge:clay cord)) %ce /===/txt)
+```
+
+Note we specified the `mark` type `wain` and diff type `(urge:clay cord)` in the `nave` returned by the scry.
+
+We can see the `mark` for diffs with `+form`:
+
+```
+> form.txt-nave
+%txt-diff
+```
+
+To clam a noun to the type of the `mark` (a `wain` in the case of a `%txt` `mark`), we can call `+vale` with a `noun`:
+
+```
+> (vale:txt-nave ~['foo' 'bar'])
+<|foo bar|>
+```
+
+We can create a diff of two files with `+diff`:
+
+```
+> (diff:txt-nave ~['foo' 'bar' 'baz'] ~['foo' 'zoo' 'baz'])
+~[[%.y p=1] [%.n p=<|bar|> q=<|zoo|>] [%.y p=1]]
+```
+
+Let's create some more diffs for experimentation:
+
+```
+> =diff-a (diff:txt-nave ~['foo' 'bar' 'baz'] ~['foo' 'zoo' 'baz'])
+> =diff-b (diff:txt-nave ~['foo' 'bar' 'baz'] ~['zap' 'bar' 'baz'])
+> =diff-c (diff:txt-nave ~['foo' 'bar' 'baz'] ~['foo' 'bla' 'baz'])
+```
+
+If we try merging diffs `a` and `b` with `+join`, we get a new merged diff back in a `unit`:
+
+```
+> (join:txt-nave diff-a diff-b)
+[~ [~ ~[[%.n p=<|foo|> q=<|zap|>] [%.n p=<|bar|> q=<|zoo|>] [%.y p=1]]]]
+```
+
+If we try merging diffs `a` and `c` however, we get `~` because of a conflict:
+
+```
+> (join:txt-nave diff-a diff-c)
+[~ ~]
+```
+
+If we run `+mash` on `a` and `b` we get the same diff as with `+join` (sans the `unit`):
+
+```
+> (mash:txt-nave [our %home diff-a] [our %blah diff-b])
+[~ ~[[%.n p=<|foo|> q=<|zap|>] [%.n p=<|bar|> q=<|zoo|>] [%.y p=1]]]
+```
+
+If we `+mash` `a` and `c`, however, we get a diff with the conflict annotated rather than just `~`:
+
+```
+> (mash:txt-nave [our %home diff-a] [our %blah diff-c])
+[ ~
+  ~[
+    [%.y p=1]
+    [ %.n
+      p=<|bar|>
+        q
+      <|>>>>>>>>>>>> ~zod/home zoo ++++++++++++ bar ------------ bla <<<<<<<<<<<< ~zod/blah|>
+    ]
+    [%.y p=1]
+  ]
+]
+```
+
+Note that the `%txt` `mark` annotates conflicts, but there are no specific rules around how the `+mash` arm should force-merge conflicting diffs apart from that it must return a valid diff, however the `mark` specified in `+form` defines that.
+
+Finally, we can patch our `wain` with diff `a` and get a new, modified `wain`:
+
+```
+> (pact:txt-nave ~['foo' 'bar' 'baz'] diff-a)
+<|foo zoo baz|>
+```
+
+### Dynamic
+
+A dynamically typed `mark` core is a `$dais:clay`, which looks like:
+
+```hoon
++$  dais
+  $_  ^|
+  |_  sam=vase
+  ++  diff  |~(new=_sam *vase)
+  ++  form  *mark
+  ++  join  |~([a=vase b=vase] *(unit (unit vase)))
+  ++  mash
+    |~  [a=[ship desk diff=vase] b=[ship desk diff=vase]]
+    *(unit vase)
+  ++  pact  |~(diff=vase sam)
+  ++  vale  |~(noun sam)
+  --
+```
+
+It has the same arms as the statically typed `mark` core, the difference is that it takes and returns `vase`s rather than the data directly. Additionally, it's a door rather than an ordinary core, and takes the type of the `mark` wrapped in a `vase` as its argument.
+
+#### Examples
+
+We can get a `%txt` `mark` `dais` with a `%b` scry:
+
+```
+> =txt-dais .^(dais:clay %cb /===/txt)
+```
+
+Its `+form` arm functions the same as a static core:
+
+```
+> form.txt-dais
+%txt-diff
+```
+
+So does `+vale` except it returns a `vase`:
+
+```
+> !<  wain  (vale:txt-dais ~['foo' 'bar'])
+<|foo bar|>
+```
+
+All the other arms also deal in `vase`s. Because it's a door, the `+pact` and `+diff` arms take the original file in a `vase` as the door sample rather than being given directly to the arm. Calling `+diff` arm, for example, works like so:
+
+```
+> !<  (urge:clay cord)  (~(diff txt-dais !>(~['foo' 'bar'])) !>(~['foo' 'baz']))
+~[[%.y p=1] [%.n p=<|bar|> q=<|baz|>]]
+```

--- a/content/docs/arvo/clay/marks/using-marks.md
+++ b/content/docs/arvo/clay/marks/using-marks.md
@@ -4,7 +4,7 @@ weight = 3
 template = "doc.html"
 +++
 
-In the last document, [Writing Marks](/docs/arvo/clay/marks/writing-marks), we walked through writing `mark` files and touched on how Clay handles them. They needn't just be left to background Vane processes though, you can also use them yourself in your code.
+In the last document, [Writing Marks](/docs/arvo/clay/marks/writing-marks), we walked through writing `mark` files and touched on how Clay handles them. They needn't just be left to background vane processes though, you can also use them yourself in your code.
 
 There are two kinds of cores that Clay can build for you: A `mark` conversion gate and a `mark` core. Each has two kinds: Statically typed and dynamically typed. Clay has a `care` for producing each of these:
 

--- a/content/docs/arvo/clay/marks/writing-marks.md
+++ b/content/docs/arvo/clay/marks/writing-marks.md
@@ -72,8 +72,6 @@ So with the nature of the `%mime` `mark` hopefully now clear, the reason we want
 
 Since a CSV file on Unix will just be a long string with ASCII or UTF-8 encoding, we can treat `q.q` in the `$mime` as a `cord`, and thus write a parser to convert it to a `(list (list @t))`. For this purpose, here's a library: `csv.hoon`, which you can view in full on the [Examples](/docs/arvo/clay/marks/examples#libcsvhoon) page.
 
-Note there's already a different `csv.hoon` library in `/lib`, but we'll use a separate one for our purposes here.
-
 The library contains four functions:
 
 - `+de-csv` - Parse a CSV `cord` to a `(list (list @t))`.

--- a/content/docs/arvo/clay/marks/writing-marks.md
+++ b/content/docs/arvo/clay/marks/writing-marks.md
@@ -50,7 +50,7 @@ Next we have the `+grab` arm of our door, which contains a core with arms for co
 
 Next is the `+grow` arm which does the inverse of `+grab`, converting _from_ our `mark` _to_ another `mark`. We've also given it a `+noun` arm, this time it will simply return the door's sample named `csv`, which is of course already a `noun`.
 
-Note that the `+noun` arm is _mandatory_ in both `+grab` and `+grow`. Clay cannot build a `mark` core without it. Conversion arms for any other `mark`s apart from `%noun` are optional.
+Note that the `+noun` arm is _mandatory_ in `+grab`. Clay cannot build a `mark` core without it. Conversion arms for any other `mark`s apart from `%noun` are optional.
 
 Finally we have the `+grad` arm. This arm specifies functions for revision control like creating diffs, patching files and so on. In our case, rather than writing all those functions, we've just delegated those tasks to the `%noun` `mark`. We can do this because we've specified conversion routines to and from the `%noun` `mark` in our `+grow` and `+grab` arms. When we modify a file with a `%csv` `mark`, Clay will convert our data to a `%noun` `mark`, execute the necessary `+grad` functions from the `%noun` `mark` file, and then convert it back to a `%csv` `mark` again.
 

--- a/content/docs/arvo/clay/marks/writing-marks.md
+++ b/content/docs/arvo/clay/marks/writing-marks.md
@@ -1,0 +1,331 @@
++++
+title = "Writing Marks"
+weight = 2
+template = "doc.html"
++++
+
+Here we'll walk through a practical example of writing a `mark` file.
+
+We'll create a `mark` for CSV (comma separated values) files, a simple format for storing tabular data in a text file.
+
+CSV files separate fields with commas and rows with line breaks. They look something like:
+
+```
+foo,bar,baz
+blah,blah,blah
+1,2,3
+```
+
+There is a little complexity surrounding special characters in fields and line endings, but otherwise the only other rule is that all rows must have the same number of fields. You can refer to [RFC4180 on the IETF website](https://datatracker.ietf.org/doc/html/rfc4180) for more details.
+
+The simplest way to represent such a structure in urbit is as a `(list (list @t))` like:
+
+```hoon
+[['foo' 'bar' 'baz' ~] ['blah' 'blah' 'blah' ~] ['1' '2' '3' ~] ~]
+```
+
+## A simple mark
+
+Let's begin with the simplest `mark` file:
+
+```hoon
+|_  csv=(list (list @t))
+++  grab
+  |%
+  ++  noun  (list (list @t))
+  --
+++  grow
+  |%
+  ++  noun  csv
+  --
+++  grad  %noun
+--
+```
+
+The door takes a `(list (list @t))` as its sample, and we've given it a face of `csv` so we can easily reference it. Note its face could be anything, it needn't be the name of our `mark`. When we're doing something with data that has a `%csv` `mark` like converting it to another `mark` or creating a diff, this is where our data will reside.
+
+Next we have the `+grab` arm of our door, which contains a core with arms for converting _to_ our `mark` _from_ other `mark`s. We've given it one arm for the `%noun` `mark` - the most generic `mark` which will take any `noun`. Our `+noun` arm will simply clam whatever it's given with the `(list (list @t))` `mold`.
+
+Next is the `+grow` arm which does the inverse of `+grab`, converting _from_ our `mark` _to_ another `mark`. We've also given it a `+noun` arm, this time it will simply return the door's sample named `csv`, which is of course already a `noun`.
+
+Note that the `+noun` arm is _mandatory_ in both `+grab` and `+grow`. Clay cannot build a `mark` core without it. Conversion arms for any other `mark`s apart from `%noun` are optional.
+
+Finally we have the `+grad` arm. This arm specifies functions for revision control like creating diffs, patching files and so on. In our case, rather than writing all those functions, we've just delegated those tasks to the `%noun` `mark`. We can do this because we've specified conversion routines to and from the `%noun` `mark` in our `+grow` and `+grab` arms. When we modify a file with a `%csv` `mark`, Clay will convert our data to a `%noun` `mark`, execute the necessary `+grad` functions from the `%noun` `mark` file, and then convert it back to a `%csv` `mark` again.
+
+So now we have a valid `%csv` `mark` file. If we save this as `csv.hoon` in the `/mar` directory we could store `%csv` data in Clay. This may be sufficient for some applications, but what if we want to import a CSV file from Unix or elsewhere? In the next section, we'll look at conversions to and from a `%mime` `mark` to address this.
+
+## `%mime` conversions
+
+The `$mime` type represents raw data from Unix or elsewhere. For example, if a text file from Unix containing the word `foo` were converted to a `$mime` type in Urbit, it would look something like:
+
+```hoon
+[/text/plain q=[p=3 q=7.303.014]]
+```
+
+`/text/plain` is its [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) and `p.q` is the byte-length of `q.q`, which is the data itself as an `atom`.
+
+The `%mime` `mark` is used by Clay to store and convert `$mime` data. It's an important `mark` for moving files from Unix to Urbit and vice versa. When you add a file to a `desk` you have mounted to Unix and `|commit` the change, Clay will first receive the file as a `%mime` `mark`, then convert from a `%mime` to whatever `mark` matches the file extension. For example, `foo.txt` will be converted from `%mime` to `%txt`. Additionally, data fetched by Iris over HTTP will come in as a `$mime-data:http`, which is an unvalidated form of `$mime` that you may wish to convert to a `%mime` `mark` and then to another `mark`. Likewise with Eyre, some of the lower-level interfaces receive HTTP requests with `$mime-data:http` in them.
+
+So with the nature of the `%mime` `mark` hopefully now clear, the reason we want conversion methods to and from `%mime` in our `%csv` `mark` is so we can import CSV files from Unix and vice versa.
+
+Since a CSV file on Unix will just be a long string with ASCII or UTF-8 encoding, we can treat `q.q` in the `$mime` as a `cord`, and thus write a parser to convert it to a `(list (list @t))`. For this, I've created a `csv.hoon` library, which you can view in full on the [Examples](/docs/arvo/clay/marks/examples#libcsvhoon) page.
+
+The library contains four functions:
+
+- `+de-csv` - Parse a CSV `cord` to a `(list (list @t))`.
+- `+en-csv` - Encode a `(list (list @t))` as a CSV `cord`.
+- `+validate` - Check all rows of `(list (list @t))` are the same length.
+- `+csv-join` - Ignore this for now, we'll use it later on.
+
+The decoding and encoding arms use parsing functions from the Hoon standard library. It's not important to be familiar with parsing in Hoon for our purposes here, but you can have a look at the [Parsing Guide](/docs/hoon/guides/parsing) in the Hoon documentation if you're interested. The important thing to note is that `+de-csv` takes a valid CSV-format `@t` and returns a `(list (list @t))`, and `+en-csv` does the reverse - it takes a `(list (list @t))` and returns a CSV-format `@t`.
+
+Let's try the library in the dojo. After we've added it to `/lib` and run `|commit`, we can build the file:
+
+```
+> =csv -build-file %/lib/csv/hoon
+```
+
+...try decode a CSV-format `@t`:
+
+```
+> (de-csv:csv 'foo,bar,baz\0ablah,blah,blah\0a1,2,3')
+~[<|foo bar baz|> <|blah blah blah|> <|1 2 3|>]
+```
+
+...and try encode a `(list (list @t))` as a CSV-format `@t`:
+
+```
+> (en-csv:csv [['foo' 'bar' 'baz' ~] ['blah' 'blah' 'blah' ~] ['1' '2' '3' ~] ~])
+'foo,bar,baz\0ablah,blah,blah\0a1,2,3\0a'
+```
+
+With that working, we can add an import for our library to our `%csv` `mark` defintion and add a `+mime` arm to both our `+grab` and `+grow` arms:
+
+```hoon
+/+  *csv
+|_  csv=(list (list @t))
+++  grab
+  |%
+  ++  mime  |=((pair mite octs) (de-csv q.q))
+  ++  noun
+    |=  n=*
+    ^-  (list (list @t))
+    =/  result  ((list (list @t)) n)
+    ?>  (validate result)
+    result
+  --
+++  grow
+  |%
+  ++  mime
+    ?>  (validate csv)
+    [/text/csv (as-octs:mimes:html (en-csv csv))]
+  ++  noun
+    ?>  (validate csv)
+    csv
+  --
+++  grad  %noun
+--
+```
+
+In `+grab` we've added a `+mime` arm to convert _from_ a `%mime` `mark` _to_ our `%csv` `mark`. It's a simple gate that takes a `$mime` (specified as `(pair mite octs)` to avoid conflict with the arm name), runs the data through the `+de-csv` function and returns a `(list (list @t))` of the CSV data.
+
+We've also added a `+mime` arm to `+grow` for converting _from_ our `%csv` `mark` _to_ a `%mime` `mark`. We encode our `(list (list @t))` `csv` sample with our `+en-csv` function and then run that through `as-octs:mimes:html` to get a `$octs` (so it has the byte-length). We also add the `/text/csv` MIME type so it's a valid `$mime`.
+
+Additionally, we've used the `+validate` function in a few places to make sure our CSV data has consistent row lengths.
+
+If we save the above mark file as `csv.hoon` in `/mar` and `|commit %home`, we should now be able to import CSV files into Urbit. Let's give it a go. In the root of our `%home` `desk`, let's add a file named `foo.csv` with the following contents:
+
+```
+foo,bar,baz
+blah,blah,blah
+1,2,3
+```
+
+If we now `|commit %home`, we should see it's been successfully added:
+
+```
+> |commit %home
+>=
++ /~zod/home/4/foo/csv
+```
+
+And if we try reading the file with the `-read` thread:
+
+```
+> -read [%x our %home da+now /foo/csv]
+~[<|foo bar baz|> <|blah blah blah|> <|1 2 3|>]
+```
+
+We can see our `%csv` `mark` has successfully converted our `foo.csv` file to a `(list (list @t))` when it was imported.
+
+Let's try the other direction now. We can create a new `bar.csv` files in the root of `%home` from the dojo like so:
+
+```
+> */bar/csv ~[['abc' 'def' ~] ['ghi' 'jkl' ~]]
++ /~zod/home/5/bar/csv
+```
+
+And if we check it in the terminal on the Unix side we can see it's been correctly encoded:
+
+```
+> cat zod/home/bar.csv
+abc,def
+ghi,jkl
+```
+
+So now our `%csv` `mark` lets us move data in and out of Urbit. In the next section, we'll look at the `+grad` arm in more detail.
+
+## `+grad`
+
+So far we've just delegated `+grad` functions to the `%noun` `mark`, but now we'll look at writing our own.
+
+For demonstrative purposes I've just poached the algorithms used in the `+grad` arm of the `%txt` `mark` and modified them to take our `(list (list @t))` type instead of a `wain`. It's not the most efficient algorithm for a CSV file but it'll do the job.
+
+Our diff format will be a `(urge:clay (list @t))`, and we'll use some `differ` functions from `zuse.hoon` like `+loss`, `+lusk` and `+lurk` to produce diffs and apply patches.
+
+The [csv.hoon library](/docs/arvo/clay/marks/examples#lib-csv-hoon) we imported also contains a `+csv-join` function which we'll use in the `+join` arm, just to save space here.
+
+Here's the new `%csv` `mark` defintion:
+
+```hoon
+/+  *csv
+|_  csv=(list (list @t))
+++  grab
+  |%
+  ++  mime  |=((pair mite octs) (de-csv q.q))
+  ++  noun
+    |=  n=*
+    ^-  (list (list @t))
+    =/  result  ((list (list @t)) n)
+    ?>  (validate result)
+    result
+  --
+++  grow
+  |%
+  ++  mime
+    ?>  (validate csv)
+    [/text/csv (as-octs:mimes:html (en-csv csv))]
+  ++  noun
+    ?>  (validate csv)
+    csv
+  --
+++  grad
+  |%
+  ++  form  %csv-diff
+  ++  diff
+    |=  bob=(list (list @t))
+    ^-  (urge:clay (list @t))
+    ?>  (validate csv)
+    ?>  (validate bob)
+    (lusk:differ csv bob (loss:differ csv bob))
+  ++  pact
+    |=  dif=(urge:clay (list @t))
+    ^-  (list (list @t))
+    =/  result  (lurk:differ csv dif)
+    ?>  (validate result)
+    result
+  ++  join
+    |=  $:  ali=(urge:clay (list @t))
+            bob=(urge:clay (list @t))
+        ==
+    ^-  (unit (urge:clay (list @t)))
+    (csv-join ali bob)
+  ++  mash
+    |=  $:  [ship desk (urge:clay (list @t))]
+            [ship desk (urge:clay (list @t))]
+        ==
+    ^-  (urge:clay (list @t))
+    ~|(%csv-mash !!)
+  --
+--
+```
+
+In our modified `+grad` arm, we've replaced the `%noun` delegation with a core containing five arms: `+form`, `+diff`, `+pact`, `+join`, and `+mash`. These arms are all required for a valid `+grad` if it's not delegated to another `mark`. We'll now look at each in detail.
+
+### `+form`
+
+```hoon
+++  form  %csv-diff
+```
+
+`+form` simply specifies the `mark` of the diff file that may be produced by other `+grad` functions. If your diff is the same type as your `mark`, it could just specify itself like `%csv`. In our case our diff is a `(urge:clay (list @t))` rather than a `(list (list @t))`, so we need a separate mark file for the diff itself.
+
+Here's another `mark` file which can be saved as `csv-diff.hoon` in `/mar`:
+
+```hoon
+|_  dif=(urge:clay (list @t))
+++  grab
+  |%
+  ++  noun  (urge:clay (list @t))
+  --
+++  grow
+  |%
+  ++  noun  dif
+  --
+++  grad  %noun
+--
+```
+
+It's very bare-bones, we just need it for our `%csv` `mark` to work. In our `%csv` `mark`, we've specified it as `%csv-diff` in `+form`.
+
+### `+diff`
+
+```hoon
+++  diff
+  |=  bob=(list (list @t))
+  ^-  (urge:clay (list @t))
+  ?>  (validate csv)
+  ?>  (validate bob)
+  (lusk:differ csv bob (loss:differ csv bob))
+```
+
+This arm produces the diff of two `%csv` files. The first `%csv` file will be given as the sample of the parent door, which if you'll recall we gave a face of `csv`. The second `%csv` file will be given as the sample of the gate in `+diff`, which we've named `bob` here. We then just produce the diff of these two files and return it as the type of the mark specified in `+form`, which in our case is `(urge:clay (list @t))` for a `%csv-diff`. Clay will use `+diff` when a file is revised, so it doesn't have to store a whole new copy of the file each time it's modified.
+
+### `+pact`
+
+```hoon
+++  pact
+  |=  dif=(urge:clay (list @t))
+  ^-  (list (list @t))
+  =/  result  (lurk:differ csv dif)
+  ?>  (validate result)
+  result
+```
+
+`+pact` patches a `%csv` file with the given diff. Its gate takes a diff and applies it to the `%csv` given as the sample of the parent door (which we gave a face of `csv`). If the patch succeeds, it will return a new `%csv` file - a valid `(list (list @t))`. When we read a file that's been modified in Clay, Clay will apply all the diffs it has with `+pact` and return the resulting file.
+
+### `+join`
+
+```hoon
+++  join
+  |=  $:  ali=(urge:clay (list @t))
+          bob=(urge:clay (list @t))
+      ==
+  ^-  (unit (urge:clay (list @t)))
+  (csv-join ali bob)
+```
+
+The `+join` arm merges two different diffs. It takes them both as the sample of its gate (which we've named `ali` and `bob`), and returns a new diff wrapped in a `unit` like `(unit (urge:clay (list @t)))`. The `unit` will be `~` if the merge failed due to a conflict. This is used by Clay in some cases when `desk`s are merged. If diff merges are not possible for your use case, you could just have it always return `~`.
+
+### `+mash`
+
+```hoon
+++  mash
+  |=  $:  [ship desk (urge:clay (list @t))]
+          [ship desk (urge:clay (list @t))]
+      ==
+  ^-  (urge:clay (list @t))
+  ~|(%csv-mash !!)
+```
+
+This is like `+join` except it forces a diff merge even if there's a conflict. Rather than returning a `unit`, it just returns the diff - a `(urge:clay (list @t))` in our case. Also unlike `+join`, it takes the `ship` and `desk` each diff came from as well as the diff itself.
+
+The `+mash` arm is not used by Clay in its file revision operations, so it's safe to just make it a dummy arm that crashes as we've done here. If you were to use it, it would likely just be used manually in an agent, thread or generator.
+
+An example of its use would be the `%txt` `mark`, which includes a proper `+mash` function that produces a diff with any conflicts annotated, though how you have `+mash` handle conficts would depend on your use case. If there were no conflicts between the two diffs, it should produce the same diff as the `+join` arm.
+
+## Conclusion
+
+So there you have it, a fully functional `mark` for CSV files. A `mark` file can be as complex or as simple as you'd like, they're very flexible depending on your use case. Additional conversion methods can always be added as they're needed. For example, with just a few lines of code we could add arms for converting CSV files to `%json` or `%txt` and vice versa.
+
+In the next document, we'll look at building and using `mark` cores and `mark` conversion gates in our own code.

--- a/content/docs/arvo/clay/marks/writing-marks.md
+++ b/content/docs/arvo/clay/marks/writing-marks.md
@@ -68,7 +68,7 @@ The `%mime` `mark` is used by Clay to store and convert `$mime` data. It's an im
 
 So with the nature of the `%mime` `mark` hopefully now clear, the reason we want conversion methods to and from `%mime` in our `%csv` `mark` is so we can import CSV files from Unix and vice versa.
 
-Since a CSV file on Unix will just be a long string with ASCII or UTF-8 encoding, we can treat `q.q` in the `$mime` as a `cord`, and thus write a parser to convert it to a `(list (list @t))`. For this, I've created a `csv.hoon` library, which you can view in full on the [Examples](/docs/arvo/clay/marks/examples#libcsvhoon) page.
+Since a CSV file on Unix will just be a long string with ASCII or UTF-8 encoding, we can treat `q.q` in the `$mime` as a `cord`, and thus write a parser to convert it to a `(list (list @t))`. For this purpose, here's a library: `csv-mark.hoon`, which you can view in full on the [Examples](/docs/arvo/clay/marks/examples#libcsv-markhoon) page. Note there's already a `csv.hoon` library in `/lib`, but we're creating a separate one for demonstrative purposes here.
 
 The library contains four functions:
 
@@ -102,7 +102,7 @@ Let's try the library in the dojo. After we've added it to `/lib` and run `|comm
 With that working, we can add an import for our library to our `%csv` `mark` defintion and add a `+mime` arm to both our `+grab` and `+grow` arms:
 
 ```hoon
-/+  *csv
+/+  *csv-mark
 |_  csv=(list (list @t))
 ++  grab
   |%
@@ -179,16 +179,16 @@ So now our `%csv` `mark` lets us move data in and out of Urbit. In the next sect
 
 So far we've just delegated `+grad` functions to the `%noun` `mark`, but now we'll look at writing our own.
 
-For demonstrative purposes I've just poached the algorithms used in the `+grad` arm of the `%txt` `mark` and modified them to take our `(list (list @t))` type instead of a `wain`. It's not the most efficient algorithm for a CSV file but it'll do the job.
+For demonstrative purposes, we can just poach the algorithms used in the `+grad` arm of the `%txt` `mark` and modify them to take our `(list (list @t))` type instead of a `wain`. It's not the most efficient algorithm for a CSV file but it'll do the job.
 
 Our diff format will be a `(urge:clay (list @t))`, and we'll use some `differ` functions from `zuse.hoon` like `+loss`, `+lusk` and `+lurk` to produce diffs and apply patches.
 
-The [csv.hoon library](/docs/arvo/clay/marks/examples#lib-csv-hoon) we imported also contains a `+csv-join` function which we'll use in the `+join` arm, just to save space here.
+The [csv-mark.hoon library](/docs/arvo/clay/marks/examples#libcsv-markhoon) we imported also contains a `+csv-join` function which we'll use in the `+join` arm, just to save space here.
 
 Here's the new `%csv` `mark` defintion:
 
 ```hoon
-/+  *csv
+/+  *csv-mark
 |_  csv=(list (list @t))
 ++  grab
   |%

--- a/content/docs/arvo/clay/marks/writing-marks.md
+++ b/content/docs/arvo/clay/marks/writing-marks.md
@@ -6,7 +6,7 @@ template = "doc.html"
 
 Here we'll walk through a practical example of writing a `mark` file.
 
-We'll create a `mark` for CSV (comma separated values) files, a simple format for storing tabular data in a text file.
+We'll create a `mark` for CSV (comma separated values) files, a simple format for storing tabular data in a text file. Note that there's already a `csv.hoon` `mark` and library, but we'll create new ones for demonstrative purposes. It shouldn't be an issue to overwrite the existing ones on a fakezod.
 
 CSV files separate fields with commas and rows with line breaks. They look something like:
 
@@ -70,7 +70,7 @@ The `%mime` `mark` is used by Clay to store and convert `$mime` data. It's an im
 
 So with the nature of the `%mime` `mark` hopefully now clear, the reason we want conversion methods to and from `%mime` in our `%csv` `mark` is so we can import CSV files from Unix and vice versa.
 
-Since a CSV file on Unix will just be a long string with ASCII or UTF-8 encoding, we can treat `q.q` in the `$mime` as a `cord`, and thus write a parser to convert it to a `(list (list @t))`. For this purpose, here's a library: `csv-mark.hoon`, which you can view in full on the [Examples](/docs/arvo/clay/marks/examples#libcsv-markhoon) page.
+Since a CSV file on Unix will just be a long string with ASCII or UTF-8 encoding, we can treat `q.q` in the `$mime` as a `cord`, and thus write a parser to convert it to a `(list (list @t))`. For this purpose, here's a library: `csv.hoon`, which you can view in full on the [Examples](/docs/arvo/clay/marks/examples#libcsvhoon) page.
 
 Note there's already a different `csv.hoon` library in `/lib`, but we'll use a separate one for our purposes here.
 
@@ -106,7 +106,7 @@ Let's try the library in the dojo. After we've added it to `/lib` and run `|comm
 With that working, we can add an import for our library to our `%csv` `mark` defintion and add a `+mime` arm to both our `+grab` and `+grow` arms:
 
 ```hoon
-/+  *csv-mark
+/+  *csv
 |_  csv=(list (list @t))
 ++  grab
   |%
@@ -187,12 +187,12 @@ For demonstrative purposes, we can just poach the algorithms used in the `+grad`
 
 Our diff format will be a `(urge:clay (list @t))`, and we'll use some `differ` functions from `zuse.hoon` like `+loss`, `+lusk` and `+lurk` to produce diffs and apply patches.
 
-The [csv-mark.hoon library](/docs/arvo/clay/marks/examples#libcsv-markhoon) we imported also contains a `+csv-join` function which we'll use in the `+join` arm, just to save space here.
+The [csv.hoon library](/docs/arvo/clay/marks/examples#libcsvhoon) we imported also contains a `+csv-join` function which we'll use in the `+join` arm, just to save space here.
 
 Here's the new `%csv` `mark` defintion:
 
 ```hoon
-/+  *csv-mark
+/+  *csv
 |_  csv=(list (list @t))
 ++  grab
   |%

--- a/content/docs/arvo/clay/marks/writing-marks.md
+++ b/content/docs/arvo/clay/marks/writing-marks.md
@@ -18,7 +18,7 @@ blah,blah,blah
 
 There is a little complexity surrounding special characters in fields and line endings, but otherwise the only other rule is that all rows must have the same number of fields. You can refer to [RFC4180 on the IETF website](https://datatracker.ietf.org/doc/html/rfc4180) for more details.
 
-The simplest way to represent such a structure in urbit is as a `(list (list @t))` like:
+The simplest way to represent such a structure in Hoon is as a `(list (list @t))` like:
 
 ```hoon
 [['foo' 'bar' 'baz' ~] ['blah' 'blah' 'blah' ~] ['1' '2' '3' ~] ~]

--- a/content/docs/arvo/clay/marks/writing-marks.md
+++ b/content/docs/arvo/clay/marks/writing-marks.md
@@ -18,11 +18,13 @@ blah,blah,blah
 
 There is a little complexity surrounding special characters in fields and line endings, but otherwise the only other rule is that all rows must have the same number of fields. You can refer to [RFC4180 on the IETF website](https://datatracker.ietf.org/doc/html/rfc4180) for more details.
 
-The simplest way to represent such a structure in Hoon is as a `(list (list @t))` like:
+We'll represent such a structure in Hoon as a `(list (list @t))` like:
 
 ```hoon
 [['foo' 'bar' 'baz' ~] ['blah' 'blah' 'blah' ~] ['1' '2' '3' ~] ~]
 ```
+
+We could perhaps create the type with a `$|` rune to include row-length validation in the mold itself, but a `(list (list @t))` is simpler for demonstrative purposes.
 
 ## A simple mark
 
@@ -68,7 +70,9 @@ The `%mime` `mark` is used by Clay to store and convert `$mime` data. It's an im
 
 So with the nature of the `%mime` `mark` hopefully now clear, the reason we want conversion methods to and from `%mime` in our `%csv` `mark` is so we can import CSV files from Unix and vice versa.
 
-Since a CSV file on Unix will just be a long string with ASCII or UTF-8 encoding, we can treat `q.q` in the `$mime` as a `cord`, and thus write a parser to convert it to a `(list (list @t))`. For this purpose, here's a library: `csv-mark.hoon`, which you can view in full on the [Examples](/docs/arvo/clay/marks/examples#libcsv-markhoon) page. Note there's already a `csv.hoon` library in `/lib`, but we're creating a separate one for demonstrative purposes here.
+Since a CSV file on Unix will just be a long string with ASCII or UTF-8 encoding, we can treat `q.q` in the `$mime` as a `cord`, and thus write a parser to convert it to a `(list (list @t))`. For this purpose, here's a library: `csv-mark.hoon`, which you can view in full on the [Examples](/docs/arvo/clay/marks/examples#libcsv-markhoon) page.
+
+Note there's already a different `csv.hoon` library in `/lib`, but we'll use a separate one for our purposes here.
 
 The library contains four functions:
 


### PR DESCRIPTION
- add overview
- add writing marks guide
- add using marks guide
- replace marks section of clay architecture doc with a link to the new
  marks section
- fix up links etc