### PR TITLE
Remove discord link

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -124,11 +124,6 @@ export default function Footer() {
                 <a className="type-bold text-gray">Dev Mailing List</a>
               </div>
             </Link>
-            <Link href="https://discord.gg/CfSKKaB2ep">
-              <div>
-                <a className="mt-2 type-bold text-gray">Support Discord</a>
-              </div>
-            </Link>
             <Link href="https://github.com/urbit/azimuth">
               <div>
                 <a className="mt-2 type-bold text-gray">Governance</a>


### PR DESCRIPTION
Per some small projects @marisarow has slated out for urbit.org, reducing our "support flow" surface area and removing extraneous pathways to receiving help/support for Urbit.