### PR TITLE
rewrite jar/jug examples to get rid of `mo`

### DIFF
--- a/content/docs/hoon/reference/stdlib/2j.md
+++ b/content/docs/hoon/reference/stdlib/2j.md
@@ -18,8 +18,11 @@ A container arm for `++jar` operation arms. A `++jar` is a `++map` of
 `a` is a jar.
 
 ```
-    > ~(. ja (mo (limo a/"ho" b/"he" ~)))
-    <2.dgz [nlr([p={%a %b} q=""]) <414.fvk 101.jzo 1.ypj %164>]>
+> ~(. ja (my [a+1 b+2 ~]))
+< 2.ngd
+  [ a=?(%~ [n=[?(p=%a p=%b) q=@ud] l=nlr([p=?(%a %b) q=@ud]) r=nlr([p=?(%a %b) q=@ud])])
+    <123.zao 45.xig 1.pnw %140>
+  ]
 ```
 
 ---
@@ -47,18 +50,18 @@ A list retrieved from jar `a` using the key `b`.
 Examples
 
 ```
-    > =l (mo `(list ,[@t (list ,@)])`[['a' `(list ,@)`[1 2 3 ~]] ['b' `(list ,@)`[4 5 6 ~]] ~])
-    > l
-    [[p='a' q=~[1 2 3]] [p='b' q=~[4 5 6]]}
+> =l (my [['a' (limo 1 2 3 ~)] ['b' (limo 4 5 6 ~)]~])
+> l
+[n=[p='b' q=[i=4 t=~[5 6]]] l={} r={[p='a' q=[i=1 t=~[2 3]]]}]
 
-    > (~(get ja l) 'a')
-    ~[1 2 3]
+> (~(get ja l) 'a')
+[i=1 t=[i=2 t=~[3]]]
 
-    > (~(get ja l) 'b')
-    ~[4 5 6]
+> (~(get ja l) 'b')
+[i=4 t=[i=5 t=~[6]]]
 
-    > (~(get ja l) 'c')
-    ~
+> (~(get ja l) 'c')
+~
 ```
 
 ---
@@ -86,22 +89,26 @@ Prepend to list
 #### Examples
 
 ```
-    > =l (mo `(list ,[@t (list ,@)])`[['a' `(list ,@)`[1 2 3 ~]] ['b' `(list ,@)`[4 5 6 ~]] ~])
-    > l
-    {[p='a' q=~[1 2 3]] [p='b' q=~[4 5 6]]}
-
-    > (~(add ja l) 'b' 7)
-    {[p='a' q=~[1 2 3]] [p='b' q=~[7 4 5 6]]}
-
-    > (~(add ja l) 'a' 100)
-    {[p='a' q=~[100 1 2 3]] [p='b' q=~[4 5 6]]}
-
-    > (~(add ja l) 'c' 7)
-    {[p='a' q=~[1 2 3]] [p='c' q=~[7]] [p='b' q=~[4 5 6]]}
-
-    > (~(add ja l) 'c' `(list ,@)`[7 8 9 ~])
-    ! type-fail
-    ! exit
+> =l (my [['a' (limo 1 2 3 ~)] ['b' (limo 4 5 6 ~)]~])
+> l
+[n=[p='b' q=[i=4 t=~[5 6]]] l={} r={[p='a' q=[i=1 t=~[2 3]]]}]
+> (~(add ja l) 'a' 100)
+[ n=[p='b' q=[i=4 t=[i=5 t=~[6]]]]
+  l=~
+  r=[n=[p='a' q=[i=100 t=[i=1 t=~[2 3]]]] l=~ r=~]
+]
+> (~(add ja l) 'a' 100)
+[n=[p='b' q=[i=4 t=[i=5 t=~[6]]]] l=~ r=[n=[p='a' q=[i=100 t=[i=1 t=~[2 3]]]] l=~ r=~]]
+> (~(add ja l) 'b' 7)
+[n=[p='b' q=[i=7 t=[i=4 t=~[5 6]]]] l=~ r=[n=[p='a' q=[i=1 t=[i=2 t=~[3]]]] l=~ r=~]]
+> (~(add ja l) 'c' 7)
+[ n=[p='b' q=[i=4 t=[i=5 t=~[6]]]]
+  l=~
+  r=[n=[p='c' q=[i=7 t=~]] l=[n=[p='a' q=[i=1 t=~[2 3]]] l={} r={}] r=~]
+]
+> (~(add ja l) 'c' (limo 7 8 9 ~))
+mull-grow
+mull-nice
 ```
 
 **
@@ -120,8 +127,18 @@ Container arm for jug operation arms. A `++jug` is a `++map` of
 `a` is a jug.
 
 ```
-    > ~(. ju (mo (limo a=(sa "ho") b=(sa "he") ~)))
-    <2.dgz [nlr([p={%a %b} q={nlr(^$1{@tD $1}) nlr(^$3{@tD $3})}]) <414.fvk 101.jzo 1.ypj %164>]>
+> ~(. ju (my [[a (sy 1 ~)] [b (sy 2 ~)] ~]))
+< 5.cws
+  [   a
+    ?(
+      %~
+      [ n=[p=@ub ?(q=%~ q=[?(n=@ud #!) l=nlr(?(@ud #!)) r=nlr(?(@ud #!))])]
+        l=nlr([p=@ub q=?(%~ [?(n=@ud #!) l=nlr(?(@ud #!)) r=nlr(?(@ud #!))])])
+        r=nlr([p=@ub q=?(%~ [?(n=@ud #!) l=nlr(?(@ud #!)) r=nlr(?(@ud #!))])])
+      ]
+    )
+    <123.zao 45.xig 1.pnw %140>
+  ]
 ```
 
 ### `++del:ju`


### PR DESCRIPTION
Addresses #780