### PR TITLE
make operator's manual easier to find

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -77,6 +77,13 @@ export default function Header(props) {
           className="mr-5 type-ui"
           href="/blog"
         >
+          Operator's Manual
+        </ActiveLink>
+        <ActiveLink
+          currentPath={currentPath}
+          className="mr-5 type-ui"
+          href="/using"
+        >
           Blog
         </ActiveLink>
         <ActiveLink

--- a/components/Header.js
+++ b/components/Header.js
@@ -77,7 +77,7 @@ export default function Header(props) {
           className="mr-5 type-ui"
           href="/using"
         >
-          Operator's Manual
+          Manual
         </ActiveLink>
         <ActiveLink
           currentPath={currentPath}

--- a/components/Header.js
+++ b/components/Header.js
@@ -75,14 +75,14 @@ export default function Header(props) {
         <ActiveLink
           currentPath={currentPath}
           className="mr-5 type-ui"
-          href="/blog"
+          href="/using"
         >
           Operator's Manual
         </ActiveLink>
         <ActiveLink
           currentPath={currentPath}
           className="mr-5 type-ui"
-          href="/using"
+          href="/blog"
         >
           Blog
         </ActiveLink>

--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -77,3 +77,12 @@ Or to install `snap` for your distribution, snapcraft provides [installation ins
 </style>
 
 If you'd like to have more direct control over the Urbit virtual machine, or are setting up Urbit on a cloud droplet, try [installation using the command line](/getting-started/cli).
+
+### Next steps
+
+If you haven't already done so, we recommend spending 10 minutes or so reading
+[Understanding Urbit](/understanding-urbit) to get acquainted with the project.
+Then once you've been become acquainted with your ship and explored the network
+for awhile, consider checking out the [Operator's Manual](/using) which provides
+guidance and reference material for operating your ship, as well as explanations
+for Urbit concepts everyone should eventually learn.

--- a/content/using/_index.md
+++ b/content/using/_index.md
@@ -1,10 +1,10 @@
 +++
-title = "Usage Docs"
+title = "Operator's Manual"
 sort_by = "weight"
 template = "sections/docs/chapters.html"
 +++
 
-Welcome to the usage documentation for the Urbit project. This documentation is
+Welcome to the Operator's Manual for the Urbit project. This documentation is
 maintained by [Tlon](https://tlon.io) and the Urbit community in a public
 [Github repository](https://github.com/urbit/urbit.org). Issues and
 contributions are welcome.


### PR DESCRIPTION
Addresses #765

Adds a link to the Operator's Manual (and Understanding Urbit) to the Getting
Started page. Should be uncontroversial.

Also adds a link to the Operator's Manual to the header on the front page. Definitely would
like feedback on this. Clutter on the front page should be avoided, and this
seems like the least useful link among the ones already in the header. So I
would be fine with removing it if anyone feels strongly.

Also changed the title of "Usage Docs" to "Operator's Manual", which is the name
we already use in a few places and sounds much less weird.