### PR TITLE
fix clay examples headers style

### DIFF
--- a/content/docs/arvo/clay/examples.md
+++ b/content/docs/arvo/clay/examples.md
@@ -4,38 +4,6 @@ weight = 7
 template = "doc.html"
 +++
 
-# Contents
-
-- [Introduction](#introduction)
-- [%warp](#warp) - Read and Subscribe.
-  - [%sing](#sing) - Read a file or directory.
-  - [%next](#next) - Subscribe for the next change to a file or directory.
-  - [%mult](#mult) - Subscribe for the next change to a set of files and/or directories.
-  - [%many](#many) - Track changes to a `desk` for the specified range of revisions.
-  - [Cancel Subscription](#cancel-subscription)
-- [%info](#info) - Write and Modify.
-  - [%ins](#ins) - Add a file.
-  - [%del](#del) - Delete a file.
-  - [%mut](#mut) - Change a file.
-  - [Multiple Changes](#multiple-changes) - Change multiple files.
-- [Manage Mounts](#manage-mounts)
-  - [%boat](#boat) - List mounts.
-  - [%mont](#mont) - Mount something.
-  - [%ogre](#ogre) - Unmount something.
-  - [%dirk](#dirk) - Commit changes.
-- [Merge Desks](#merge-desks)
-  - [%merg](#merg)
-- [Permissions](#permissions)
-  - [%perm](#perm) - Set file permissions.
-  - [%cred](#cred) - Add permission group.
-  - [%crew](#crew) - Get permission groups.
-  - [%crow](#crow) - Get group usage.
-- [Foreign Ships](#foreign-ships)
-  - [%warp](#warp-remote) - Read a file on a foreign ship.
-  - [%merg](#merg-remote) - Merge from a foreign `desk`.
-
-# Introduction
-
 This document contains a number of examples of interacting with Clay using its various `task`s. Sections correspond to the general details in the [API Reference](/docs/arvo/clay/tasks) document.
 
 Most examples will either use `|pass` to just send a `task` or the following thread to send a `task` and take the resulting `gift`. You can save the following thread to the `ted` directory of your `%home` `desk`:
@@ -61,11 +29,11 @@ Most examples will either use `|pass` to just send a `task` or the following thr
 (pure:m !>(~))
 ```
 
-# `%warp`
+## `%warp`
 
 See the [Read and Subscribe](/docs/arvo/clay/tasks#warp---read-and-track) section of the [API Reference](/docs/arvo/clay/tasks) document for general details.
 
-## `%sing`
+### `%sing`
 
 Here we'll look at reading files by passing Clay a `%warp` `task` with a `%sing` `rave` and receiving a `%writ` `gift` containing the data in response.
 
@@ -115,7 +83,7 @@ Here's a breakdown of the `task` we sent:
 
 ![%sing diagram](https://media.urbit.org/docs/arvo/clay/sing.png "%sing diagram")
 
-## `%next`
+### `%next`
 
 Here we'll look at subscribing to the next version of a file by passing Clay a `%warp` `task` with a `%next` `rave` and receiving a `%writ` `gift` when the file changes.
 
@@ -151,7 +119,7 @@ Here's a breakdown of the task we sent:
 
 ![%next diagram](https://media.urbit.org/docs/arvo/clay/next.png "%next diagram")
 
-## `%mult`
+### `%mult`
 
 Here we'll look at subscribing to the next version of multiple files by passing Clay a `%warp` `task` with a `%mult` `rave` and receiving a `%wris` `gift` when any of the files change.
 
@@ -210,7 +178,7 @@ Here's a breakdown of the `task` we sent:
 
 ![subscribe mult diagram](https://media.urbit.org/docs/arvo/clay/sub-mult.png "subscribe mult diagram")
 
-## `%many`
+### `%many`
 
 Here we'll look at subscribing to a range of changes to a `desk` by passing Clay a `%warp` `task` with a `%many` `rave` and receiving `%writ` `gift`s when changes occur.
 
@@ -304,7 +272,7 @@ Here's a breakdown of the `task` we sent:
 
 ![subscribe many diagram](https://media.urbit.org/docs/arvo/clay/sub-many.png "subscribe many diagram")
 
-## Cancel Subscription
+### Cancel Subscription
 
 Here we'll look at cancelling a subscription by sending Clay a `%warp` `task` with a null `(unit rave)` in the `riff`.
 
@@ -348,11 +316,11 @@ Here's a breakdown of the `task` we sent:
 
 ![cancel subscription diagram](https://media.urbit.org/docs/arvo/clay/stop-sub.png "cancel subscription diagram")
 
-# `%info`
+## `%info`
 
 See the [Write and Modify](/docs/arvo/clay/tasks#write-and-modify) section of the [API Reference](/docs/arvo/clay/tasks) document for general details.
 
-## `%ins`
+### `%ins`
 
 Here we'll look at adding a file by sending Clay a `%info` `task` containing a `%ins` `miso`.
 
@@ -371,7 +339,7 @@ Here's a breakdown of the `task` we sent:
 
 ![%ins diagram](https://media.urbit.org/docs/arvo/clay/ins.png)
 
-## `%del`
+### `%del`
 
 Here we'll look at deleting a file by sending Clay a `%info` `task` containing a `%del` `miso`.
 
@@ -388,11 +356,11 @@ Here's a breakdown of the `task` we sent:
 
 ![%del diagram](https://media.urbit.org/docs/arvo/clay/del.png)
 
-## `%mut`
+### `%mut`
 
 Identical to the [%ins](#ins) example, just replace `%ins` with `%mut`.
 
-## Multiple Changes
+### Multiple Changes
 
 Here we'll look at changing multiple files in one request by sending Clay a `%info` `task` containing multiple `miso` in the `soba`.
 
@@ -433,11 +401,11 @@ Save to `ted/multi-change.hoon`, `|commit %home`, and run:
 - /~zod/home/38/baz/txt
 ```
 
-# Manage Mounts
+## Manage Mounts
 
 See the [Manage Mounts](/docs/arvo/clay/tasks#manage-mounts) section of the [API Reference](/docs/arvo/clay/tasks) document for general details.
 
-## `%boat`
+### `%boat`
 
 Here we'll look at requesting the list of existing mount points on a ship by sending Clay a `%boat` `task` and receiving a `%hill` `gift`.
 
@@ -448,7 +416,7 @@ Using the `send-task-take-gift.hoon` thread, let's make such a request:
 [%hill p=~[%home]]
 ```
 
-## `%mont`
+### `%mont`
 
 Here we'll look at mounting `desk`s, directories and files to unix by sending Clay a `%mont` `task`.
 
@@ -487,7 +455,7 @@ Let's try mounting a subdirectory and a single folder:
 
 If you look in your pier you'll now see a `gen` folder with the contents of `/gen` and a `hi.hoon` file by itself. Notice how the file extension has been automatically added.
 
-## `%ogre`
+### `%ogre`
 
 Here we'll look at unmounting `desk`s, directories and files by sending Clay a `%ogre` `task`.
 
@@ -518,7 +486,7 @@ If we specify a non-existent mount point it will fail with an error printed to t
 
 If we give it an unmounted `beam` it will not print an error but still won't work.
 
-## `%dirk`
+### `%dirk`
 
 Here we'll look at committing changed files by sending Clay a `%dirk` `task`.
 
@@ -535,11 +503,11 @@ Clay will print the changed files to the dojo with a leading `+`, `-` or `:` to 
 
 If you have the same `desk` mounted to multiple points, a committed change in one mount will also update the others.
 
-# Merge Desks
+## Merge Desks
 
 See the [Merge Desks](/docs/arvo/clay/tasks#merge-desks) section of the [API Reference](/docs/arvo/clay/tasks) document for general details.
 
-## `%merg`
+### `%merg`
 
 Here we'll look at merging `desk`s by sending Clay a `%merg` `task` and receiving a `%mere` `gift` in response.
 
@@ -610,11 +578,11 @@ Now change the text in the `foo.txt` in the `%home` `desk`, hit backspace to det
 
 You can also specify it by revision number or label.
 
-# Permissions
+## Permissions
 
 See the [Permissions](/docs/arvo/clay/tasks#permissions) section of the [API Reference](/docs/arvo/clay/tasks) document for general details.
 
-## `%perm`
+### `%perm`
 
 Here we'll look at setting permissions by sending Clay a `%perm` `task`.
 
@@ -694,7 +662,7 @@ Here's a breakdown of a `%perm` task:
 
 ![perm diagram](https://media.urbit.org/docs/arvo/clay/perm-diagram.png)
 
-## `%cred`
+### `%cred`
 
 Here we'll look at creating a permission group by sending Clay a `%cred` `task`.
 
@@ -706,7 +674,7 @@ Let's create a group called `'foo'` with a few ships:
 
 We'll check it with the next kind of `task`: [%crew](#crew).
 
-## `%crew`
+### `%crew`
 
 Here we'll look at retrieving permission groups by sending Clay a `%crew` `task` and receiving a `%cruz` `gift` in response.
 
@@ -717,7 +685,7 @@ Let's check, using the `send-task-take-gift.hoon` thread, for the permission gro
 [%cruz cez={[p=~.foo q={~nec ~bud ~wes ~zod ~sev}]}]
 ```
 
-## `%crow`
+### `%crow`
 
 Here we'll look at retrieving a list of all files and directories in all `desk`s which have permissions set for a group by sending Clay a `%crow` `task` and receiving a `%croz` `gift` in response.
 
@@ -749,11 +717,11 @@ Now we'll use the `send-task-take-gift.hoon` thread to try `%crow`:
 ]
 ```
 
-# Foreign Ships
+## Foreign Ships
 
 See the [Foreign Ships](/docs/arvo/clay/tasks#foreign-ships) section of the [API Reference](/docs/arvo/clay/tasks) document for general details.
 
-## `%warp` - Remote
+### `%warp` - Remote
 
 Here we'll look at reading files on a foreign ship by sending Clay a `%warp` `task` with a foreign ship in the `wer` field and receiving a `%writ` `gift` in response.
 
@@ -816,7 +784,7 @@ call: failed
 /sys/vane/clay/hoon:<[1.365 48].[1.365 50]>
 ```
 
-## `%merg` - Remote
+### `%merg` - Remote
 
 To merge a foreign `desk` into a local one, you just send Clay a `%merg` `task` (as you would for a local merge) and specify the foreign ship in the `her` field. For an example, see the [%merg](#merg) section.
 


### PR DESCRIPTION
- remove redundant contents section
- rejigger headers so they render nicely in sidebar