### PR TITLE
Syntax highlighting fix

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+unsafe-perm = true

--- a/components/Markdown.js
+++ b/components/Markdown.js
@@ -43,20 +43,7 @@ export default async function Markdown({ post }) {
     })
     .use(slug)
     .use(heading)
-    .process(post.content)
-    .then(
-      (file) => {
-        // console.error(reporter(file))
-
-        // console.log(String(file))
-        return file.toString();
-      },
-      (error) => {
-        // Handle your error here!
-        console.log("error", error);
-        throw error;
-      }
-    );
+    .process(post.content);
 
   return result.toString();
 }

--- a/components/Markdown.js
+++ b/components/Markdown.js
@@ -43,7 +43,20 @@ export default async function Markdown({ post }) {
     })
     .use(slug)
     .use(heading)
-    .process(post.content);
+    .process(post.content)
+    .then(
+      (file) => {
+        // console.error(reporter(file))
+
+        // console.log(String(file))
+        return file.toString();
+      },
+      (error) => {
+        // Handle your error here!
+        console.log("error", error);
+        throw error;
+      }
+    );
 
   return result.toString();
 }


### PR DESCRIPTION
Vercel could not run the postinstall script which applies the hoon syntax highlighting patch to remark-prism. This PR sets `unsafe-perm` to true to enable this script to run.