### PR TITLE
fix docs github link

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -6,7 +6,7 @@ template = "sections/docs.html"
 
 Welcome to the developer documentation for the Urbit project. This documentation
 is maintained by [Tlon](https://tlon.io) and the Urbit community in a public
-[Github repository](https://github.com/urbit/docs). Issues and contributions are
+[Github repository](https://github.com/urbit/urbit.org/tree/master/content/docs). Issues and contributions are
 welcome.
 
 This documentation provides a series of explainers, guides, tutorials and


### PR DESCRIPTION
- link to GH repo in docs index goes to old archived docs. Updated to
  new urbit.org repo.

resolves #1159 