### PR TITLE
docs: fix code block formatting

### DIFF
--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -1,8 +1,8 @@
-.markdown *:last-child {
+.markdown *:last-child:not(pre) {
   @apply pb-0 mb-0;
 }
 
-.markdown *:first-child {
+.markdown *:first-child:not(pre) {
   @apply pt-0 mt-0;
 }
 
@@ -108,9 +108,13 @@
   @apply bg-green-100 text-green-400;
 }
 
+.markdown pre {
+  @apply block p-4 bg-wall-100 rounded-md;
+}
+
 .markdown pre code,
 .markdown pre[class*="language-"] code {
-  @apply p-4 md:p-8 rounded-xl;
+  @apply p-0 bg-transparent;
 }
 
 .markdown ul {

--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -109,11 +109,11 @@
 }
 
 .markdown pre {
-  @apply block p-4 bg-wall-100 rounded-md;
+  @apply block p-4 bg-wall-100 rounded-md overflow-x-auto;
 }
 
-.markdown pre code,
-.markdown pre[class*="language-"] code {
+.markdown pre > code,
+.markdown pre[class*="language-"] > code {
   @apply p-0 bg-transparent;
 }
 


### PR DESCRIPTION
Adds some styles to `code` blocks wrapped in `pre`. Also allows for overscroll on wide blocks with small main column widths.

Before:
![image](https://user-images.githubusercontent.com/748181/135009757-da7a038e-9b68-433b-af7f-c37b2a6c8584.png)

After: 
![image](https://user-images.githubusercontent.com/748181/135009742-2dd32413-ea64-47bf-a36d-aef605c8446e.png)

Does not address the endemic Markdown parsing issues, but at least treats this visible symptom.

Fixes urbit/urbit.org#1139