### PR TITLE
latest OTA installs FAQ

### DIFF
--- a/content/using/os/dist-faq.md
+++ b/content/using/os/dist-faq.md
@@ -79,6 +79,18 @@ Ships with the OTA will not be able to communicate over graph store with ships w
 
 See above. Once your peers receive the OTA, you will be able to communicate again.
 
+Your sponsor or your sponsor's sponsor also might have only gotten the first OTA
+but not the latest one, if either of them are not Tlon stars/galaxies. Try
+installing from one of Tlon's stars with
+
+```
+|install ~binzod %base
+|install ~binzod %garden
+|install ~binzod %landscape
+|install ~binzod %webterm
+|install ~binzod %bitcoin
+```
+
 **Can I still `|hi` between pre and post OTA ships?**
 
 `|hi` will continue to work between pre and post OTA ships.


### PR DESCRIPTION
The galaxy sponsoring my star only had the first OTA, and then since by
default it wasn't pulling updates from anyone, it didn't get the later ones. I had to run
the `|install ~zod %foo` commands on the galaxy to get it to update and then once it
propagated to my planet I was able to message again. In case anyone else is
under a galaxy like that they may be in a similar boat, so we should tell them
to pull from one of Tlon's stars until their galaxy fixes itself.