### PR TITLE
Update threads docs for dist

### DIFF
--- a/content/docs/userspace/threads/basics/bind.md
+++ b/content/docs/userspace/threads/basics/bind.md
@@ -77,7 +77,7 @@ Here's a simple thread with a couple of `strandio` functions:
 (pure:m !>([s t]))
 ```
 
-Save it as `/ted/mythread.hoon`, `|commit` it and run it with `-mythread`. You should see something like:
+Save it as `/ted/mythread.hoon` of `%base`, `|commit` it and run it with `-mythread`. You should see something like:
 
 ```
 > -mythread

--- a/content/docs/userspace/threads/basics/fundamentals.md
+++ b/content/docs/userspace/threads/basics/fundamentals.md
@@ -15,23 +15,22 @@ Threads are managed by the gall agent called `spider`.
 
 ## Thread location
 
-Threads live in the `ted` directory of your desk:
+Threads live in the `ted` directory of each desk. For example, in a desk named `%sandbox`:
 
 ```
-%
+%sandbox
 ├──app
 ├──gen
 ├──lib
 ├──mar
 ├──sur
-├──sys
 └──ted <-
    ├──foo
    │  └──bar.hoon
    └──baz.hoon
 ```
 
-From the dojo, `ted/baz.hoon` can be run with `-baz`, and `ted/foo/bar.hoon` with `-foo-bar`.
+From the dojo, `ted/baz.hoon` can be run with `-sandbox!baz`, and `ted/foo/bar.hoon` with `-sandbox!foo-bar`. Threads in the `%base` desk can just be run like `-foo`, but all others must have the format `-desk!thread`.
 
 **NOTE:** When the dojo sees the `-` prefix it automatically handles creating a thread ID, composing the argument, poking the `spider` gall agent and subscribing for the result. Running a thread from another context (eg. a gall agent) requires doing these things explicitly and is outside the scope of this particular tutorial.
 
@@ -57,7 +56,7 @@ That is, a gate which takes a `vase` and returns the `form` of a `strand` that p
 
 ![thread diagram](https://storage.googleapis.com/media.urbit.org/site/thread-diagram.png "diagram of a thread")
 
-This is because threads typically do a bunch of I/O so it can't just immediately produce a result and end. Instead the strand will get some input, produce output, get some new input, produce new output, and so forth, until they eventually produce a `%done` with the actual final result. 
+This is because threads typically do a bunch of I/O so it can't just immediately produce a result and end. Instead the strand will get some input, produce output, get some new input, produce new output, and so forth, until they eventually produce a `%done` with the actual final result.
 
 ## Strands
 
@@ -66,9 +65,10 @@ Strands are the building blocks of threads. A thread will typically compose mult
 A strand is a function of `strand-input:strand -> output:strand` and is defined in `/lib/strand/hoon`. You can see the details of `strand-input` [here](https://github.com/urbit/urbit/blob/master/pkg/arvo/lib/strand.hoon#L2-L21) and `output:strand` [here](https://github.com/urbit/urbit/blob/master/pkg/arvo/lib/strand.hoon#L23-L48). At this stage you don't need to know the nitty-gritty but it's helpful to have a quick look through. We'll discuss these things in more detail later.
 
 A strand is a core that has three important arms:
+
 - `form` - the mold of the strand
 - `pure` - produces a strand that does nothing except return a value
-- `bind` - monadic bind, like `then` in javascript promises 
+- `bind` - monadic bind, like `then` in javascript promises
 
 We'll discuss each of these arms later.
 
@@ -81,7 +81,7 @@ Strands are conventionally given the face `m` like:
 ...
 ```
 
-**NOTE:** a comma prefix as in `,vase` is the irregular form of `^:` which is a gate that returns the sample value if it's of the correct type, but crashes otherwise. 
+**NOTE:** a comma prefix as in `,vase` is the irregular form of `^:` which is a gate that returns the sample value if it's of the correct type, but crashes otherwise.
 
 ## Form and Pure
 
@@ -104,19 +104,18 @@ We'll cover `bind` later.
 ## A trivial thread
 
 ```hoon
-/-  spider 
-=,  strand=strand:spider 
-^-  thread:spider 
-|=  arg=vase 
-=/  m  (strand ,vase) 
-^-  form:m 
+/-  spider
+=,  strand=strand:spider
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
 (pure:m arg)
 ```
 
 The above code is a simple thread that just returns its argument, and it's a good boilerplate to start from.
 
 Save the above code as a file in `ted/mythread.hoon` and `|commit` it. Run it with `-mythread 'foo'`, you should see the following:
-
 
 ```
 > -mythread 'foo'
@@ -130,8 +129,8 @@ Save the above code as a file in `ted/mythread.hoon` and `|commit` it. Run it wi
 We'll go through it line-by line.
 
 ```hoon
-/-  spider 
-=,  strand=strand:spider 
+/-  spider
+=,  strand=strand:spider
 ```
 
 First we import `/sur/spider/hoon` which includes `/lib/strand/hoon` and give give the latter the face `strand` for convenience.
@@ -155,7 +154,7 @@ We create a gate that takes a vase, the first part of the previously mentioned t
 Inside the gate we create our `strand` specialised to produce a `vase` and give it the canonical face `m`.
 
 ```hoon
-^-  form:m 
+^-  form:m
 ```
 
 We cast the output to `form` - the mold of the strand we created.

--- a/content/docs/userspace/threads/examples/child-thread.md
+++ b/content/docs/userspace/threads/examples/child-thread.md
@@ -34,7 +34,7 @@ Here's a simple example of a thread that starts another thread:
 (pure:m !>(~))
 ```
 
-Save `parent.hoon` and `child.hoon` in `/ted`, `|commit %home` and run `-parent`. You should see something like:
+Save `parent.hoon` and `child.hoon` in `/ted` of the `%base` desk, `|commit %base` and run `-parent`. You should see something like:
 
 ```
 foo
@@ -74,7 +74,7 @@ If we want to actually get the result of the thread we started, it's slightly mo
 ;<  ~             bind:m  %-  poke-our
                           :*  %spider
                               %spider-start
-                              !>([`tid.bowl `tid %child !>(~)])
+                              !>([`tid.bowl `tid byk.bowl %child !>(~)])
                           ==
 ;<  =cage         bind:m  (take-fact /awaiting/[tid])
 ;<  ~             bind:m  (take-kick /awaiting/[tid])
@@ -130,14 +130,15 @@ We pre-emptively subscribe for the result. Spider sends the result at `/thread-r
 ;<  ~             bind:m  %-  poke-our
                           :*  %spider
                               %spider-start
-                              !>([`tid.bowl `tid %child !>(~)])
+                              !>([`tid.bowl byk.bowl `tid %child !>(~)])
                           ==
 ```
 
-Spider takes a poke with a mark %spider-start and a vase containing `[parent=(unit tid) use=(unit tid) file=term =vase]` to start a thread, where:
+Spider takes a poke with a mark %spider-start and a vase containing `[parent=(unit tid) use=(unit tid) =beak file=term =vase]` to start a thread, where:
 
 - `parent` is an optional parent thread. In this case we say the parent is our tid. Specifying a parent means the child will be killed if the parent ends.
 - `use` is the thread ID for the thread we're creating
+- `beak` is a `[p=ship q=desk r=case]` triple which specifies the desk and revision containing the thread we want to run. In this case we just use `byk.bowl`.
 - `file` is the filename of the thread we want to start
 - `vase` is the vase it will be given as an argument when it's started
 
@@ -180,7 +181,7 @@ Finally we test whether the thread produced a `%thread-done` or a `%thread-fail`
 ;<  ~             bind:m  %-  poke-our
                           :*  %spider
                               %spider-start
-                              !>([`tid.bowl `tid %child !>(~)])
+                              !>([`tid.bowl byk.bowl `tid %child !>(~)])
                           ==
 ;<  ~             bind:m  (sleep ~s5)
 %-  (slog leaf+"Stopping child thread..." ~)

--- a/content/docs/userspace/threads/examples/get-json.md
+++ b/content/docs/userspace/threads/examples/get-json.md
@@ -75,7 +75,7 @@ Here's a simple thread that will:
 (pure:m !>(~))
 ```
 
-Save it as `/ted/latest-hash.hoon`, `|commit %home` and run it with `-latest-hash`. You should see something like:
+Save it as `/ted/latest-hash.hoon` of the `%base` desk, `|commit %base` and run it with `-latest-hash`. You should see something like:
 
 ```
 > -latest-hash

--- a/content/docs/userspace/threads/examples/main-loop.md
+++ b/content/docs/userspace/threads/examples/main-loop.md
@@ -68,7 +68,7 @@ Here's an example of a thread that subscribes to `graph-store` for updates and n
 (pure:m !>(~))
 ```
 
-Save it in `/ted`, `|commit %home`, and run it with `-chat-watch`. Now try typing some messages in the chat and you should see them printed like:
+Save it in `/ted`, `|commit %base`, and run it with `-chat-watch`. Now try typing some messages in the chat and you should see them printed like:
 
 ```
 ~zod/test-8488: [~zod] x
@@ -103,7 +103,7 @@ Once this is done, main-loop will just call the same function again which will a
 
 To try the same input against multiple function you must use another `strandio` function `handle`. Handle converts a `%skip` into a `[fail %ignore ~]`. When `main-loop` sees a `[fail %ignore ~]` it tries the next function in its list with the same input.
 
-Here are two files: `tester.hoon` and `tested.hoon`. Save them both to `/ted`, `|commit %home` and run `-tester`. You should see:
+Here are two files: `tester.hoon` and `tested.hoon`. Save them both to `/ted` in the `%base` desk, `|commit %base` and run `-tester`. You should see:
 
 ```
 > -tester

--- a/content/docs/userspace/threads/examples/poke-agent.md
+++ b/content/docs/userspace/threads/examples/poke-agent.md
@@ -47,7 +47,7 @@ Here's a thread that lets you post a message to a chat in graph-store:
 (pure:m !>(~))
 ```
 
-Save it in `/ted`, `|commit`, and run it like:
+Save it in `/ted` of the `%base` desk, `|commit %base`, and run it like:
 
 ```
 -post-msg [~zod %foo-9955] 'some message'

--- a/content/docs/userspace/threads/examples/scry.md
+++ b/content/docs/userspace/threads/examples/scry.md
@@ -45,7 +45,7 @@ Here's an example of a thread that scries ames for the IP address & port of a sh
 
 **Note:** Pretty useless on a fake ship.
 
-Save as `ted/get-ip.hoon`, `|commit %home`, and run it with `-get-ip ~bitbet-bolbel`. You should see something like:
+Save as `ted/get-ip.hoon` in the `%base` desk, `|commit %base`, and run it with `-get-ip ~bitbet-bolbel`. You should see something like:
 
 ```
 34.83.113.220:60659

--- a/content/docs/userspace/threads/examples/take-fact.md
+++ b/content/docs/userspace/threads/examples/take-fact.md
@@ -42,7 +42,7 @@ Taking a fact from an agent, arvo or whatever is easy. First you subscribe using
 (pure:m !>(~))
 ```
 
-Create a chat on your fake zod if you don't have one already, then save it in `/ted`, `|commit %home`, and run `-print-msg`. Next, type some message in your chat and you'll see it printed in the dojo.
+Create a chat on your fake zod if you don't have one already, then save the thread in `/ted` on the `%base` desk, `|commit %base`, and run `-print-msg`. Next, type some message in your chat and you'll see it printed in the dojo.
 
 ### Analysis
 

--- a/content/docs/userspace/threads/gall/poke-thread.md
+++ b/content/docs/userspace/threads/gall/poke-thread.md
@@ -29,7 +29,7 @@ Here's a modified agent that pokes our thread. I've replaced some off the previo
         (pair term term)
       =/  tid  `@ta`(cat 3 'thread_' (scot %uv (sham eny.bowl)))
       =/  ta-now  `@ta`(scot %da now.bowl)
-      =/  start-args  [~ `tid p.q.vase !>(q.q.vase)]
+      =/  start-args  [~ `tid byk.bowl p.q.vase !>(q.q.vase)]
       :_  this
       :~
         [%pass /thread/[ta-now] %agent [our.bowl %spider] %watch /thread-result/[tid]]

--- a/content/docs/userspace/threads/gall/start-thread.md
+++ b/content/docs/userspace/threads/gall/start-thread.md
@@ -29,7 +29,7 @@ Here's an example of a barebones gall agent that just starts a thread:
         (pair term term)
       =/  tid  `@ta`(cat 3 'thread_' (scot %uv (sham eny.bowl)))
       =/  ta-now  `@ta`(scot %da now.bowl)
-      =/  start-args  [~ `tid p.q.vase !>(q.q.vase)]
+      =/  start-args  [~ `tid byk.bowl p.q.vase !>(q.q.vase)]
       :_  this
       :~
         [%pass /thread/[ta-now] %agent [our.bowl %spider] %poke %spider-start !>(start-args)]
@@ -76,7 +76,7 @@ And here's a minimal thread to test it with:
 ==
 ```
 
-Save them as `/app/thread-starter.hoon` and `/ted/test-thread.hoon` respectively, `|commit %home`, and start the app with `|start %thread-starter`.
+Save them as `/app/thread-starter.hoon` and `/ted/test-thread.hoon` respectively in the `%base` desk, `|commit %base`, and start the app with `|rein %base [& %thread-starter]`.
 
 Now you can poke it with a pair of thread name and argument like:
 
@@ -116,7 +116,7 @@ We can ignore the input logic, here's the important part:
 ```hoon
 =/  tid  `@ta`(cat 3 'thread_' (scot %uv (sham eny.bowl)))
 =/  ta-now  `@ta`(scot %da now.bowl)
-=/  start-args  [~ `tid p.q.vase !>(q.q.vase)]
+=/  start-args  [~ `tid byk.bowl p.q.vase !>(q.q.vase)]
 :_  this
 :~
   [%pass /thread/[ta-now] %agent [our.bowl %spider] %poke %spider-start !>(start-args)]

--- a/content/docs/userspace/threads/gall/stop-thread.md
+++ b/content/docs/userspace/threads/gall/stop-thread.md
@@ -29,7 +29,7 @@ Here we've added one last card to `on-poke` to stop the thread and a little extr
         (pair term term)
       =/  tid  `@ta`(cat 3 'thread_' (scot %uv (sham eny.bowl)))
       =/  ta-now  `@ta`(scot %da now.bowl)
-      =/  start-args  [~ `tid p.q.vase !>(q.q.vase)]
+      =/  start-args  [~ `tid byk.bowl p.q.vase !>(q.q.vase)]
       :_  this
       :~
         [%pass /thread/[ta-now] %agent [our.bowl %spider] %watch /thread-result/[tid]]

--- a/content/docs/userspace/threads/gall/take-facts.md
+++ b/content/docs/userspace/threads/gall/take-facts.md
@@ -31,7 +31,7 @@ Here we've added another card to subscribe for any facts sent by the thread and 
         (pair term term)
       =/  tid  `@ta`(cat 3 'thread_' (scot %uv (sham eny.bowl)))
       =/  ta-now  `@ta`(scot %da now.bowl)
-      =/  start-args  [~ `tid p.q.vase !>(q.q.vase)]
+      =/  start-args  [~ `tid byk.bowl p.q.vase !>(q.q.vase)]
       :_  this
       :~
         [%pass /thread/[ta-now] %agent [our.bowl %spider] %watch /thread-result/[tid]]

--- a/content/docs/userspace/threads/gall/take-result.md
+++ b/content/docs/userspace/threads/gall/take-result.md
@@ -29,7 +29,7 @@ Here we've added an extra card to subscribe for the result and a couple of lines
         (pair term term)
       =/  tid  `@ta`(cat 3 'thread_' (scot %uv (sham eny.bowl)))
       =/  ta-now  `@ta`(scot %da now.bowl)
-      =/  start-args  [~ `tid p.q.vase !>(q.q.vase)]
+      =/  start-args  [~ `tid byk.bowl p.q.vase !>(q.q.vase)]
       :_  this
       :~
         [%pass /thread/[ta-now] %agent [our.bowl %spider] %watch /thread-result/[tid]]

--- a/content/docs/userspace/threads/http-api.md
+++ b/content/docs/userspace/threads/http-api.md
@@ -9,10 +9,10 @@ Spider has an Eyre binding which allows threads to be run externally via [authen
 Spider is bound to the `/spider` URL path, and expects the requested URL to look like:
 
 ```
-http{s}://{host}/spider/{inputMark}/{threadName}/{outputMark}
+http{s}://{host}/spider/{desk}/{inputMark}/{threadName}/{outputMark}
 ```
 
-The `inputMark` is the `mark` the thread takes. The `threadName` is the name of the thread, e.g. `foo` for `/ted/foo/hoon`. The `outputMark` is the `mark` the thread produces. You may also include a file extension though it doesn't have an effect.
+The `desk` is the desk in which the thread resides. The `inputMark` is the `mark` the thread takes. The `threadName` is the name of the thread, e.g. `foo` for `/ted/foo/hoon`. The `outputMark` is the `mark` the thread produces. You may also include a file extension though it doesn't have an effect.
 
 When Spider receives an HTTP request, the following steps happen:
 
@@ -30,7 +30,7 @@ Thus, it's important to understand that the original HTTP request and final HTTP
 
 Here we'll look at running Spider threads through Eyre.
 
-Here's an extremely simple thread that takes a `vase` of `(unit json)` and just returns the `json` in a new `vase`. You can save it in `/ted` and `|commit %home`:
+Here's an extremely simple thread that takes a `vase` of `(unit json)` and just returns the `json` in a new `vase`. You can save it in `/ted` and `|commit %base`:
 
 `eyre-thread.hoon`
 
@@ -48,14 +48,14 @@ Here's an extremely simple thread that takes a `vase` of `(unit json)` and just 
 
 First we must obtain a session cookie by [authenticating](/docs/arvo/eyre/examples#authenticating).
 
-Now we can try and run our thread. Spider is bound to the `/spider` URL path, and expects the rest of the path to be `/{inputMark}/{thread}/{outputMark}`. Our `{thread}` is called `eyre-thread`, and both its `{inputMark}` and `{outputMark}` are `json`, so our URL path will be `/spider/json/eyre-agent/json`. Our request will be an HTTP POST request and the body will be some `json`, in this case `[{"foo": "bar"}]`:
+Now we can try and run our thread. Spider is bound to the `/spider` URL path, and expects the rest of the path to be `/{desk}/{inputMark}/{thread}/{outputMark}`. Our `{thread}` is called `eyre-thread` and is in the `%base` `{desk}`. Both its `{inputMark}` and `{outputMark}` are `json`. Therefore, our URL path will be `/spider/base/json/eyre-agent/json`. Our request will be an HTTP POST request and the body will be some `json`, in this case `[{"foo": "bar"}]`:
 
 ```
 curl -i --header "Content-Type: application/json" \
         --cookie "urbauth-~zod=0v6.h6t4q.2tkui.oeaqu.nihh9.i0qv6" \
         --request POST \
         --data '[{"foo": "bar"}]' \
-        http://localhost:8080/spider/json/eyre-thread/json
+        http://localhost:8080/spider/base/json/eyre-thread/json
 ```
 
 Spider will run the thread and the result will be returned through Eyre in the body of an HTTP response with a 200 status code:

--- a/content/docs/userspace/threads/reference.md
+++ b/content/docs/userspace/threads/reference.md
@@ -25,14 +25,14 @@ Where:
         [%ud p=@ud]      ::  number
     ==
   ```
-  You'll almost always just want the current revision, so you can specify the `case` as `da+now.bowl`.
+  You'll almost always just want the current revision, so you can specify the `case` as `da+now.bowl`. If the thread is on the same desk as the agent, you can also just use `byk.bowl` for the `beak`.
 - `file` - name of the thread file in `/ted`. For example, if the thread you want to start is `/ted/foo/hoon` you'd specify `%foo`.
 - `vase` - `vase` to be given to the thread when it's started. Can be whatever or just `!>(~)` if it doesn't need any args.
 
 #### Example
 
 ```hoon
-[%pass /some-path %agent [our.bowl %spider] %poke %spider-start !>([~ `tid [our.bowl %base da+now.bowl] %foo !>(~)])]
+[%pass /some-path %agent [our.bowl %spider] %poke %spider-start !>([~ `tid byk.bowl %foo !>(~)])]
 ```
 
 ## Stop thread

--- a/content/docs/userspace/threads/reference.md
+++ b/content/docs/userspace/threads/reference.md
@@ -10,20 +10,29 @@ Poke `spider` with mark `%spider-start` and a vase containing `start-args`:
 
 ```hoon
 +$  start-args
-  [parent=(unit tid) use=(unit tid) file=term =vase]
+  [parent=(unit tid) use=(unit tid) =beak file=term =vase]
 ```
 
 Where:
 
 - `parent` - optional `tid` of parent thread if the thread is a child. If specified, the child thread will be killed with the parent thread ends.
 - `use` - `tid` (thread ID) to give the new thread. Can be generated with something like `(scot %ta (cat 3 'my-agent_' (scot %uv (sham eny))))`. However you do it, make sure it's unique.
+- `beak` - A `$beak` is a triple of `[p=ship q=desk r=case]`. `p` is always our ship, `q` is the desk which contains the thread we want to run. `r` is a `case`, which specifies a desk revision and is a tagged union of:
+  ```hoon
+  +$  case
+    $%  [%da p=@da]      ::  date
+        [%tas p=@tas]    ::  label
+        [%ud p=@ud]      ::  number
+    ==
+  ```
+  You'll almost always just want the current revision, so you can specify the `case` as `da+now.bowl`.
 - `file` - name of the thread file in `/ted`. For example, if the thread you want to start is `/ted/foo/hoon` you'd specify `%foo`.
 - `vase` - `vase` to be given to the thread when it's started. Can be whatever or just `!>(~)` if it doesn't need any args.
 
 #### Example
 
 ```hoon
-[%pass /some-path %agent [our.bowl %spider] %poke %spider-start !>([~ `tid %foo !>(~)])]
+[%pass /some-path %agent [our.bowl %spider] %poke %spider-start !>([~ `tid [our.bowl %base da+now.bowl] %foo !>(~)])]
 ```
 
 ## Stop thread


### PR DESCRIPTION
updates threads docs for dist changes. Mostly:

- change %home to %base
- update all instances of start-args to include beak
- update reference to explain start-args beak field
- explain new -desk!thread syntax
- update HTTP API with new desk field
- various other tweaks related to dist changes