### PR TITLE
update operators manual wrt dist

### DIFF
--- a/content/using/os/basics.md
+++ b/content/using/os/basics.md
@@ -8,16 +8,20 @@ aliases = ["docs/using/messaging/", "docs/using/admin/"]
 hidetitle = "true"
 +++
 
-Your urbit (also called your _ship_) is a persistent Unix process that you
-mainly control from its console, called the `dojo`.
+This document deals with:
 
-### Shutdown
+- Running an Urbit ship with the ordinary runtime [from the command line](/getting-started/cli).
+- Basic setup, configuration and usage in Urbit's shell called the `dojo`.
+
+If you're looking for information on using the GUI application [Port](/getting-started#port), see the [Port guide](/using/running/port) instead.
+
+## Shutdown
 
 You can turn your urbit off with `Ctrl-d` from the Chat or Dojo prompts.
 
 You can force-quit your urbit with `Ctrl-z` from anywhere.
 
-### Restart
+## Restart
 
 To restart your urbit simply pass the name of your pier:
 
@@ -31,7 +35,7 @@ or
 $ ./urbit comet
 ```
 
-### Logging
+## Logging
 
 To log an urbit's command line output to a file, use `script`:
 
@@ -39,7 +43,7 @@ To log an urbit's command line output to a file, use `script`:
 $ script urbit.log ./urbit your-urbit
 ```
 
-### Moving your pier
+## Moving your pier
 
 Piers are designed to be portable, but it _must_ be done while the urbit
 is not running. Urbit networking is stateful, so you can't run two copies
@@ -66,13 +70,13 @@ Delete the tar file, and, after installing Urbit on your new server, start your 
 ./urbit your-urbit
 ```
 
-### Hardware requirements
+## Hardware requirements
 
 Urbit can run on any x86 computer (unofficial, unsupported [ARM binaries](https://botter-nidnul.github.io/AArch64_Urbit_Static_Binaries.html) are also available), ideally with at least 2GB of RAM.
 
 Urbit maintains a persistent log of the history of your ship. Eventually this log will be automatically trimmed when necessary, but for now it only increases in size. An actively used planet will consume 5-50 GB of storage space per year of operation.
 
-### Console
+## Console
 
 Your Urbit terminal is separated into two parts: the prompt (the bottom line) and the record (everything above that). The record is shared; all the output from all the apps in your command set appears in it. The prompt is multiplexed.
 
@@ -107,13 +111,13 @@ Ctrl-u    Kill to beginning of line
 Ctrl-y    Yank from kill buffer
 ```
 
-### Updates
+## Updates
 
-By default, you will automatically receive updates ([OTAs](/docs/glossary/ota-updates)) from your sponsor. To check your OTA source, run `|ota` in the [dojo](/docs/glossary/dojo).
+By default, your `%base` [desk](/docs/glossary/desk) (which contains the [Arvo](/docs/glossary/arvo) kernel and core apps) receives updates ([OTAs](/docs/glossary/ota-updates)) from your sponsor. Other desks will receive updates from their respective publishers. To check the OTA source for each desk, run `+vats` in the [dojo](/docs/glossary/dojo). It will print out details for each desk - the `source` field shows which ship the desk gets updates from and the `updates` field shows `tracking` if automatic updates are enabled.
 
-If for some reason (for example, if your sponsor is out of date), you can switch OTA sources by running `|ota ~otasrc %kids` in the dojo, where `~otasrc` is the ship from which you want to receive updates. It is a good idea to contact the source ship and ask permission to sync from them.
+If for some reason updates are not enabled or the current source is not online or up to date, you can enable updates or change source with the `|install` command.
 
-If OTAs are not succeeding, or if you are on an version of Urbit before the `|ota` command was introduced, you can run `|merge %home (sein:title our now our) %kids, =gem %take-that`. **Note:** This will wipe out any custom changes to the base distribution.
+`|install (sein:title our now our) %landscape` will enable updates to the `%landscape` desk from your sponsor. `|install ~some-ship %landscape` will enable updates to the landscape desk from whatever ship is specified in place of `~some-ship`. For third party apps, make sure to correctly specify the publisher's ship. Each desk's updates are managed separately, so you'll need to run this for each desk separately. For the `%base` desk specifically, you sync from `%kids` rather than `%base` on the remote ship, so must specify it like `|install (sein:title our now our) %kids, =local %base`.
 
 #### Additional OTA Troubleshooting
 
@@ -124,65 +128,41 @@ Please check the Support Wiki for additional OTA troubleshooting, such as:
 OTAs](https://github.com/urbit/support/wiki/Stuck-flow-preventing-planets-from-receiving-OTAs),
 and [No content shows in Links page after OTA](https://github.com/urbit/support/wiki/No-content-shows-in-Links-page-after-OTA).
 
-### Landscape
+## Web interface
 
-On startup Urbit tries to bind to `localhost:80`. If you're already running something on port `80` -- such as any other HTTP server, or another urbit -- you'll find the urbit that you just started on `8080`, `8081`, and so on. For planets only, we also provide web domains through Urbit's own domain. Any planet `~your-urbit` is also at `your-urbit.arvo.network`, but only after you [set up DNS](#dns-setup).
+On startup, urbit tries to bind to `localhost:80`. If you're already running something on port `80`, or your host OS will not allow urbit to bind port `80`, urbit will try `8080`, then `8081`, `8082`, and so on. For planets only, we also provide subdomains of `arvo.network` for free. Any planet `~your-urbit` is also at `your-urbit.arvo.network`, but only after you [set up DNS](#dns-setup).
 
-Once running, you can sign into Landscape, your ship’s web interface, from `http://localhost` or `https://your-urbit.arvo.network`. Since our HTTPS isn't audited / battle tested, we just call it "secure" HTTPS. You can find that on `8443`. Or `8444` (and so on) if you're already running something on `8443`.
+Once running, you can sign into your ship’s web interface from `http://localhost` (if bound to port `80`), `http://localhost:8080` (if bound to port `8080`), or `https://your-urbit.arvo.network` if you've set up DNS.
 
-### Moons {#moons}
+## Moons {#moons}
 
-Planets can spawn moons, which are meant for connected devices: phones, smart TVs, digital thermostats. The basic idea is that your planet runs permanently in a data center somewhere, while moons run on all your devices. Each planet can issue ~4 billion (`2^32`) moons.
+Planets can spawn moons, which are conceptually meant for connected devices: phones, smart TVs, digital thermostats. The basic idea is that your planet runs permanently in a data center somewhere, while moons run on all your devices. Each planet can issue ~4 billion (`2^32`) moons.
 
 To generate a random moon from your planet, run:
 
 ```
 ~sampel-palnet:dojo> |moon
 moon: ~faswep-navred-sampel-palnet
-\/0w5cT5t.wCO6i.~e1xg.Oz0qb.QNO6I.3Kt2T.h9M9F.U3vU~.X3Qu0.gtb19.IYTkY.80kWZ.SI\/
-  EUE.DXa8i.TiDof.o3-1C.RHLKS.k81M0.ecz5o.ic0Bg.600g1
-\/                                                                                                 \/
+0w5cT5t.wCO6i.~e1xg.Oz0qb.QNO6I.3Kt2T.h9M9F.U3vU~.X3Qu0.gtb19.IYTkY.80kWZ.SIEUE.DXa8i.TiDof.o3-1C.RHLKS.k81M0.ecz5o.ic0Bg.600g1
 ```
 
-You must manually edit the output of `|moon` to get the correct format for the `key`:
+The `moon:` part is the name of the moon, in this case `~faswep-navred-sampel-palnet`. The next line starting with `0w5...` is the private key necessary to boot it.
 
-- strip out the `\/`
+You can just copy the key (which in this case would be the `0w5[...]600g1` part) to the clipboard, or save it in a `.key` file, for example `faswep-navred-sampel-palnet.key`.
 
-- combine into one line, omitting spaces
-
-`key` would be `0w5cT5t.wCO6i.~e1xg.Oz0qb.QNO6I.3Kt2T.h9M9F.U3vU~.X3Qu0.gtb19.IYTkY.80kWZ.SIEUE.DXa8i.TiDof.o3-1C.RHLKS.k81M0.ecz5o.ic0Bg.600g1`
-in this example.
-
-Put `key` in a file and that file becomes `keyfile`.
-
-You can use the resulting output in the same installation flow from the [Installing Urbit](/getting-started/) guide, following the same scheme as for booting a planet. That scheme is:
+You can use the key and moon name in the same installation flow from the [Command line installation](/getting-started/cli) guide, following the same scheme as for booting a planet. That scheme is:
 
 ```sh
-$ ./urbit -w <moonname> -G <key> -c <piername>
+$ ./urbit -w <moon-name> -G <key> -c <pier-name>
 ```
 
 or
 
 ```sh
-$ ./urbit -w <moonname> -k <keyfile> -c <piername>
+$ ./urbit -w <moon-name> -k <key-file> -c <pier-name>
 ```
 
-The `-c <piername>` argument is not required, but it is recommended; otherwise,
-the resulting directory is a rather unwieldy moon name.
-
-Here's how an example moon might be booted:
-
-```sh
-$ ./urbit -w faswep-navred-sampel-palnet -G <key> -c mymoon
-```
-
-or
-
-```sh
-$ ./urbit -w faswep-navred-sampel-palnet -k <keyfile> -c mymoon
-```
-
-Moons are automatically synced to their parent `%kids` desk, and can control applications on their parent planet using `|link`.
+Note the `<moon-name>` excludes the leading `~`. The `-c <piername>` argument is not required, but it is recommended; otherwise, the resulting directory is a rather unwieldy moon name. Moons are automatically synced to their parent `%kids` desk, and can control applications on their parent planet using `|link`.
 
 To breach a moon -- that is, to reset its presence on the network so that it's treated as a freshly spawned ship by others -- run from the parent ship:
 
@@ -193,10 +173,12 @@ To breach a moon -- that is, to reset its presence on the network so that it's t
 To cycle the keys of a moon without breaching, run:
 
 ```
-|moon-cycle-keys ~sampel-sipnym-wicdev-wisryt
+|moon-cycle-keys ~faswep-navred-sampel-palnet
 ```
 
-### Escaping A Sponsor {#escape}
+You can then run `|rekey` on the moon with the key given by the above command as the argument.
+
+## Escaping A Sponsor {#escape}
 
 To use the network as a planet or star, you must be sponsored by an active star
 or galaxy, respectively. If your sponsor isn't suiting your needs, you can
@@ -204,55 +186,35 @@ escape to a different one. This can be done with
 [Bridge](https://bridge.urbit.org/) following the instructions
 [here](/using/id/using-bridge#escaping-your-sponsor).
 
-### Continuity breaches
-
-While the Urbit network is in this alpha state, we sometimes have to reboot the whole network. This happens either when major changes need to be shipped or we hit a bug that can't be fixed over the air.
-
-Because Urbit networking is stateful we call this a _continuity breach_. Everything has to be restarted from scratch. Your pier will continue to function after we have breached, but it won’t connect to the rest of the Urbit network.
-
-When this happens, back up any files you'd like to save, shut down your urbit, and recreate it (as if you were starting for the first time).
-
-### Life and rift number
+## Life and rift number
 
 You can check your ship's _life_ and _rift_ number by running `+keys our` in
 dojo. You can inspect another ship's life and rift number by running `+keys ~sampel-palnet`. For information on what life and rift are, see [Life and Rift](/docs/azimuth/life-and-rift).
 
 ## DNS setup {#dns-setup}
 
-We have a system that lets you request a domain name for your ship in the form of `ship.arvo.network`, where `ship` is your ship's name minus the `~`. This allows users to access their ships remotely using Landscape, our graphical web interface.
-
-Stars and planets follow the same process DNS request process, and galaxies have their own requirements. Moons and comets are not supported.
-
-### Planets and Stars
+We have a system that lets you request a domain name for your ship in the form of `ship.arvo.network`, where `ship` is your ship's name minus the `~`. This allows users to access their ships remotely using Landscape, our graphical web interface. Stars and planets follow the same DNS request process, and galaxies have their own requirements. Moons and comets are not supported.
 
 For a planet or star's DNS request to be made and fulfilled, they must be hosting their ship someplace with a public IP address, and its HTTP server must be listening on port 80.
 
-To get `ship.arvo.network` on a planet or star, you must set up DNS routing with its parent ship by starting the `:dns` app.
-
-To do so, simply run this command in your ship's Dojo, passing the IP address as an argument, using the .0.0.0.0 (`@if`) syntax. For example:
+To initiate a DNS request, run the following thread in your ship's dojo, passing the IP address as an argument with .0.0.0.0 (`@if`) syntax. For example:
 
 ```
-> -dns-address &dns-address [%if .1.2.3.4]
+-dns-address [%if .1.2.3.4]
 ```
 
-`:dns`, running locally, will make an HTTP request to that IP address on port 80 to confirm that it is itself available at that IP and port. If that fails, you'll receive a `%bail-early` message in `:chat-cli`; this request will retry a few times. If the self-check is successful, the request is relayed to `~zod`, and you'll receive a message saying, `request for DNS sent to ~zod`. Once `~zod` has acknowledged receipt of the request, your local `:dns` app will send a `:chat-cli` message saying `awaiting response from ~zod`.
+The `%dns-address` thread, running locally, will make an HTTP request to that IP address on port 80 to confirm that it is itself available at that IP and port. If that fails, you'll receive a `couldn't access ship on port 80` message in the terminal; this request will retry a few times. If the self-check is successful, the request is relayed to `~zod`, and you'll receive a message saying, `request for DNS sent to ~zod`. Once `~zod` has acknowledged receipt of the request, the `%dns-address` thread will print a terminal message saying `awaiting response from ~zod`.
 
-The request will be picked up shortly, and the `ship.arvo.network` DNS record will be set to the given IP address. Once that's set up, `~zod` will be notified and `~zod` will, in turn, notify your ship. That ship will now try to verify that it can reach itself on `ship.arvo.network` over port 80. If it can't, it'll send a message saying, `unable to access via ship.arvo.network`. If it can, it will configure itself with that domain and say `confirmed access via ship.arvo.network`.
+The request will make take a little time to be fulfilled, but eventually the `ship.arvo.network` DNS record will be set to the given IP address. Once that's set up, `~zod` will be notified and `~zod` will, in turn, notify your ship. That ship will now try to verify that it can reach itself on `ship.arvo.network` over port 80. If it can't, it'll send a message saying, `unable to access via ship.arvo.network`. If it can, it will configure itself with that domain and say `confirmed access via ship.arvo.network`.
 
 Great! You're set up now. Try accessing your `ship.arvo.network` in your browser to use Landscape; we recommend Chrome or Brave.
 
 ### Configuring SSL
 
-To enable SSL on your ship, use the `acme` agent, which will request a certificate through Let's Encrypt. First, make sure the agent is started:
+To enable SSL on your ship, you must poke the `%acme` agent with the domain encoded in a path and it will request a certificate. The path format is `/tld/your_domain/your_subdomain`, so if your domain is `sampel-palnet.arvo.network`, you'd use it like so:
 
 ```
-> |start %acme
-```
-
-Next, provide the path for the SSL certificate by poking the `acme` agent. The path format is `/tld/your_domain/your_subdomain`, so if your domain is `sampel-palnet.arvo.network`, you'd use it like so:
-
-```
-> :acme &path /network/arvo/sampel-palnet
+:acme &path /network/arvo/sampel-palnet
 ```
 
 ### Galaxies
@@ -267,69 +229,8 @@ There is a command for galaxies that will try to re-use their already-necessary 
 
 This will make HTTP-requests to self-check availability over `galaxy.$AMES-DOMAIN` (currently galaxy.urbit.org), where `galaxy` is the galaxy's name minus the `~`.
 
-Otherwise, `-dns-auto` works the same as `:dns|ip` does with stars and planets: if it's available or unavailable, Chat messages, and so on.
+Otherwise, `-dns-auto` works the same as `-dns-address` does with stars and planets: if it's available or unavailable, terminal messages, and so on.
 
 ### Ports
 
-The built-in logic for listening on port 80 is to try to bind to port 80; if it cannot, it tries 8080, then increments until it can bind a port. Port 80 is available to unprivileged process on recent version of macOS. Otherwise, the process needs to either be run as root, or be given special permission (CAP_NET_BIND on Linux).
-
-### Hoon
-
-You can use Chat to evaluate Hoon code and share the results with everyone in a chat. To do so, preface your Hoon with `#`.
-
-```
-~sampel-palnet:chat-cli= #(add 2 2)
-```
-
-This will print as:
-
-```
-~sampel-palnet# (add 2 2)
-                4
-```
-
-### URLs
-
-To share a URL, send it as its own message, with no content before or after it.
-
-```
-~sampel-palnet:chat-cli= https://urbit.org/
-```
-
-This will print as:
-
-```
-~sampel-palnet/ https://urbit.org/
-```
-
-### Expanding messages
-
-In the case of URLs, they may be too long to display on a single message line. For Hoon code, the code or result could be big. In `:chat-cli`, these get shortened when initially printed out. To view the entire contents, you can select the message in various ways.
-
-```
-~sampel-palnet+ some message
-----------[240]
-~sampel-palnet+ let's try selecting this message!
-~sampel-palnet+ another message
-~sampel-palnet:chat-cli=
-```
-
-In the above example, we can select the middle message by issuing any of the following command:
-
-```
-;240
-;40
-;;
-```
-
-`;n` looks for the last message whose sequence number ends in `n`. `;;` simply picks the second-to-last message.
-
-Detailed message output will look something like this:
-
-```
-? 240
-  0v5.g7r7l.n0d7m.mp4bn.gp6vr.sm5lj at ~2019.10.17..22.08.27..8a03
-  ~sampel-palnet
-  to ~dopzod/urbit-help
-let's try selecting this message!
-```
+The built-in logic for listening on port 80 is to try to bind to port 80; if it cannot, it tries 8080, then increments until it can bind a port. Port 80 is available to unprivileged process on recent versions of macOS. Otherwise, the process needs to either be run as root, or be given special permission (`sudo setcap 'cap_net_bind_service=+ep' /path/to/urbit/binary` on Linux).

--- a/content/using/os/filesystem.md
+++ b/content/using/os/filesystem.md
@@ -8,7 +8,8 @@ Urbit has its own revision-controlled filesystem, Clay. Clay is a typed, global,
 referentially transparent namespace. An easy way to think about it is like typed
 `git`.
 
-The most common way to use Clay is to mount a Clay node in a Unix directory. The mounted directory is always at the root of your pier directory.
+The most common way to use Clay is to mount a Clay node in a Unix directory. The
+mounted directory is always at the root of your pier directory.
 
 For more information on Clay, see the [Overview](/docs/arvo/clay/clay), and
 additional usage information at [Using Clay](/docs/arvo/clay/using).
@@ -21,32 +22,24 @@ that the command was successful.
 
 A [`desk`](/docs/glossary/desk) is something like an independently
 revision-controlled branch of your urbit's file-system. Your urbit's system
-files live in the `%home` `desk`.
+files live in the `%base` desk.
 
 It's important to note that whenever you want to sync changes from your Unix
 directory to your ship, you must use the `|commit %desk` command, where `%desk`
 is the `desk` that you'd like to sync to.
 
 When developing it's a good idea to use a separate `desk`. Create a `%sandbox`
-`desk` based on the `%home` `desk`:
+`desk` based on the `%base` `desk` (`our` produces your ship name):
 
 ```
-~zod:dojo> |merge %sandbox ~zod %home
+~zod:dojo> |merge %sandbox our %base
 ```
 
-Running `our` produces your ship-name, meaning that you can run the following
-command instead of typing out the entire thing. This is especially useful for
-comets due to their very long names.
+Most of the time we want to use Clay from Unix. Mount the entire contents of
+your `%sandbox` desk to Unix:
 
 ```
-~zod:dojo> |merge %sandbox our %home
-```
-
-Most of the time we want to use Clay from Unix.  Mount the entire contents of
-your `sandbox` desk to Unix:
-
-```
-~zod:dojo> |mount /=sandbox=
+~zod:dojo> |mount %sandbox
 ```
 
 To explore the filesystem from inside Urbit `+ls` and `+cat` are useful. `+ls`
@@ -93,19 +86,18 @@ and other basic tasks familiar to novice users of the Unix terminal.
 
 #### Paths
 
-A path in Clay is a list of URL-safe text, restricted to the characters `[a
-z]`,`[0 9]`, `.`, `-`, `_`, and `~`. This path is a list of strings each
+A path in Clay is a list of URL-safe text, restricted to the characters `[a z]`,`[0 9]`, `.`, `-`, `_`, and `~`. This path is a list of strings each
 prepended by `/`. In other words, paths are expressed as `/foo/bar/baz`. File
 extensions are separated from file names with `/`, not `.`. Extensions are
 syntactically identical to subdirectories, except that they must terminate the
 path.
 
 Paths begin with three strings indicating the ship, desk, and revision, and
-might look like `/~dozbud-namsep/home/11`.
+might look like `/~dozbud-namsep/base/11`.
 
 The first component is `ship`, which is, as you might guess, the name of
 an Urbit ship. The second component is `desk`, which is a workspace meant to
-contain other directories; the default `desk` is `%home`. The third component is
+contain other directories; the default `desk` is `%base`. The third component is
 the revision, which represents version information in various ways: date and time;
 a version sequence, which is a value incremented by one whenever a file on the
 given `desk` is modified; or an arbitrary plaintext label.
@@ -113,22 +105,23 @@ given `desk` is modified; or an arbitrary plaintext label.
 You can find what your current ship, desk, and revision is at any given moment by
 typing `%` in the Dojo and looking at the first three results. This will display
 as a cell rather than a path, like
+
 ```
-[~.~zod ~.home ~.~2021.3.19..16.11.20..0c60]
+[~.~zod ~.base ~.~2021.3.19..16.11.20..0c60]
 ```
+
 Here we see that the revision consists of the date, time, and a short hash.
 
 We use this format because, unlike the current internet, the Urbit network uses a
 global namespace. That means that a file named `example.hoon` in the `/gen`
-directory on the `%home` desk of your ship `~lodleb-ritrul` would have a
+directory on the `%base` desk of your ship `~lodleb-ritrul` would have a
 universal address to anyone else on the network:
-`/~lodleb-ritrul/home/186/gen/example/hoon`. That, of
+`/~lodleb-ritrul/base/186/gen/example/hoon`. That, of
 course, doesn't mean that everyone on the network has privileges to access that
 path. But given the revision-controlled and immutable nature of Urbit, this
 means that if the file requested is available, it will always be the same. This
 means that if an Urbit is serving a webpage, that exact version will always be
 retrievable (assuming you have access to it).
-
 
 #### Relative paths
 
@@ -198,7 +191,7 @@ address hierarchy – which, if you recall, is just a `list` – the above comma
 works!
 
 We can do the same thing between desks. If `%sandbox` has been merged with
-`%home`, the following command will produce the same results as the above
+`%base`, the following command will produce the same results as the above
 command.
 
 ```
@@ -206,16 +199,16 @@ command.
 ```
 
 Most commonly this is used to avoid having to know the current revision
-number in the `dojo`: `/~lodleb-ritrul/home/~2021.3.19..16.11.20..0c60/gen/example/hoon`
+number in the `dojo`: `/~lodleb-ritrul/base/~2021.3.19..16.11.20..0c60/gen/example/hoon`
 
 #### Changing directories
 
 Change the working directory with `=dir`. It's our equivalent of the Unix `cd`.
 
-For example, the syntax to navigate to `/home/gen/ask` is:
+For example, the syntax to navigate to `/base/gen/ask` is:
 
 ```
-~sampel-palnet:dojo> =dir /=home=/gen/ask
+~sampel-palnet:dojo> =dir /=base=/gen/ask
 ```
 
 This command will turn your prompt into something like this:
@@ -225,7 +218,7 @@ This command will turn your prompt into something like this:
 ```
 
 Using `=dir` without anything else uses the null path, which returns you to
-your home desk.
+your base desk.
 
 ```
 ~sampel-palnet:dojo/=/=/~2021.3.19..16.11.20..0c60/gen/ask> =dir
@@ -263,24 +256,18 @@ Mounts `%/gen` to `/generators` inside your pier directory.
 #### Unmount
 
 ```
-|unmount [clay-path || Unix-name]
+|unmount %mount-point
 ```
 
-Unmount the path or name from Unix.
+Unmount the the mount point from Unix.
 
 **Examples:**
 
 ```
-|unmount %/gen
+|unmount %foo
 ```
 
-Unmounts the Clay path `%/gen` from whatever name it was mounted as.
-
-```
-|unmount %generators
-```
-
-Unmounts the Unix path `/generators`.
+Unmounts the Unix path `/foo`.
 
 #### Merge
 
@@ -318,22 +305,18 @@ Merge the `%examples` `desk` from `~waxbex-ribmex`
 
 Merge `/=home=` into `%home-work` using merge strategy `%fine`.
 
-
 #### Sync
 
 ```
 |sync %target-desk ~source-ship %target-desk
 ```
 
-Subscribe to continuous updates from remote `desk` on local `desk`. Non-comet
-urbits have `|sync %home ~sponsor %kids` automatically set up (where `~sponsor`
-is the planet that issued a moon, the star that issued a planet, or the galaxy
-that issued a star).
+Subscribe to continuous updates from remote `desk` on local `desk`.
 
 **Examples:**
 
 ```
-|sync %home-local ~dozbud %home
+|sync %foo ~dozbud %kids
 ```
 
 #### Unsync
@@ -348,9 +331,8 @@ match original `|sync` command.
 Example:
 
 ```
-|unsync %home-local ~dozbud %home
+|unsync %foo ~dozbud %kids
 ```
-
 
 ### Manipulation
 
@@ -371,7 +353,7 @@ Similar to Unix `ls`. `+ls` takes a single `path`.
 Produces a list of names at the `path`.
 
 ```
-~sampel-palnet:dojo> +cat %/our/home/gen/curl/hoon
+~sampel-palnet:dojo> +cat %/our/base/gen/curl/hoon
 ```
 
 #### `|rm`

--- a/content/using/os/shell.md
+++ b/content/using/os/shell.md
@@ -77,7 +77,9 @@ Run system commands from `:hood`, like `reload`, using `|`:
 
 Generators are short Hoon scripts, saved as `.hoon` files in the `/gen`
 directory. Many Dojo commands exist in the form of generators. The syntax for
-running a generator is `+genname` for a generator saved as `genname.hoon`.
+running a generator is `+genname` for a generator saved as `genname.hoon` in the
+`%base` desk. For generators on other desks, you can use the syntax
+`+desk!genname`.
 
 #### `+cat`
 
@@ -96,25 +98,8 @@ arguments.
 ~your-urbit:dojo> +code
 ```
 
-You can change your code to a new randomly generated one by entering `|code
-%reset`. Please note that this will prevent [Bridge](/docs/glossary/bridge)
+You can change your code to a new randomly generated one by entering `|code %reset`. Please note that this will prevent [Bridge](/docs/glossary/bridge)
 from being able to derive your code in the future.
-
-#### `+curl`
-
-Retrieves data from a URL. Accepts a `tape`. Similar to Unix `curl`.
-
-```
-~your-urbit:dojo> +curl "http://nyt.com"
-```
-
-#### `+hello`
-
-Just prints the argument. Accepts a `@ta`.
-
-```
-~your-urbit:dojo> +hello 'mars'
-```
 
 #### `+ls`
 
@@ -122,34 +107,18 @@ Similar to Unix `ls`. Accepts a path.
 
 ```
 ~your-urbit:dojo> +ls %/gen
-~your-urbit:dojo> +ls /~talsur-todres/home/2/gen/program
+~your-urbit:dojo> +ls /~talsur-todres/base/2/gen/program
 ```
 
 #### `+solid`
 
-Compile the current state of the kernel and output a
-noun. Usually downloaded to a file in unix. No arguments.
+Compile the current state of the kernel and output a noun. Usually downloaded to
+a file in unix. This generator takes a series of desks to include as its
+argument. The first desk must be the base desk that contains the Arvo kernel,
+standard library and related files - typically `%base`.
 
 ```
-~your-urbit:dojo> .urbit/pill +solid
-```
-
-#### `+test`
-
-Testrunner. Can test multiple generators at once, conventionally ones
-in the `/test` folder. Takes a path.
-
-```
-~your-urbit:dojo> +test /lib
-```
-
-#### `+ticket`
-
-Generate a ticket for an urbit ship. Takes an urbit name (`@p`).
-
-
-```
-~your-urbit:dojo> +ticket ~talsur-todres-your-urbit
+~your-urbit:dojo> .urbit/pill +solid %base %garden %landscape %webterm %bitcoin
 ```
 
 #### `+tree`
@@ -171,11 +140,13 @@ an urbit name (`@p`) and a string (`tape`, which is text wrapped with double-quo
 ~your-urbit:dojo> |hi ~binzod "you there?"
 ```
 
-`|link` / `|unlink` - Link / unlink a remote app. Accepts an
-Urbit name and an app name.
+`|link` / `|unlink` - Link / unlink a CLI app - may or may not be remote.
+Accepts an optional ship name and a mandatory app name.
 
 ```
 ~your-urbit:dojo> |link ~talsur-todres %octo
+
+~your-urbit:dojo> |link %chat-cli
 ```
 
 `|mass` - Prints the current memory usage of all the kernel modules.
@@ -185,23 +156,11 @@ No arguments.
 ~your-urbit:dojo> |mass
 ```
 
-`|reload` - Reloads a kernel module (vane) from source. Accepts any
+`|breload` - Reloads a kernel module (vane) from source. Accepts any
 number of vane names.
 
 ```
-~your-urbit:dojo> |reload %clay %eyre
-```
-
-`|reset` - Reloads `hoon.hoon` and all modules. No arguments.
-
-```
-~your-urbit:dojo> |reset
-```
-
-`|start` - Starts an app. Accepts an app name.
-
-```
-~your-urbit:dojo> |start %curl
+~your-urbit:dojo> |breload %clay %eyre
 ```
 
 ---
@@ -324,6 +283,9 @@ the code needed to log into your ship remotely.
 fintyr-haldet-fassev-solhex
 ```
 
+Generators on desks other than `%base` can be run with the syntax
+`+desk!generator`.
+
 ### Variables
 
 You can use `=` to set an environment variable in Dojo, but there are
@@ -339,36 +301,6 @@ Current working `%clay` desk and revision. Read / write.
 ~your-urbit:dojo> =dir %/gen
 ~your-urbit:dojo> +ls %
 404/hoon docs/ dojo/hoon lib/ listen/hoon md static/udon talk/ testing/udon tree/main/ unmark/ womb/
-```
-
-#### `lib`
-
-Current set of libraries (`/lib`) in your environment. Can be set
-with `/+`. Read / write.
-
-**Examples:**
-
-```
-~your-urbit:dojo> /+  number-to-words
-```
-Now we can use arms from lib/number-to-words.hoon
-```
-~your-urbit:dojo> (to-words:eng-us:number-to-words 123.456)
-```
-
-#### `sur`
-
-Current set of structures (`/sur`) in your environment. Can be set
-with `/-`. Read / write.
-
-**Examples:**
-
-```
-~your-urbit:dojo> /-  sole
-```
-Now we can use arms in sur/sole.hoon.
-```
-~your-urbit:dojo> `sole-effect:sole`[%bel ~]
 ```
 
 #### `now`
@@ -401,9 +333,7 @@ The current urbit ship. Read-only.
 
 ```
 ~your-urbit:dojo> eny
-\/0vnt.d474o.gpahj.jcf3o.448fh.2lamb.82ljm.8ol8u.b02vi.mrvvp.b7et2.knb7m.l8he\/
-  8.8qb9s.drm36.77n9b.a0qst.30g03.l5lb5.nvsbc.v39tn
-\/
+0v27k.n4atp.fovm6.f7ggm.jdkn5.elct5.11tna.4qtid.g4so7.a1h6g.grp7u.qml4i.0ed1v.sl0r0.97d4b.6aepr.6v6qm.ls5ve.60kgb.j6521.2fqcb
 ```
 
 ### Troubleshooting


### PR DESCRIPTION
- change all reference to home desk to base
- update relevant explanations of desks
- change ota instructions
- update outdated instructions
- remove deprecated instructions
- various other fixes

this edits /using/os only, specifically basics, shell and filesystem. Doesn't touch id section.

This needs a much more substantial overhaul but for now its information should atleast be technically correct 