### PR TITLE
Correct for html rendering of <p> in ;+ by escaping

### DIFF
--- a/content/docs/hoon/reference/rune/mic.md
+++ b/content/docs/hoon/reference/rune/mic.md
@@ -157,7 +157,7 @@ tl;dr -- `;+` converts a `manx` to a `marl`.
 
 `;+` is a Sail rune.  Sail is a part of Hoon used for creating and operating on nouns that represent XML nodes.  With the appropriate rendering pipeline, a Sail document can be used to generate a static website.
 
-In Sail a single XML node is represented by a `manx`.  A single `<p>` node `manx` can be produced in the following way:
+In Sail a single XML node is represented by a `manx`.  A single <code>&lt;p&gt;</code> node `manx` can be produced in the following way:
 
 ```
 > ;p: This will be rendered as an XML node.


### PR DESCRIPTION
previously, <p> was entered in markdown as '<p>' which was, on urbit.org, rendering into a blank paragraph in code highlighting (sorta amusing, really).

By using <code>&lt;p&gt;</code>, the characters escape parsing by the browser and are rendered as characters, not a paragraph tag.