### PR TITLE
change eyre's examples doc to a guide

### DIFF
--- a/content/docs/arvo/eyre/_index.md
+++ b/content/docs/arvo/eyre/_index.md
@@ -26,6 +26,6 @@ The scry endpoints of Eyre.
 
 Reference documentation of the various data types used by Eyre.
 
-## [Examples](/docs/arvo/eyre/examples)
+## [Guide](/docs/arvo/eyre/guide)
 
 Practical examples of the different ways of using Eyre.

--- a/content/docs/arvo/eyre/external-api-ref.md
+++ b/content/docs/arvo/eyre/external-api-ref.md
@@ -4,7 +4,7 @@ weight = 2
 template = "doc.html"
 +++
 
-This document contains reference information about Eyre's external APIs including [the channel system](#channels) and [scries](#scry). Each section will also have practical examples in the [Examples](/docs/arvo/eyre/examples) document.
+This document contains reference information about Eyre's external APIs including [the channel system](#channels) and [scries](#scry). Each section will also have practical examples in the [Guide](/docs/arvo/eyre/guide) document.
 
 ## Authentication
 
@@ -14,7 +14,7 @@ To use Eyre's channel system, run threads or perform scries you must first obtai
 | ----------- | -------------------------------------- | ---------- | ----------------------------------------------------------------------------------- |
 | `POST`      | `password=lidlut-tabwed-pillex-ridrup` | `/~/login` | The password is your web login code which can be obtained with `+code` in the dojo. |
 
-See the [examples](/docs/arvo/eyre/examples#authenticating) for an example of how to do this using the curl.
+See the [Guide](/docs/arvo/eyre/guide#authenticating) for an example of how to do this using the curl.
 
 Eyre's response will include a `set-cookie` header like:
 
@@ -51,7 +51,7 @@ All the events that Eyre sends you on a channel must be [ack](#ack)ed so that Ey
 
 When you're finished with a channel, you can send Eyre a [delete action](#delete-channel) to close it.
 
-See the [Using the Channel System](/docs/arvo/eyre/examples#using-the-channel-system) section of the [Examples](/docs/arvo/eyre/examples) document for a practical example.
+See the [Using the Channel System](/docs/arvo/eyre/guide#using-channels) section of the [Guide](/docs/arvo/eyre/guide) document for a practical example.
 
 ### HTTP Requests
 
@@ -352,7 +352,7 @@ The `{mark}` is the type you want returned. It needn't just be `json` as with th
 
 If your session cookie is invalid or missing, Eyre will respond with a 403 Forbidden status. If the scry endpoint cannot be found, Eyre will respond with a 404 Missing status. If the `mark` conversions can't be done, Eyre will respond with a 500 Internal Server Error status. Otherwise, Eyre will respond with a 200 OK status with the requested data in the body of the HTTP response.
 
-See the [Scrying](/docs/arvo/eyre/examples#scrying) section of the [Examples](/docs/arvo/eyre/examples) document for a practical example.
+See the [Scrying](/docs/arvo/eyre/guide#scrying) section of the [Guide](/docs/arvo/eyre/guide) document for a practical example.
 
 ## Spider
 

--- a/content/docs/arvo/eyre/eyre.md
+++ b/content/docs/arvo/eyre/eyre.md
@@ -18,7 +18,7 @@ Eyre's channel system is the primary way of interacting with Gall agents from ou
 
 The channel system is designed to be extremely simple with just a handful of `action` and `response` JSON objects to deal. Essentially it's a thin layer on top of the underlying Gall agent interface. You can poke agents, subscribe for updates, etc, just like you would from within Urbit.
 
-Detailed documentation of the channel system's JSON API is provided in the [External API Reference](/docs/arvo/eyre/external-api-ref) document with corresponding examples in the [Examples](/docs/arvo/eyre/examples#using-the-channel-system) document.
+Detailed documentation of the channel system's JSON API is provided in the [External API Reference](/docs/arvo/eyre/external-api-ref) document with corresponding examples in the [Guide](/docs/arvo/eyre/guide#using-the-channel-system) document.
 
 ## Scrying
 
@@ -34,19 +34,19 @@ Spider (the Gall agent that manages threads) has an Eyre binding that allows you
 
 Generators, which are like Hoon scripts, can also be used through Eyre. Rather than having a predefined JSON API, they instead handle HTTP requests and return HTTP responses directly, and are therefore a more complex case that you're less likely to use.
 
-Their usage is explained in the [%serve](/docs/arvo/eyre/tasks#serve) section of the [Internal API Reference](/docs/arvo/eyre/tasks) documentation and a practical example is provided in the [Generators](/docs/arvo/eyre/examples#generators) section of the [Examples](/docs/arvo/eyre/examples) document.
+Their usage is explained in the [%serve](/docs/arvo/eyre/tasks#serve) section of the [Internal API Reference](/docs/arvo/eyre/tasks) documentation and a practical example is provided in the [Generators](/docs/arvo/eyre/guide#generators) section of the [Guide](/docs/arvo/eyre/guide) document.
 
 ## Direct HTTP Handling With Gall Agents
 
 As well as the [Channel System](#the-channel-system) and [Scries](#scrying), it's also possible for Gall agents to deal directly with HTTP requests. This method is much more complicated than the channel system so you're unlikely to use it unless you want to build a custom HTTP-based API or something like that.
 
-This method is explained in the [%connect](/docs/arvo/eyre/tasks#connect) section of the [Internal API Reference](/docs/arvo/eyre/tasks) document and a detailed example is provided in the [Direct HTTP Handling With Gall Agents](/docs/arvo/eyre/examples#direct-http-handling-with-gall-agents) section of the [Examples](/docs/arvo/eyre/examples) document.
+This method is explained in the [%connect](/docs/arvo/eyre/tasks#connect) section of the [Internal API Reference](/docs/arvo/eyre/tasks) document and a detailed example is provided in the [Agents: Direct HTTP](/docs/arvo/eyre/guide#agents-direct-http) section of the [Guide](/docs/arvo/eyre/guide) document.
 
 ## Cross-Origin Resource Sharing
 
 Eyre supports both simple [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) requests and OPTIONS preflight requests. It has a CORS registry with three categories - `approved`, `rejected` and `requests`. Eyre will respond positively for origins in its `approved` list and negatively for all others. Eyre will add origins in requests that it doesn't have in either its `approved` or `rejected` lists to its `requests` list. Eyre always allows all methods and headers over CORS.
 
-There are three generators - `+cors-registry`, `|cors-approve`, and `|cors-reject` to view, approve, and deny origins respectively from the dojo. Eyre also has [tasks](/docs/arvo/eyre/tasks) to [approve](/docs/arvo/eyre/tasks#approve-origin) and [reject](/docs/arvo/eyre/tasks#reject-origin) origins programmatically, and a number of [scry endpoints](/docs/arvo/eyre/scry) to query them. Examples are also included in the [Managing CORS Origins](/docs/arvo/eyre/examples#managing-cors-origins) section of the Examples document.
+There are three generators - `+cors-registry`, `|cors-approve`, and `|cors-reject` to view, approve, and deny origins respectively from the dojo. Eyre also has [tasks](/docs/arvo/eyre/tasks) to [approve](/docs/arvo/eyre/tasks#approve-origin) and [reject](/docs/arvo/eyre/tasks#reject-origin) origins programmatically, and a number of [scry endpoints](/docs/arvo/eyre/scry) to query them. Examples are also included in the [Managing CORS Origins](/docs/arvo/eyre/guide#managing-cors-origins) section of the Guide document.
 
 ## Sections
 
@@ -58,4 +58,4 @@ There are three generators - `+cors-registry`, `|cors-approve`, and `|cors-rejec
 
 [Data Types](/docs/arvo/eyre/data-types) - Reference documentation of the various data types used by Eyre.
 
-[Examples](/docs/arvo/eyre/examples) - Practical examples of the different ways of using Eyre.
+[Guide](/docs/arvo/eyre/guide) - Practical examples of the different ways of using Eyre.

--- a/content/docs/arvo/eyre/tasks.md
+++ b/content/docs/arvo/eyre/tasks.md
@@ -6,7 +6,7 @@ template = "doc.html"
 
 This document details all the `task`s you're likely to use to interact with Eyre, as well as the `gift`s you'll receive in response.
 
-The primary way of interacting with Eyre is from the outside with HTTP requests. As a result, most of its `task`s are only used internally and you're unlikely to need to deal with them directly. The ones you may want to use in certain cases are [%connect](#connect), [%serve](#serve), [%disconnect](#disconnect), [%approve-origin](#approve-origin) and [%reject-origin](#reject-origin), and they are also demonstrated in the [Examples](/docs/arvo/eyre/examples) document. The rest are just documented for completeness.
+The primary way of interacting with Eyre is from the outside with HTTP requests. As a result, most of its `task`s are only used internally and you're unlikely to need to deal with them directly. The ones you may want to use in certain cases are [%connect](#connect), [%serve](#serve), [%disconnect](#disconnect), [%approve-origin](#approve-origin) and [%reject-origin](#reject-origin), and they are also demonstrated in the [Guide](/docs/arvo/eyre/guide) document. The rest are just documented for completeness.
 
 Many of the types referenced are detailed in the [Data Types](/docs/arvo/eyre/data-types) document. It may also be useful to look at the `+eyre` section of `/sys/lull.hoon` in Arvo where these `task`s, `gift`s and data structures are defined.
 
@@ -110,7 +110,7 @@ The `accepted` field says whether the binding succeeded and the `binding` is the
 
 #### Example
 
-See the [Direct HTTP Handling With Gall Agents](/docs/arvo/eyre/examples#direct-http-handling-with-gall-agents) section of the [Examples](/docs/arvo/eyre/examples) document for an example.
+See the [Agents: Direct HTTP](/docs/arvo/eyre/guide#agents-direct-http) section of the [Guide](/docs/arvo/eyre/guide) document for an example.
 
 ## `%serve`
 
@@ -146,7 +146,7 @@ Eyre will return a `%bound` `gift` as described at the end of the [%connect](#co
 
 #### Example
 
-See the [Generators](/docs/arvo/eyre/examples#generators) section of the [Examples](/docs/arvo/eyre/examples) document for an example.
+See the [Generators](/docs/arvo/eyre/guide#generators) section of the [Guide](/docs/arvo/eyre/guide) document for an example.
 
 ## `%disconnect`
 
@@ -192,7 +192,7 @@ Eyre returns no `gift` in response to a `%approve-origin` `task`.
 
 #### Example
 
-See the [Managing CORS Origins](/docs/arvo/eyre/examples#managing-cors-origins) section of the [Examples](/docs/arvo/eyre/examples) document for an example.
+See the [Managing CORS Origins](/docs/arvo/eyre/guide#managing-cors-origins) section of the [Guide](/docs/arvo/eyre/guide) document for an example.
 
 ## `%reject-origin`
 
@@ -210,4 +210,4 @@ Eyre returns no `gift` in response to a `%reject-origin` `task`.
 
 #### Example
 
-See the [Managing CORS Origins](/docs/arvo/eyre/examples#managing-cors-origins) section of the [Examples](/docs/arvo/eyre/examples) document for an example.
+See the [Managing CORS Origins](/docs/arvo/eyre/guide#managing-cors-origins) section of the [Guide](/docs/arvo/eyre/guide) document for an example.

--- a/content/docs/userspace/threads/http-api.md
+++ b/content/docs/userspace/threads/http-api.md
@@ -46,7 +46,7 @@ Here's an extremely simple thread that takes a `vase` of `(unit json)` and just 
 (pure:m !>(json))
 ```
 
-First we must obtain a session cookie by [authenticating](/docs/arvo/eyre/examples#authenticating).
+First we must obtain a session cookie by [authenticating](/docs/arvo/eyre/guide#authenticating).
 
 Now we can try and run our thread. Spider is bound to the `/spider` URL path, and expects the rest of the path to be `/{desk}/{inputMark}/{thread}/{outputMark}`. Our `{thread}` is called `eyre-thread` and is in the `%base` `{desk}`. Both its `{inputMark}` and `{outputMark}` are `json`. Therefore, our URL path will be `/spider/base/json/eyre-agent/json`. Our request will be an HTTP POST request and the body will be some `json`, in this case `[{"foo": "bar"}]`:
 


### PR DESCRIPTION
- rename examples to guide
- update relevant links throughout docs
- restructure into basic and advanced section
- add additional commentary
- misc tweaks