### PR TITLE
Add /install/windows/latest redirect and update /getting-started/cli

### DIFF
--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -46,11 +46,15 @@ sudo setcap 'cap_net_bind_service=+ep' ~/urbit/urbit
   <label for="windows">Windows</label>
   <div class="tab">
 
-> Please note that this method of installing Urbit is experimental, and we may not be able to assist you if you encounter issues related to WSL 2.
+```winbatch
+mkdir %USERPROFILE%\urbit
+cd %USERPROFILE%\urbit
+curl -JLO https://urbit.org/install/windows/latest
+tar zxvf .\windows.tgz --strip=1
+%USERPROFILE%\urbit\urbit
+```
 
-Urbit cannot run on Windows itself, but there is a convenient way to run Linux using the [Windows Subsystem for Linux 2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install) on Windows 10. Install the Windows Subsystem for Linux 2 and open a Linux terminal in Windows, then follow the Linux installation instructions below. These instructions have been tested and verified for WSL 2 + Ubuntu 18.04 LTS, as demonstrated in `~sitful-hatred`'s step-by-step setup guide [here](https://subject.network/posts/urbit-wsl2/).
-
-For performance reasons, do not install Urbit in the mounted Windows volume, but install it in the Linux file system. For example, in your home directory, which can be navigated to by entering `cd ~`.
+> Windows 10 build 17063 and later includes the familiar `curl` and `tar` command-line tools.
 
 </div>
 </div>

--- a/content/getting-started/planet.md
+++ b/content/getting-started/planet.md
@@ -114,8 +114,8 @@ here](/getting-started#port).
 Running Urbit from the command line is suitable for either a cloud installation
 or a local installation. If you're comfortable with the command line and would
 like greater control over the Urbit virtual machine, this is the right option.
-The Urbit runtime is available for Linux, MacOS, and can also be run on Windows
-by using WSL2. Additionally, there are guides for [hosting your planet on
+The Urbit runtime is available for Linux, MacOS and Windows.
+Additionally, there are guides for [hosting your planet on
 DigitalOcean](/using/running/hosting) and [hosting your planet on Linode
 (external
 link)](https://jeremytunnell.com/2021/01/09/how-to-install-urbit-on-a-linode-vps),

--- a/vercel.json
+++ b/vercel.json
@@ -44,6 +44,11 @@
       "permanent": true
     },
     {
+      "source": "/install/windows/latest",
+      "destination": "http://github.com/urbit/urbit/releases/latest/download/windows.tgz",
+      "permanent": true
+    },
+    {
       "source": "/using/install",
       "destination": "/getting-started",
       "permanent": true


### PR DESCRIPTION
Urbit 1.6 release includes Windows binaries. This PR adds a redirect and fixes the getting started guide to match.