### PR TITLE
Fix ambiguity in hoon-syntax.md

### DIFF
--- a/content/docs/hoon/hoon-school/hoon-syntax.md
+++ b/content/docs/hoon/hoon-school/hoon-syntax.md
@@ -254,7 +254,7 @@ The irregular form of the `.=` rune is just `=( )`:
 %.y
 ```
 
-The examples above have another irregular form: `(add 11 11)`. This is the irregular form of `%+`, which calls a [gate](/docs/glossary/gate/) (i.e., a Hoon function) with two arguments for the sample.
+The examples above contain another irregular form: `(add 11 11)`. This is the irregular form of `%+`, which calls a [gate](/docs/glossary/gate/) (i.e., a Hoon function) with two arguments for the sample.
 
 ```
 > %+  add  11  11


### PR DESCRIPTION
Change "have another irregular form" -> "contain another irregular form".  "have another irregular form" can too easily be read as "admit another irregular form", which is incorrect.