### PR TITLE
Sample of `+get:ju`

### DIFF
--- a/content/docs/hoon/reference/stdlib/2j.md
+++ b/content/docs/hoon/reference/stdlib/2j.md
@@ -263,11 +263,11 @@ A `jug`.
 
 Retrieve set
 
-Produces a set retrieved from jar `a` using key `b`.
+Produces a set retrieved from jug `a` using key `b`.
 
 #### Accepts
 
-`a` is a jar, and the sample of `+ju`.
+`a` is a jug, and the sample of `+ju`.
 
 `b` is key, a noun of the same type as the keys in `a`.
 


### PR DESCRIPTION
`+get:ju` was described as taking `a=jar`, which is incorrect. Updating to say that `a=jug`.