### PR TITLE
lustar alias -> deferred expression

### DIFF
--- a/content/docs/hoon/reference/rune/lus.md
+++ b/content/docs/hoon/reference/rune/lus.md
@@ -135,7 +135,7 @@ Any Hoon expression, `q`, may be used to define the arm computation.
 
 ### `+*` "lustar"
 
-Defines aliases within doors.
+Defines deferred expressions within doors.
 
 ##### Syntax
 
@@ -148,23 +148,28 @@ Regular: **variadic**.
     e=term  f=hoon
 ```
 
-`a`, `c`, `e` are arm names and `b`, `d`, `f` are any Hoon expression. Note that unlike all other
-runes with a variable number of arguments, the list of arguments of `+*` does
-not end with a terminator.
+`a`, `c`, `e` are arm names and `b`, `d`, `f` are any Hoon expression. Note that
+unlike all other runes with a variable number of arguments, the list of
+arguments of `+*` does not end with a terminator.
 
 `+*` arms must always come at the beginning of the battery, before any other
 type of lus arm.
 
 ##### Discussion
 
-The primary use of `+*` is to create aliases within doors (see Examples below).
-Aliases given by `+*` do not count towards the number of arms in the door and
-thus are also called "virtual arms", which
-can be important for things like Gall app cores that require a fixed number of arms.
+The primary use of `+*` is to create deferred expressions within doors (see
+Examples below). This is a name for an expressions that will be evaluated in
+each place the name is dereferenced. This is a similar concept to aliases or
+macros, but there are some subtle but important differences. Deferred
+expressions given by `+*` do not count towards the number of arms in the door
+and thus are also called "virtual arms", which can be important for things like
+Gall agent cores that require a fixed number of arms.
 
-Under the hood, `+*` gets compiled as `=*`'s. `+*  foo  bar` rewrites each `++`
-arm beneath it in the core to include
-`=*  foo  bar`. For example, the interpreter sees the Nock compiled from this Hoon expression
+Under the hood, `+*` gets compiled as
+[`=*`'s](/docs/hoon/reference/rune/tis#tistar) (see here for more discussion on
+deferred expressions). `+* foo bar` rewrites each `++` arm beneath it in the
+core to include `=* foo bar`. For example, the interpreter sees the Nock
+compiled from this Hoon expression
 
 ```hoon
 |_  z=@ud

--- a/content/docs/hoon/reference/rune/tis.md
+++ b/content/docs/hoon/reference/rune/tis.md
@@ -421,7 +421,7 @@ Regular: **running**.
 3
 ```
 
-### `=*` "tistar"
+### `=*` "tistar" {#tistar}
 
 `[%tstr p=term q=hoon r=hoon]`: define a deferred expression.
 

--- a/lib/glossary.js
+++ b/lib/glossary.js
@@ -425,7 +425,7 @@ export const glossary = [
     symbol: "+*",
     usage: "Arms",
     slug: "/docs/hoon/reference/rune/lus/#-lustar",
-    desc: "Produce a type constructor arm.",
+    desc: "Produce a deferred expression arm.",
   },
   {
     name: "col",


### PR DESCRIPTION
In #1085 we decided what `=*` actually does to be "deferred expression"
rather than alias or macro. Lustar never got the same treatment, so this fixes
that up.