### PR TITLE
revise overlooked placeholder in L2 docs

### DIFF
--- a/content/docs/azimuth/l2/layer2.md
+++ b/content/docs/azimuth/l2/layer2.md
@@ -14,8 +14,9 @@ protocol works, how secure it is, and how to extract data from layer 2 to obtain
 a complete picture of the Arvo network.
 
 This is not intended for everyday users who only wish to know how
-to either transfer their ship to layer 2 or perform layer 2 actions. For that,
-see ((bridge documentation yet to be written)). For a casual overview of the
+to either transfer their ship to layer 2 or perform layer 2 actions. This is a
+functionality of [Bridge](https://bridge.urbit.org) for which documentation will
+soon be available. For a casual overview of the
 rationale and functionality of layer 2, please see this [blog
 post](/blog/rollups). For more information on how Azimuth works more generally,
 including interactions with Bridge and Ethereum, see the page on [Azimuth data flow](/docs/azimuth/flow).


### PR DESCRIPTION
Bridge docs are coming very soon, I just forgot to remove the placeholder
referencing this when merging #1084