### PR TITLE
aura: correct typo in bitwidth example

### DIFF
--- a/content/docs/hoon/reference/auras.md
+++ b/content/docs/hoon/reference/auras.md
@@ -55,7 +55,7 @@ Capital letters at the end of auras indicate the bitwidth in binary powers of
 two, starting from A.
 
 ```
-        @ubD    signed single-byte (8-bit) decimal
+        @udD    unsigned single-byte (8-bit) decimal
         @tD     8-bit ASCII text
         @rhE    half-precision (16-bit) floating-point number
         @uxG    unsigned 64-bit hexadecimal


### PR DESCRIPTION
One of the examples in the [Bitwidth section of the Auras page](https://urbit.org/docs/hoon/reference/auras#bitwidth) mistakenly describes the aura `@ubD` as a signed 8-bit decimal. I've updated the aura to `@udD` and the description to an _unsigned_ 8-bit decimal.