### PR TITLE
Fix CSS width bug on several pages

### DIFF
--- a/components/Container.js
+++ b/components/Container.js
@@ -1,7 +1,7 @@
 // Ensures the root container is always 100vw, min 100vh, and centers all children along the y-axis
 export default function Container({ children }) {
   return (
-    <div className="flex flex-col min-h-screen w-screen items-center">
+    <div className="flex flex-col min-h-screen w-screen max-w-full items-center">
       {children}
     </div>
   );

--- a/pages/community/[[...slug]].js
+++ b/pages/community/[[...slug]].js
@@ -66,7 +66,7 @@ export default function UsingLayout({ posts, data, params, search, markdown }) {
         <title>{data.title} • Community • urbit.org</title>
         {Meta(data)}
       </Head>
-      <div className="flex w-screen h-screen min-h-screen w-screen sidebar">
+      <div className="flex h-screen min-h-screen w-screen sidebar">
         <Sidebar search={search}>
           {childPages("/community", posts.pages)}
         </Sidebar>

--- a/pages/docs/[[...slug]].js
+++ b/pages/docs/[[...slug]].js
@@ -127,7 +127,7 @@ export default function DocsLayout({
         <title>{data.title} • Documentation • urbit.org</title>
         {Meta(data)}
       </Head>
-      <div className="flex w-screen h-screen min-h-screen w-screen sidebar">
+      <div className="flex h-screen min-h-screen w-screen sidebar">
         <Sidebar search={search}>
           <ul>
             <li>

--- a/pages/getting-started/[[...slug]].js
+++ b/pages/getting-started/[[...slug]].js
@@ -76,7 +76,7 @@ export default function UsingLayout({ posts, data, params, search, markdown }) {
         <title>{data.title} • Getting Started • urbit.org</title>
         {Meta(data)}
       </Head>
-      <div className="flex w-screen h-screen min-h-screen w-screen sidebar">
+      <div className="flex h-screen min-h-screen w-screen sidebar">
         <Sidebar search={search}>
           <ul>
             <li>

--- a/pages/understanding-urbit/[[...slug]].js
+++ b/pages/understanding-urbit/[[...slug]].js
@@ -88,7 +88,7 @@ export default function UnderstandingLayout({
         <title>{data.title} • Understanding Urbit • urbit.org</title>
         {Meta(data)}
       </Head>
-      <div className="flex w-screen h-screen min-h-screen w-screen sidebar">
+      <div className="flex h-screen min-h-screen w-screen sidebar">
         <Sidebar search={search}>
           <ul>
             <li>

--- a/pages/using/[[...slug]].js
+++ b/pages/using/[[...slug]].js
@@ -105,7 +105,7 @@ export default function UsingLayout({ posts, data, params, search, markdown }) {
         <title>{data.title} • User's Manual • urbit.org</title>
         {Meta(data)}
       </Head>
-      <div className="flex w-screen h-screen min-h-screen w-screen sidebar">
+      <div className="flex h-screen min-h-screen w-screen sidebar">
         <Sidebar search={search}>
           {childPages("/using", posts.children)}
         </Sidebar>


### PR DESCRIPTION
urbit.org has a little CSS bug that's making the page width wider than it needs to be. The width extends beyond the screen, forcing a bottom scrollbar even though there is no content in the blank area:

![image](https://user-images.githubusercontent.com/93157753/146100030-40f3489a-97c8-4a17-b761-7f63570acb76.png)

This appears to affect all non-Sidebar-layout pages. Luckily, it's all caused by a simple bug in `Container`. This bug's a classic: [your scrollbar is part of your viewport](https://stackoverflow.com/questions/23367345/100vw-causing-horizontal-overflow-but-only-if-more-than-one/23367686), so if there is a vertical scrollbar in a `100vw` element, that element will end up one scrollbar wider than the screen's visible area. In in this case, it's easy to fix- we can just add `max-w-full`, which fixes the problem:

![image](https://user-images.githubusercontent.com/93157753/146104033-6dec966e-775f-4b37-881a-e9c87ed873c9.png)

(While I was in there, I noticed some repeated `w-screen` classes, and figured I might as well fix those too.)