### PR TITLE
footer: add link to whitepaper

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -72,6 +72,11 @@ export default function Footer() {
                 <a className="mt-2 type-bold text-wall-500">FAQ</a>
               </div>
             </Link>
+            <Link href="//media.urbit.org/whitepaper.pdf">
+              <div>
+                <a className="mt-2 type-bold text-wall-500">Whitepaper</a>
+              </div>
+            </Link>
           </div>
           <div className="w-1/2 md:w-1/3 flex flex-col flex-shrink">
             <h4 className="mt-16 mb-8">News</h4>


### PR DESCRIPTION
Somewhere along the line the whitepaper disappeared from the website.

This adds it back in, subtly, in the footer. We may or may not also want to mention it elsewhere. For example, it doesn't turn up in search right now.