### PR TITLE
%keys scry does not return a (set resource) but an `update:store` tha…

### DIFF
--- a/content/docs/userspace/graph-store/graph-store-reference.md
+++ b/content/docs/userspace/graph-store/graph-store-reference.md
@@ -61,7 +61,7 @@ Obtain a vase of the current state of graph-store as a noun.
 Fetch the resources of all graphs that graph-store is currently tracking.
 
 - Path: `/x/keys`
-- Output Type: `(set resource)`
+- Output Type: `update:store`, `%keys`
 
 ### Fetch tag queries
 


### PR DESCRIPTION
…t itself contains [%keys (set resource)].