### PR TITLE
update stdlib 4k and 4l

### DIFF
--- a/content/docs/hoon/reference/stdlib/4k.md
+++ b/content/docs/hoon/reference/stdlib/4k.md
@@ -8,30 +8,38 @@ template = "doc.html"
 
 Literal rendering engine
 
-A door that contains arms that operate on the sample coin `lot`.
+`++co` contains three parts:
+
+- A door that contains arms that operate on the sample coin `lot`.
+- A core of rendering idioms.
+- A core of additional formatting functions used internally.
 
 #### Accepts
 
-#### Produces
-
-`lot` is a `++coin`.
+`lot` is a `coin`.
 
 #### Source
 
+The arm begins with the door:
+
 ```hoon
-    ++  co  !.
-      ~%  %co  ..co  ~
-      =<  |_  lot/coin
+++  co
+  !:
+  ~%  %co  ..co  ~
+  =<  |_  lot=coin
 ```
 
-#### Examples
+Then after that the rendering idiom core begins with:
 
+```hoon
+=|  rep=tape
+=<  |%
 ```
-        > < 3.nta
-        { lot/{$many {$~ $ta @t} {$~ $ud @ud} $~}
-          <10.cfg 4.jjn {rep/"" <402.arm 110.jyx 1.ztu $151>}>
-        }
-        >
+
+And finally the third core:
+
+```hoon
+|%
 ```
 
 ---
@@ -44,53 +52,57 @@ Renders a coin `lot` as a tape prepended to the sample tape `rom`.
 
 #### Accepts
 
+`lot` is a `coin`, and is the sample of `++co`.
+
+`rom` is a `tape`.
+
 #### Produces
 
-`rom` is a `pe`
-
-`lot` is a `++coin`.
+A `tape`.
 
 #### Source
 
 ```hoon
-          ++  rear  |=(rom/tape =>(.(rex rom) rend))
+++  rear  |=(rom=tape rend(rep rom))
 ```
 
 #### Examples
 
 ```
-    > (~(rear co %$ %ux 200) "--ha")
-    "0xc8--ha"
+> (~(rear co %$ %ux 200) "--ha")
+"0xc8--ha"
 ```
 
 ---
 
 ### `++rent:co`
 
-Render as span
+Render as knot
 
-Renders a coin `lot` as a span.
+Renders a coin `lot` as a `knot`.
 
 #### Accepts
 
+`lot` is a `coin`, and is the sample of `++co`.
+
 #### Produces
 
-`lot` is a `++coin`.
+A `knot`.
 
 #### Source
 
 ```hoon
-          ++  rent  `@ta`(rap 3 rend)
+++  rent  ~+  `@ta`(rap 3 rend)
 ```
 
 #### Examples
 
 ```
-    > ~(rent co %$ %ux 200)
-    ~.0xc8
+> ~(rent co %$ %ux 200)
+~.0xc8
 
-    > `@t`~(rent co %$ %ux 200)
-    '0xc8'
+> `@t`~(rent co %$ %ux 200)
+'0xc8'
 ```
 
 ---
@@ -99,178 +111,731 @@ Renders a coin `lot` as a span.
 
 Render as tape
 
-Renders a coin `lot` as a tape.
+Renders a coin `lot` as a `tape`.
 
 #### Accepts
 
+`lot` is a `coin`, and is the sample of `++co`.
+
 #### Produces
 
-`lot` is a `++coin`.
+A `tape`.
 
 #### Source
 
 ```hoon
-      ++  rend
-        ^-  tape
-        ?:  ?=($blob -.lot)
-          ['~' '0' ((v-co 1) (jam p.lot))]
-        ?:  ?=($many -.lot)
-          :-  '.'
-          |-  ^-  tape
-          ?~   p.lot
-            ['_' '_' rep]
-          ['_' (weld (trip (wack rent(lot i.p.lot))) $(p.lot t.p.lot))]
-        =+  [yed=(end 3 1 p.p.lot) hay=(cut 3 [1 1] p.p.lot)]
-        |-  ^-  tape
-        ?+    yed  (z-co q.p.lot)
-            $c   ['~' '-' (weld (rip 3 (wood (tuft q.p.lot))) rep)]
-            $d
-          ?+    hay  (z-co q.p.lot)
-              $a
-            =+  yod=(yore q.p.lot)
-            =>  ^+(. .(rep ?~(f.t.yod rep ['.' (s-co f.t.yod)])))
-            =>  ^+  .
-                %=    .
-                    rep
-                  ?:  &(=(~ f.t.yod) =(0 h.t.yod) =(0 m.t.yod) =(0 s.t.yod))
-                    rep
-                  =>  .(rep ['.' (y-co s.t.yod)])
-                  =>  .(rep ['.' (y-co m.t.yod)])
-                  ['.' '.' (y-co h.t.yod)]
-                ==
-            =>  .(rep ['.' (a-co d.t.yod)])
-            =>  .(rep ['.' (a-co m.yod)])
-            =>  .(rep ?:(a.yod rep ['-' rep]))
-            ['~' (a-co y.yod)]
-          ::
-              $r
-            =+  yug=(yell q.p.lot)
-            =>  ^+(. .(rep ?~(f.yug rep ['.' (s-co f.yug)])))
-            :-  '~'
-            ?:  &(=(0 d.yug) =(0 m.yug) =(0 h.yug) =(0 s.yug))
-              ['s' '0' rep]
-            =>  ^+(. ?:(=(0 s.yug) . .(rep ['.' 's' (a-co s.yug)])))
-            =>  ^+(. ?:(=(0 m.yug) . .(rep ['.' 'm' (a-co m.yug)])))
-            =>  ^+(. ?:(=(0 h.yug) . .(rep ['.' 'h' (a-co h.yug)])))
-            =>  ^+(. ?:(=(0 d.yug) . .(rep ['.' 'd' (a-co d.yug)])))
-            +.rep
-          ==
-        ::
-            $f
-          ?:  =(& q.p.lot)
-            ['.' 'y' rep]
-          ?:(=(| q.p.lot) ['.' 'n' rep] (z-co q.p.lot))
-        ::
-            $n   ['~' rep]
-            $i
-          ?+  hay  (z-co q.p.lot)
-            $f  ((ro-co [3 10 4] |=(a/@ ~(d ne a))) q.p.lot)
-            $s  ((ro-co [4 16 8] |=(a/@ ~(x ne a))) q.p.lot)
-          ==
-        ::
-            $p
-          =+  dyx=(met 3 q.p.lot)
-          :-  '~'
-          ?:  (lte dyx 1)
-            (weld (trip (tod:po q.p.lot)) rep)
-          ?:  =(2 dyx)
-            ;:  weld
-              (trip (tos:po (end 3 1 q.p.lot)))
-              (trip (tod:po (rsh 3 1 q.p.lot)))
-              rep
-            ==
-          =+  [dyz=(met 5 q.p.lot) fin=| dub=&]
-          |-  ^-  tape
-          ?:  =(0 dyz)
-            rep
-          %=    $
-              fin      &
-              dub      !dub
-              dyz      (dec dyz)
-              q.p.lot  (rsh 5 1 q.p.lot)
-              rep
-            =+  syb=(wren:un (end 5 1 q.p.lot))
-            =+  cog=~(zig mu [(rsh 4 1 syb) (end 4 1 syb)])
-            ;:  weld
-              (trip (tos:po (end 3 1 p.cog)))
-              (trip (tod:po (rsh 3 1 p.cog)))
-              `tape`['-' ~]
-              (trip (tos:po (end 3 1 q.cog)))
-              (trip (tod:po (rsh 3 1 q.cog)))
-              `tape`?.(fin ~ ['-' ?.(dub ~ ['-' ~])])
-              rep
-            ==
-          ==
-        ::
-            $r
-          ?+  hay  (z-co q.p.lot)
-            $d  ['.' '~' (r-co (rlyd q.p.lot))]
-            $h  ['.' '~' '~' (r-co (rlyh q.p.lot))]
-            $q  ['.' '~' '~' '~' (r-co (rlyq q.p.lot))]
-            $s  ['.' (r-co (rlys q.p.lot))]
-          ==
-        ::
-            $u
-          ?:  ?=($c hay)
-            %+  welp  ['0' 'c' (reap (pad:fa q.p.lot) '1')]
-            (c-co (enc:fa q.p.lot))
-          =-  (weld p.gam ?:(=(0 q.p.lot) `tape`['0' ~] q.gam))
-          ^=  gam  ^-  {p/tape q/tape}
-          ?+  hay  [~ ((ox-co [10 3] |=(a/@ ~(d ne a))) q.p.lot)]
-            $b  [['0' 'b' ~] ((ox-co [2 4] |=(a/@ ~(d ne a))) q.p.lot)]
-            $i  [['0' 'i' ~] ((d-co 1) q.p.lot)]
-            $x  [['0' 'x' ~] ((ox-co [16 4] |=(a/@ ~(x ne a))) q.p.lot)]
-            $v  [['0' 'v' ~] ((ox-co [32 5] |=(a/@ ~(x ne a))) q.p.lot)]
-            $w  [['0' 'w' ~] ((ox-co [64 5] |=(a/@ ~(w ne a))) q.p.lot)]
-          ==
-        ::
-            $s
-          %+  weld
-            ?:((syn:si q.p.lot) "--" "-")
-          $(yed 'u', q.p.lot (abs:si q.p.lot))
-        ::
-            $t
-          ?:  =('a' hay)
-            ?:  =('s' (cut 3 [2 1] p.p.lot))
-              (weld (rip 3 q.p.lot) rep)
-            ['~' '.' (weld (rip 3 q.p.lot) rep)]
-          ['~' '~' (weld (rip 3 (wood q.p.lot)) rep)]
-        ==
-      --
+++  rend
+  ^-  tape
+  ~+
+  ?:  ?=(%blob -.lot)
+    ['~' '0' ((v-co 1) (jam p.lot))]
+  ?:  ?=(%many -.lot)
+    :-  '.'
+    |-  ^-  tape
+    ?~   p.lot
+      ['_' '_' rep]
+    ['_' (weld (trip (wack rent(lot i.p.lot))) $(p.lot t.p.lot))]
+  =+  [yed=(end 3 p.p.lot) hay=(cut 3 [1 1] p.p.lot)]
+  |-  ^-  tape
+  ?+    yed  (z-co q.p.lot)
+      %c   ['~' '-' (weld (rip 3 (wood (tuft q.p.lot))) rep)]
+      %d
+    ?+    hay  (z-co q.p.lot)
+        %a
+      =+  yod=(yore q.p.lot)
+      =?  rep  ?=(^ f.t.yod)  ['.' (s-co f.t.yod)]
+      =?  rep  !&(?=(~ f) =(0 h) =(0 m) =(0 s)):t.yod
+        =.  rep  ['.' (y-co s.t.yod)]
+        =.  rep  ['.' (y-co m.t.yod)]
+        ['.' '.' (y-co h.t.yod)]
+      =.  rep  ['.' (a-co d.t.yod)]
+      =.  rep  ['.' (a-co m.yod)]
+      =?  rep  !a.yod  ['-' rep]
+      ['~' (a-co y.yod)]
+    ::
+        %r
+      =+  yug=(yell q.p.lot)
+      =?  rep  ?=(^ f.yug)  ['.' (s-co f.yug)]
+      :-  '~'
+      ?:  &(=(0 d.yug) =(0 m.yug) =(0 h.yug) =(0 s.yug))
+        ['s' '0' rep]
+      =?  rep  !=(0 s.yug)  ['.' 's' (a-co s.yug)]
+      =?  rep  !=(0 m.yug)  ['.' 'm' (a-co m.yug)]
+      =?  rep  !=(0 h.yug)  ['.' 'h' (a-co h.yug)]
+      =?  rep  !=(0 d.yug)  ['.' 'd' (a-co d.yug)]
+      +.rep
+    ==
+  ::
+      %f
+    ?:  =(& q.p.lot)
+      ['.' 'y' rep]
+    ?:(=(| q.p.lot) ['.' 'n' rep] (z-co q.p.lot))
+  ::
+      %n   ['~' rep]
+      %i
+    ?+  hay  (z-co q.p.lot)
+      %f  ((ro-co [3 10 4] |=(a=@ ~(d ne a))) q.p.lot)
+      %s  ((ro-co [4 16 8] |=(a=@ ~(x ne a))) q.p.lot)
+    ==
+  ::
+      %p
+    =+  sxz=(fein:ob q.p.lot)
+    =+  dyx=(met 3 sxz)
+    :-  '~'
+    ?:  (lte dyx 1)
+      (weld (trip (tod:po sxz)) rep)
+    =+  dyy=(met 4 sxz)
+    =|  imp=@ud
+    |-  ^-  tape
+    ?:  =(imp dyy)
+      rep
+    %=  $
+      imp  +(imp)
+      rep  =/  log  (cut 4 [imp 1] sxz)
+           ;:  weld
+             (trip (tos:po (rsh 3 log)))
+             (trip (tod:po (end 3 log)))
+             ?:(=((mod imp 4) 0) ?:(=(imp 0) "" "--") "-")
+             rep
+    ==     ==
+  ::
+      %q
+    :+  '.'  '~'
+    =;  res=(pair ? tape)
+      (weld q.res rep)
+    %+  roll
+      =*  val  q.p.lot
+      ?:(=(0 val) ~[0] (rip 3 val))
+    |=  [q=@ s=? r=tape]
+    :-  !s
+    %+  weld
+     (trip (?:(s tod:po tos:po) q))
+    ?.(&(s !=(r "")) r ['-' r])
+  ::
+      %r
+    ?+  hay  (z-co q.p.lot)
+      %d  ['.' '~' (r-co (rlyd q.p.lot))]
+      %h  ['.' '~' '~' (r-co (rlyh q.p.lot))]
+      %q  ['.' '~' '~' '~' (r-co (rlyq q.p.lot))]
+      %s  ['.' (r-co (rlys q.p.lot))]
+    ==
+  ::
+      %u
+    ?:  ?=(%c hay)
+      %+  welp  ['0' 'c' (reap (pad:fa q.p.lot) '1')]
+      (c-co (enc:fa q.p.lot))
+    ::
+    =;  gam=(pair tape tape)
+      (weld p.gam ?:(=(0 q.p.lot) `tape`['0' ~] q.gam))
+    ?+  hay  [~ ((ox-co [10 3] |=(a=@ ~(d ne a))) q.p.lot)]
+      %b  [['0' 'b' ~] ((ox-co [2 4] |=(a=@ ~(d ne a))) q.p.lot)]
+      %i  [['0' 'i' ~] ((d-co 1) q.p.lot)]
+      %x  [['0' 'x' ~] ((ox-co [16 4] |=(a=@ ~(x ne a))) q.p.lot)]
+      %v  [['0' 'v' ~] ((ox-co [32 5] |=(a=@ ~(x ne a))) q.p.lot)]
+      %w  [['0' 'w' ~] ((ox-co [64 5] |=(a=@ ~(w ne a))) q.p.lot)]
+    ==
+  ::
+      %s
+    %+  weld
+      ?:((syn:si q.p.lot) "--" "-")
+    $(yed 'u', q.p.lot (abs:si q.p.lot))
+  ::
+      %t
+    ?:  =('a' hay)
+      ?:  =('s' (cut 3 [2 1] p.p.lot))
+        (weld (rip 3 q.p.lot) rep)
+      ['~' '.' (weld (rip 3 q.p.lot) rep)]
+    ['~' '~' (weld (rip 3 (wood q.p.lot)) rep)]
+  ==
 ```
 
 #### Examples
 
 ```
-    > ~(rend co %$ %ux 200)
-    "0xc8"
+> ~(rend co %$ %ux 200)
+"0xc8"
 
-    > ~(rend co %many ~[[%$ ux+200] [%$ p+40]])
-    "._0xc8_~~tem__"
+> ~(rend co %many ~[[%$ ux+200] [%$ p+40]])
+"._0xc8_~~tem__"
 
-    > ~(rend co %$ %p 32.819)
-    "~pillyt"
+> ~(rend co %$ %p 32.819)
+"~lasmev"
 
-    > ~(rend co %$ %ux 18)
-    "0x12"
+> ~(rend co %$ %ux 18)
+"0x12"
 
-    > ~(rend co [%$ p=[p=%if q=0x7f00.0001]])
-    ".127.0.0.1"
+> ~(rend co [%$ p=[p=%if q=0x7f00.0001]])
+".127.0.0.1"
 
-    > `@ux`.127.0.0.1
-    2.130.706.433
+> ~(rend co %many ~[[%$ %ud 20] [%$ %uw 133] [%$ %tas 'sam']])
+"._20_0w25_sam__"
 
-    > ~(rend co %many ~[[%$ %ud 20] [%$ %uw 133] [%$ %tas 'sam']])
-    "._20_0w25_sam__"
+> ~(rend co %blob [1 1])
+"~0ph"
+```
 
-    > ~(rend co %blob [1 1])
-    "~0ph"
+---
 
-    > ~0ph
-    [1 1]
+### `++a-co:co`
 
-    > `@uv`(jam [1 1])
-    0vph
+Render decimal
+
+Render `dat` as a decimal integer without separators.
+
+#### Accepts
+
+`dat` is an atom.
+
+#### Produces
+
+A `tape`
+
+#### Source
+
+```hoon
+++  a-co  |=(dat=@ ((d-co 1) dat))
+```
+
+#### Examples
+
+```
+> (a-co:co 123.456.789)
+"123456789"
+```
+
+---
+
+### `++c-co:co`
+
+Render base58check
+
+Renders the given `atom` as a base58check `tape`.
+
+#### Accepts
+
+An `atom`.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  c-co  (em-co [58 1] |=([? b=@ c=tape] [~(c ne b) c]))
+```
+
+#### Examples
+
+```
+> (enc:fa 0xdead.beef)
+0xdead.beef.938b.8b0c
+
+> (c-co:co 0xdead.beef.938b.8b0c)
+"eFGDJSVvRHd"
+```
+
+---
+
+### `++d-co:co`
+
+Render decimal with min length
+
+Render `hol` as a decimal integer without separators and with a minimum length
+of `min`. If `hol` has less than `min` digits, leading zeros will be added to
+make up the difference.
+
+#### Accepts
+
+`min` is an atom.
+
+`hol` is an atom.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  d-co  |=(min=@ (em-co [10 min] |=([? b=@ c=tape] [~(d ne b) c])))
+```
+
+#### Examples
+
+```
+> ((d-co:co 1) 123.456)
+"123456"
+
+> ((d-co:co 9) 123.456)
+"000123456"
+```
+
+---
+
+### `++r-co:co`
+
+Render floating point
+
+Render decimal float `a` as a `tape`.
+
+#### Accepts
+
+`a` is a `++dn`.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  r-co
+  |=  a=dn
+  ?:  ?=([%i *] a)  (weld ?:(s.a "inf" "-inf") rep)
+  ?:  ?=([%n *] a)  (weld "nan" rep)
+  =;  rep  ?:(s.a rep ['-' rep])
+  =/  f  ((d-co 1) a.a)
+  =^  e  e.a
+    =/  e=@s  (sun:si (lent f))
+    =/  sci  :(sum:si e.a e -1)
+    ?:  (syn:si (dif:si e.a --3))  [--1 sci]  :: 12000 -> 12e3 e>+2
+    ?:  !(syn:si (dif:si sci -2))  [--1 sci]  :: 0.001 -> 1e-3 e<-2
+    [(sum:si sci --1) --0] :: 1.234e2 -> '.'@3 -> 123 .4
+  =?  rep  !=(--0 e.a)
+    :(weld ?:((syn:si e.a) "e" "e-") ((d-co 1) (abs:si e.a)))
+  (weld (ed-co e f) rep)
+```
+
+#### Examples
+
+```
+> `tape`(r-co:co (rlys .3.14))
+"3.14"
+
+> `tape`(r-co:co (rlys .1.681557e-39))
+"1.681557e-39"
+```
+
+---
+
+### `++s-co:co`
+
+Render hex list
+
+Render `esc`, a list of atoms, as hex with a dot before each value. Values less
+than two bytes in length will be padded with zeros.
+
+#### Accepts
+
+`esc` is a `(list @)`.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  s-co
+  |=  esc=(list @)  ^-  tape
+  ?~  esc  rep
+  ['.' =>(.(rep $(esc t.esc)) ((x-co 4) i.esc))]
+```
+
+#### Examples
+
+```
+> `tape`(s-co:co ~[0xdead 0xbeef 0xcafe])
+".dead.beef.cafe"
+
+> `tape`(s-co:co ~[0xa 0xb 0xc])
+".000a.000b.000c"
+
+> `tape`(s-co:co ~[0xdead.beef])
+".deadbeef"
+```
+
+---
+
+### `++v-co:co`
+
+Render base-32 with minimum length
+
+Render `hol` as base-32 with a minimum length of `min`. If `hol` is shorter than
+`min` it will be padded with zeros.
+
+#### Accepts
+
+`min` is a `@ud`.
+
+`hol` is an atom.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  v-co  |=(min=@ (em-co [32 min] |=([? b=@ c=tape] [~(v ne b) c])))
+```
+
+#### Examples
+
+```
+> `tape`((v-co:co 1) 0v2l7.eiug3.0mbd9)
+"2l7eiug30mbd9"
+
+> `tape`((v-co:co 20) 0v2l7.eiug3.0mbd9)
+"00000002l7eiug30mbd9"
+```
+
+---
+
+### `++w-co:co`
+
+Render base-64 with minimum length
+
+Render `hol` as base-64 with a minimum length of `min`. If `hol` is horter than
+`min` it will be padded with zeros.
+
+#### Accepts
+
+`min` is a `@ud`.
+
+`hol` is an atom.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  w-co  |=(min=@ (em-co [64 min] |=([? b=@ c=tape] [~(w ne b) c])))
+```
+
+#### Examples
+
+```
+> `tape`((w-co:co 1) 0w2.OtBSR.pPVeT)
+"2OtBSRpPVeT"
+
+> `tape`((w-co:co 20) 0w2.OtBSR.pPVeT)
+"0000000002OtBSRpPVeT"
+```
+
+---
+
+### `++x-co:co`
+
+Render hex with minimum length
+
+Render `hol` as hex with a minimum length of `min`. If `hol` is horter than
+`min` it will be padded with zeros.
+
+#### Accepts
+
+`min` is a `@ud`.
+
+`hol` is an atom.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  x-co  |=(min=@ (em-co [16 min] |=([? b=@ c=tape] [~(x ne b) c])))
+```
+
+#### Examples
+
+```
+> `tape`((x-co:co 1) 0xdead.beef)
+"deadbeef"
+
+> `tape`((x-co:co 20) 0xdead.beef)
+"000000000000deadbeef"
+```
+
+---
+
+### `++y-co:co`
+
+Render decimal with at least two digits
+
+Render `dat` as a decimal with a minimum of two digits. If `dat` is less than
+two digits it will be padded with zeros.
+
+#### Accepts
+
+`dat` is an atom.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  y-co  |=(dat=@ ((d-co 2) dat))
+```
+
+#### Examples
+
+```
+> (y-co:co 0)
+"00"
+
+> (y-co:co 1)
+"01"
+
+> (y-co:co 123)
+"123"
+
+> (y-co:co 123.456)
+"123456"
+```
+
+---
+
+### `++z-co:co`
+
+Render '0x'-prefixed hex
+
+Render `dat` as hex with a `0x` prefix.
+
+#### Accepts
+
+`dat` is an atom.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  z-co  |=(dat=@ `tape`['0' 'x' ((x-co 1) dat)])
+```
+
+#### Examples
+
+```
+> (z-co:co 123)
+"0x7b"
+
+> (z-co:co 0xdead.beef)
+"0xdeadbeef"
+
+> (z-co:co 0)
+"0x0"
+```
+
+---
+
+### `++em-co:co`
+
+Render in numeric base
+
+In base `bas`, format `min` digits of `hol` with `par`. This is used internally
+by other rendering functions.
+
+- `hol` is processed least-significant digit first.
+- All available digits in `hol` will be processed, but
+  `min` digits can exceed the number available in `hol`
+- `par` handles all accumulated output on each call, and can edit it, prepend or
+  append digits, etc.
+- Until `hol` is exhausted, `par`'s sample is `[| digit output]`, subsequently,
+  it's `[& 0 output]`.
+
+#### Accepts
+
+`[bas=@ min=@]`, where `bas` is the numeric base and `min` is the minimum
+length.
+
+`par` is a `gate` of `$-([? @ tape] tape)`.
+
+`hol` is an atom.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  em-co
+  |=  [[bas=@ min=@] par=$-([? @ tape] tape)]
+  |=  hol=@
+  ^-  tape
+  ?:  &(=(0 hol) =(0 min))
+    rep
+  =/  [dar=@ rad=@]  (dvr hol bas)
+  %=  $
+    min  ?:(=(0 min) 0 (dec min))
+    hol  dar
+    rep  (par =(0 dar) rad rep)
+  ==
+```
+
+#### Examples
+
+```
+> ((em-co:co [16 10] |=([? b=@ c=tape] [~(x ne b) c])) 0xbeef)
+"000000beef"
+```
+
+---
+
+### `++ed-co:co`
+
+Format with decimal place
+
+Format `int` by specifying its size with `exp`, which may be negative. This is
+used internally by other rendering functions.
+
+#### Accepts
+
+`exp` is a `@s`.
+
+`int` is a `tape`.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  ed-co
+  |=  [exp=@s int=tape]  ^-  tape
+  =/  [pos=? dig=@u]  [=(--1 (cmp:si exp --0)) (abs:si exp)]
+  ?.  pos
+    (into (weld (reap +(dig) '0') int) 1 '.')
+  =/  len  (lent int)
+  ?:  (lth dig len)  (into int dig '.')
+  (weld int (reap (sub dig len) '0'))
+```
+
+#### Examples
+
+```
+> (ed-co:co --3 "100")
+"100"
+
+> (ed-co:co --5 "100")
+"10000"
+
+> (ed-co:co -1 "100")
+"0.0100"
+
+> (ed-co:co -5 "100")
+"0.00000100"
+```
+
+---
+
+### `++ox-co:co`
+
+Format dot-separated digits in numeric base
+
+In base `bas`, format each digit of `hol` with gate `dug`, with '.' separators
+every `gop` digits. This is used internally by other rendering functions.
+
+- `hol` is processed least-significant digit first.
+- `dug` handles individual digits, output is prepended.
+- Every segment but the last is zero-padded to `gop`.
+
+#### Accepts
+
+`[bas=@ gop=@]` where `bas` is the numeric base and `gop` is dot separator
+frequency.
+
+`dug` is a `gate` of `$-(@ @)`.
+
+`hol` is an atom.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  ox-co
+  |=  [[bas=@ gop=@] dug=$-(@ @)]
+  %+  em-co
+    [(pow bas gop) 0]
+  |=  [top=? seg=@ res=tape]
+  %+  weld
+    ?:(top ~ `tape`['.' ~])
+  %.  seg
+  %+  em-co(rep res)
+    [bas ?:(top 0 gop)]
+  |=([? b=@ c=tape] [(dug b) c])
+```
+
+#### Examples
+
+```
+> ((ox-co:co [2 4] |=(a=@ ~(d ne a))) 0b1011.1101)
+"1011.1101"
+
+> ((ox-co:co [2 1] |=(a=@ ~(d ne a))) 0b1011.1101)
+"1.0.1.1.1.1.0.1"
+
+> ((ox-co:co [2 100] |=(a=@ ~(d ne a))) 0b1011.1101)
+"10111101"
+```
+
+---
+
+### `++ro-co:co`
+
+Format dot-prefixed bloqs in numeric base
+
+In base `bas`, for `buz` bloqs 0 to `dop`, format at least one digit of `hol`,
+prefixed with `.`. This is used internally for `@i` address rendering functions.
+
+#### Accepts
+
+`[buz=@ bas=@ dop=@]` where `buz` is the bloq size, `bas` is the numeric base,
+and `dop` is the number of bloqs.
+
+`dug` is a `gate` of `$-(@ @)`.
+
+`hol` is an atom.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  ro-co
+  |=  [[buz=@ bas=@ dop=@] dug=$-(@ @)]
+  |=  hol=@
+  ^-  tape
+  ?:  =(0 dop)
+    rep
+  :-  '.'
+  =/  pod  (dec dop)
+  %.  (cut buz [pod 1] hol)
+  %+  em-co(rep $(dop pod))
+    [bas 1]
+  |=([? b=@ c=tape] [(dug b) c])
+```
+
+#### Examples
+
+```
+> ((ro-co:co [3 10 4] |=(a=@ ~(d ne a))) .127.0.0.1)
+".127.0.0.1"
 ```
 
 ---

--- a/content/docs/hoon/reference/stdlib/4l.md
+++ b/content/docs/hoon/reference/stdlib/4l.md
@@ -8,24 +8,14 @@ template = "doc.html"
 
 Coin parser engine
 
-Core containing arms that parse `++coin`.
-
-#### Accepts
-
-#### Produces
+Core containing arms that parse atoms encoded in strings.
 
 #### Source
 
 ```hoon
-    ++  so
-      |%
-```
-
-#### Examples
-
-```
-    > so
-    <10.mkn 414.hhh 100.xkc 1.ypj %164>
+++  so
+  ~%  %so  +  ~
+  |%
 ```
 
 ---
@@ -34,38 +24,37 @@ Core containing arms that parse `++coin`.
 
 Parse aura-atom pair
 
-Parsing rule. Parses an unsigned integer of any permitted base,
-producing a `++dime`.
-
-#### Accepts
-
-#### Produces
+Parsing `rule`. Parses an `@u` of any permitted base,
+producing a `dime`.
 
 #### Source
 
 ```hoon
-      ++  bisk
-        ;~  pose
-          ;~  pfix  (just '0')
-            ;~  pose
-              (stag %ub ;~(pfix (just 'b') bay:ag))
-              (stag %ui ;~(pfix (just 'i') dim:ag))
-              (stag %ux ;~(pfix (just 'x') hex:ag))
-              (stag %uv ;~(pfix (just 'v') viz:ag))
-              (stag %uw ;~(pfix (just 'w') wiz:ag))
-            ==
-          ==
-          (stag %ud dem:ag)
-        ==
+++  bisk
+  ~+
+  ;~  pose
+    ;~  pfix  (just '0')
+      ;~  pose
+        (stag %ub ;~(pfix (just 'b') bay:ag))
+        (stag %uc ;~(pfix (just 'c') fim:ag))
+        (stag %ui ;~(pfix (just 'i') dim:ag))
+        (stag %ux ;~(pfix (just 'x') hex:ag))
+        (stag %uv ;~(pfix (just 'v') viz:ag))
+        (stag %uw ;~(pfix (just 'w') wiz:ag))
+      ==
+    ==
+    (stag %ud dem:ag)
+  ==
 ```
 
 #### Examples
 
 ```
-    > (scan "25" bisk:so)
-    [%ud q=25]
-    > (scan "0x12.6401" bisk:so)
-    [%ux q=1.205.249]
+> (scan "25" bisk:so)
+[%ud 25]
+
+> (scan "0x12.6401" bisk:so)
+[%ux 1.205.249]
 ```
 
 ---
@@ -74,190 +63,68 @@ producing a `++dime`.
 
 Parse `@da`, `@dr`, `@p`, `@t`
 
-Parsing rule. Parses any atom of any of the following auras after a
-leading sig, `~` into a `++dime`: `@da`, `@dr`, `@p`,
-and `@t`, producing a `++dime`.
-
-#### Accepts
-
-#### Produces
+Parsing `rule`. Parses any atom of any of the following auras after a leading
+sig: `@da`, `@dr`, `@p`, and `@t`. Produces a `dime`.
 
 #### Source
 
 ```hoon
-      ++  crub
-        ~+
-        ;~  pose
-          %+  cook
-            |=(det/date `dime`[%da (year det)])
-          ;~  plug
-            %+  cook
-              |=({a/@ b/?} [b a])
-            ;~(plug dim:ag ;~(pose (cold | hep) (easy &)))
-            ;~(pfix dot dim:ag)   ::  month
-            ;~(pfix dot dim:ag)   ::  day
-            ;~  pose
-              ;~  pfix
-                ;~(plug dot dot)
-                ;~  plug
-                  dum:ag
-                  ;~(pfix dot dum:ag)
-                  ;~(pfix dot dum:ag)
-                  ;~(pose ;~(pfix ;~(plug dot dot) (most dot qix:ab)) (easy ~))
-                ==
-              ==
-              (easy [0 0 0 ~])
-            ==
-          ==
-        ::
-          %+  cook
-            |=  {a/(list {p/?($d $h $m $s) q/@}) b/(list @)}
-            =+  rop=`tarp`[0 0 0 0 b]
-            |-  ^-  dime
-            ?~  a
-              [%dr (yule rop)]
-            ?-  p.i.a
-              $d  $(a t.a, d.rop (add q.i.a d.rop))
-              $h  $(a t.a, h.rop (add q.i.a h.rop))
-              $m  $(a t.a, m.rop (add q.i.a m.rop))
-              $s  $(a t.a, s.rop (add q.i.a s.rop))
-            ==
-          ;~  plug
-            %+  most
-              dot
-            ;~  pose
-              ;~(pfix (just 'd') (stag %d dim:ag))
-              ;~(pfix (just 'h') (stag %h dim:ag))
-              ;~(pfix (just 'm') (stag %m dim:ag))
-              ;~(pfix (just 's') (stag %s dim:ag))
-            ==
-            ;~(pose ;~(pfix ;~(plug dot dot) (most dot qix:ab)) (easy ~))
-          ==
-        ::
-          (stag %p fed:ag)
-          ;~(pfix dot (stag %ta urs:ab))
-          ;~(pfix sig (stag %t urx:ab))
-          ;~(pfix hep (stag %c (cook turf urx:ab)))
-        ==
-      ++  nuck
-        ~/  %nuck  |=  a/nail  %.  a
-        %+  knee  *coin  |.  ~+
-        %-  stew
-        ^.  stet  ^.  limo
-        :~  :-  ['a' 'z']  (cook |=(a/@ta [%$ %tas a]) sym)
-            :-  ['0' '9']  (stag %$ bisk)
-            :-  '-'        (stag %$ tash)
-            :-  '.'        ;~(pfix dot perd)
-            :-  '~'        ;~(pfix sig ;~(pose twid (easy [%$ %n 0])))
-        ==
-      ++  nusk
-        ~+
-        :(sear |=(a/@ta (rush a nuck)) wick urt:ab)
-      ++  perd
-        ~+
-        ;~  pose
-          (stag %$ zust)
-          (stag %many (ifix [cab ;~(plug cab cab)] (more cab nusk)))
-        ==
-      ++  royl
-        ~+
-        =+  ^=  moo
-          |=  a/tape
-          :-  (lent a)
-          (scan a (bass 10 (plus sid:ab)))
-        =+  ^=  voy
-          %+  cook  royl-cell
-          ;~  pose
-            ;~  plug
-              (easy %d)
-              ;~  pose  (cold | hep)  (easy &)  ==
-              ;~  plug  dim:ag
-                ;~  pose
-                  ;~(pfix dot (cook moo (plus (shim '0' '9'))))
-                  (easy [0 0])
-                ==
-                ;~  pose
-                  ;~  pfix
-                    (just 'e')
-                    ;~(plug ;~(pose (cold | hep) (easy &)) dim:ag)
-                  ==
-                  (easy [& 0])
-                ==
-              ==
-            ==
-            ;~  plug
-              (easy %i)
-              ;~  sfix
-                ;~  pose  (cold | hep)  (easy &)  ==
-                (jest 'inf')
-              ==
-            ==
-            ;~  plug
-              (easy %n)
-              (cold ~ (jest 'nan'))
-            ==
-          ==
-        ;~  pose
-          (stag %rh (cook rylh ;~(pfix ;~(plug sig sig) voy)))
-          (stag %rq (cook rylq ;~(pfix ;~(plug sig sig sig) voy)))
-          (stag %rd (cook ryld ;~(pfix sig voy)))
-          (stag %rs (cook ryls voy))
-        ==
-      ::
-      ++  royl-cell
-        |=  rn
-        ^-  dn
-        ?.  ?=({$d *} +<)  +<
-        =+  ^=  h
-          (dif:si (new:si f.b i.b) (sun:si d.b))
-        [%d a h (add (mul c.b (pow 10 d.b)) e.b)]
-      ::
-      ++  tash
-        ~+
-        =+  ^=  neg
-            |=  {syn/? mol/dime}  ^-  dime
-            ?>  =('u' (end 3 1 p.mol))
-            [(cat 3 's' (rsh 3 1 p.mol)) (new:si syn q.mol)]
-        ;~  pfix  hep
-          ;~  pose
-            (cook |=(a/dime (neg | a)) bisk)
-            ;~(pfix hep (cook |=(a/dime (neg & a)) bisk))
-          ==
-        ==
-      ::
-      ++  twid
-        ~+
-        ;~  pose
-          (cook |=(a/@ [%blob (cue a)]) ;~(pfix (just '0') vum:ag))
-          (stag %$ crub)
-        ==
-      ::
-      ++  zust
-        ~+
-        ;~  pose
-          (stag %is bip:ag)
-          (stag %if lip:ag)
-          (stag %f ;~(pose (cold & (just 'y')) (cold | (just 'n'))))
-          royl
-        ==
-      --
+++  crub
+  ~+
+  ;~  pose
+    (cook |=(det=date `dime`[%da (year det)]) when)
+  ::
+    %+  cook
+      |=  [a=(list [p=?(%d %h %m %s) q=@]) b=(list @)]
+      =+  rop=`tarp`[0 0 0 0 b]
+      |-  ^-  dime
+      ?~  a
+        [%dr (yule rop)]
+      ?-  p.i.a
+        %d  $(a t.a, d.rop (add q.i.a d.rop))
+        %h  $(a t.a, h.rop (add q.i.a h.rop))
+        %m  $(a t.a, m.rop (add q.i.a m.rop))
+        %s  $(a t.a, s.rop (add q.i.a s.rop))
+      ==
+    ;~  plug
+      %+  most
+        dot
+      ;~  pose
+        ;~(pfix (just 'd') (stag %d dim:ag))
+        ;~(pfix (just 'h') (stag %h dim:ag))
+        ;~(pfix (just 'm') (stag %m dim:ag))
+        ;~(pfix (just 's') (stag %s dim:ag))
+      ==
+      ;~(pose ;~(pfix ;~(plug dot dot) (most dot qix:ab)) (easy ~))
+    ==
+  ::
+    (stag %p fed:ag)
+    ;~(pfix dot (stag %ta urs:ab))
+    ;~(pfix sig (stag %t urx:ab))
+    ;~(pfix hep (stag %c (cook taft urx:ab)))
+  ==
 ```
 
 #### Examples
 
 ```
-    > (scan "1926.5.12" crub:so)
-    [p=~.da q=170.141.184.449.747.016.871.285.095.307.149.312.000]
-    > ([%da @da] (scan "1926.5.12" crub:so))
-    [%da ~1926.5.12]
-    > (scan "s10" crub:so)
-    [p=~.dr q=184.467.440.737.095.516.160]
-    > ([%dr @dr] (scan "s10" crub:so))
-    [%dr ~s10]
-    > (scan "doznec" crub:so)
-    [%p 256]
-    > (scan ".mas" crub:so)
-    [%ta 7.561.581]
+> (scan "1926.5.12" crub:so)
+[p=~.da q=170.141.184.449.747.016.871.285.095.307.149.312.000]
+
+> ;;([%da @da] (scan "1926.5.12" crub:so))
+[%da ~1926.5.12]
+
+> (scan "s10" crub:so)
+[p=~.dr q=184.467.440.737.095.516.160]
+
+> ;;([%dr @dr] (scan "s10" crub:so))
+[%dr ~s10]
+
+> (scan "sampel" crub:so)
+[%p 1.135]
+
+> (scan ".mas" crub:so)
+[%ta 7.561.581]
 ```
 
 ---
@@ -266,53 +133,46 @@ and `@t`, producing a `++dime`.
 
 Top-level coin parser
 
-Parsing rule. Switches on the first character and applies the
-corresponding `++coin` parser.
-
-#### Accepts
-
-#### Produces
+Parsing `rule`. Switches on the first character and applies the
+corresponding `coin` parser.
 
 #### Source
 
 ```hoon
-        ++  nuck
-          ~/  %nuck  |=  a/nail  %.  a
-          %+  knee  *coin  |.  ~+
-          %-  stew
-          ^.  stet  ^.  limo
-          :~  :-  ['a' 'z']  (cook |=(a/@ta [%$ %tas a]) sym)
-              :-  ['0' '9']  (stag %$ bisk)
-              :-  '-'        (stag %$ tash)
-              :-  '.'        ;~(pfix dot perd)
-              :-  '~'        ;~(pfix sig ;~(pose twid (easy [%$ %n 0])))
-          ==
+++  nuck
+  ~/  %nuck  |=  a=nail  %.  a
+  %+  knee  *coin  |.  ~+
+  %-  stew
+  ^.  stet  ^.  limo
+  :~  :-  ['a' 'z']  (cook |=(a=@ta [%$ %tas a]) sym)
+      :-  ['0' '9']  (stag %$ bisk)
+      :-  '-'        (stag %$ tash)
+      :-  '.'        ;~(pfix dot perd)
+      :-  '~'        ;~(pfix sig ;~(pose twid (easy [%$ %n 0])))
+  ==
 ```
 
 #### Examples
 
 ```
-    > (scan "~pillyt" nuck:so)
-    [% p=[p=~.p q=32.819]]
-    > (scan "0x12" nuck:so)
-    [% p=[p=~.ux q=18]]
-    > (scan ".127.0.0.1" nuck:so)
-    [% p=[p=~.if q=2.130.706.433]]
-    > `@ud`.127.0.0.1
-    2.130.706.433
-    > (scan "._20_0w25_sam__" nuck:so)
-    [ %many
-        p
-      ~[[% p=[p=~.ud q=20]] [% p=[p=~.uw q=133]] [% p=[p=~.tas q=7.168.371]]]
-    ]
-    > `@`%sam
-    7.168.371
-    > (scan "~0ph" nuck:so)
-    [%blob p=[1 1]]
-    > ~0ph
-    [1 1]
-    > `@uv`(jam [1 1])
-    0vph
+> (scan "~pillyt" nuck:so)
+[%$ p=[p=~.p q=13.184]]
+
+> (scan "0x12" nuck:so)
+[%$ p=[p=~.ux q=18]]
+
+> (scan ".127.0.0.1" nuck:so)
+[%$ p=[p=~.if q=2.130.706.433]]
+
+> (scan "._20_0w25_sam__" nuck:so)
+[ %many
+    p
+  ~[
+    [%$ p=[p=~.ud q=20]]
+    [%$ p=[p=~.uw q=133]]
+    [%$ p=[p=~.tas q=7.168.371]]
+  ]
+]
 ```
 
 ---
@@ -321,67 +181,60 @@ corresponding `++coin` parser.
 
 Parse coin literal with escapes
 
-Parsing rule. Parses a coin literal with escapes. (See also: xx tuple
-formatting).
-
-#### Accepts
-
-#### Produces
+Parsing `rule`. Parses a coin literal with escapes.
 
 #### Source
 
 ```hoon
-      ++  nusk
-        (sear |=(a/@ta (rush (wick a) nuck)) urt:ab)
+++  nusk
+  ~+
+  :(sear |=(a=@ta (rush a nuck)) wick urt:ab)
 ```
 
 #### Examples
 
 ```
-    > ~.asd_a
-    ~.asd_a
-    > ._1_~~.asd~-a__
-    [1 ~.asd_a]
-    > (scan "~~.asd~-a" nusk:so)
-    [% p=[p=~.ta q=418.212.246.369]]
-    > ([~ %ta @ta] (scan "~~.asd~-a" nusk:so))
-    [~ %ta ~.asd_a]
+> ~.asd_a
+~.asd_a
+
+> ._1_~~.asd~-a__
+[1 ~.asd_a]
+
+> (scan "~~.asd~-a" nusk:so)
+[%$ p=[p=~.ta q=418.212.246.369]]
 ```
 
 ---
 
 ### `++perd:so`
 
-Parsing rule.
+Parsing coin literal without prefixes
 
-Parsing rule. Parses a dime or tuple without their respective standard
+Parsing `rule`. Parses a dime or tuple without their respective standard
 prefixes.
-
-#### Accepts
-
-#### Produces
 
 #### Source
 
 ```hoon
-      ++  perd
-        ;~  pose
-          (stag ~ zust)
-          (stag %many (ifix [cab ;~(plug cab cab)] (more cab nusk)))
-        ==
+++  perd
+  ~+
+  ;~  pose
+    (stag %$ zust)
+    (stag %many (ifix [cab ;~(plug cab cab)] (more cab nusk)))
+  ==
 ```
 
 #### Examples
 
 ```
-    > (scan "y" perd:so)
-    [~ [%f %.y]]
-    > (scan "n" perd:so)
-    [~ [%f %.n]]
-    > |
-    %.n
-    > (scan "_20_x__" perd:so)
-    [%many [[% p=[p=~.ud q=20]] ~[[% p=[p=~.tas q=120]]]]]
+> (scan "y" perd:so)
+[%$ [%f %.y]]
+
+> (scan "n" perd:so)
+[%$ [%f %.n]]
+
+> (scan "_20_x__" perd:so)
+[%many [[%$ p=[p=~.ud q=20]] [i=[%$ p=[p=~.tas q=120]] t=~]]]
 ```
 
 ---
@@ -390,88 +243,216 @@ prefixes.
 
 Parse dime float
 
-Parsing rule. Parses a number into a `++dime` float.
-
-#### Accepts
-
-#### Produces
+Parsing `rule`. Parses a number into a `dime` float.
 
 #### Source
 
 ```hoon
-  ++  royl
-    ~+
-    =+  ^=  moo
-      |=  a/tape
-      :-  (lent a)
-      (scan a (bass 10 (plus sid:ab)))
-    =+  ^=  voy
-      %+  cook  royl-cell
-      ;~  pose
-        ;~  plug
-          (easy %d)
-          ;~  pose  (cold | hep)  (easy &)  ==
-          ;~  plug  dim:ag
-            ;~  pose
-              ;~(pfix dot (cook moo (plus (shim '0' '9'))))
-              (easy [0 0])
-            ==
-            ;~  pose
-              ;~  pfix
-                (just 'e')
-                ;~(plug ;~(pose (cold | hep) (easy &)) dim:ag)
-              ==
-              (easy [& 0])
-            ==
-          ==
-        ==
-        ;~  plug
-          (easy %i)
-          ;~  sfix
-            ;~  pose  (cold | hep)  (easy &)  ==
-            (jest 'inf')
-          ==
-        ==
-        ;~  plug
-          (easy %n)
-          (cold ~ (jest 'nan'))
-        ==
-      ==
-    ;~  pose
-      (stag %rh (cook rylh ;~(pfix ;~(plug sig sig) voy)))
-      (stag %rq (cook rylq ;~(pfix ;~(plug sig sig sig) voy)))
-      (stag %rd (cook ryld ;~(pfix sig voy)))
-      (stag %rs (cook ryls voy))
-    ==
-  ::
+++  royl
+  ~+
+  ;~  pose
+    (stag %rh royl-rh)
+    (stag %rq royl-rq)
+    (stag %rd royl-rd)
+    (stag %rs royl-rs)
+  ==
 ```
 
 #### Examples
 
 ```
-    > (scan "~3.14" royl:so)
-    [%rd .~3.13999999999999]
-    > .~3.14
-    .~3.13999999999999
+> (scan "~3.14" royl:so)
+[%rd .~3.14]
+
+> (scan "3.14" royl:so)
+[%rs .3.14]
+```
+
+---
+
+### `++royl-rh:so`
+
+Parse half-precision float
+
+Parsing `rule`. Parses a `@rh`.
+
+#### Source
+
+```hoon
+++  royl-rh  (cook rylh ;~(pfix ;~(plug sig sig) (cook royl-cell royl-rn)))
+```
+
+#### Examples
+
+```
+> (scan "~~3.14" royl-rh:so)
+.~~3.14
+```
+
+---
+
+### `++royl-rq:so`
+
+Parse quad-precision float
+
+Parsing `rule`. Parses a `@rq`.
+
+#### Source
+
+```hoon
+++  royl-rq  (cook rylq ;~(pfix ;~(plug sig sig sig) (cook royl-cell royl-rn)))
+```
+
+#### Examples
+
+```
+> (scan "~~~3.14" royl-rq:so)
+.~~~3.14
+```
+
+---
+
+### `++royl-rd:so`
+
+Parse double-precision float
+
+Parsing `rule`. Parses a `@rd`.
+
+#### Source
+
+```hoon
+++  royl-rd  (cook ryld ;~(pfix sig (cook royl-cell royl-rn)))
+```
+
+#### Examples
+
+```
+> (scan "~3.14" royl-rd:so)
+.~3.14
+```
+
+---
+
+### `++royl-rs:so`
+
+Parse single-precision float
+
+Parsing `rule`. Parses a `@rs`.
+
+#### Source
+
+```hoon
+++  royl-rs  (cook ryls (cook royl-cell royl-rn))
+```
+
+#### Examples
+
+```
+> (scan "3.14" royl-rs:so)
+.3.14
+```
+
+---
+
+### `++royl-rn:so`
+
+Parse real number
+
+Parsing `rule`. Parses a real number to a [`++rn`](/docs/hoon/reference/stdlib/3b#rn).
+
+#### Source
+
+```hoon
+++  royl-rn
+  =/  moo
+    |=  a=tape
+    :-  (lent a)
+    (scan a (bass 10 (plus sid:ab)))
+  ;~  pose
+    ;~  plug
+      (easy %d)
+      ;~(pose (cold | hep) (easy &))
+      ;~  plug  dim:ag
+        ;~  pose
+          ;~(pfix dot (cook moo (plus (shim '0' '9'))))
+          (easy [0 0])
+        ==
+        ;~  pose
+          ;~  pfix
+            (just 'e')
+            ;~(plug ;~(pose (cold | hep) (easy &)) dim:ag)
+          ==
+          (easy [& 0])
+        ==
+      ==
+    ==
+    ::
+    ;~  plug
+      (easy %i)
+      ;~  sfix
+        ;~(pose (cold | hep) (easy &))
+        (jest 'inf')
+      ==
+    ==
+    ::
+    ;~  plug
+      (easy %n)
+      (cold ~ (jest 'nan'))
+    ==
+  ==
+```
+
+#### Examples
+
+```
+> (scan "3.14" royl-rn:so)
+[%d %.y 3 [2 14] [%.y 0]]
+
+> (scan "-3.14e-39" royl-rn:so)
+[%d %.n 3 [2 14] [%.n 39]]
+
+> (scan "3" royl-rn:so)
+[%d %.y 3 [0 0] [%.y 0]]
 ```
 
 ---
 
 ### `++royl-cell:so`
 
-XX still not fully functional
+Convert rn to dn
 
-Intermediate parsed float convereter
+Intermediate parsed float converter. Convert a
+[`++rn`](/docs/hoon/reference/stdlib/3b#rn) to
+[`++dn`](/docs/hoon/reference/stdlib/3b#dn).
+
+#### Accepts
+
+A `++rn`.
+
+#### Produces
+
+A `++dn`.
+
+#### Source
 
 ```hoon
-      ++  royl-cell
-        |=  rn
-        ^-  dn
-        ?.  ?=({$d *} +<)  +<
-        =+  ^=  h
-          (dif:si (new:si f.b i.b) (sun:si d.b))
-        [%d a h (add (mul c.b (pow 10 d.b)) e.b)]
-      ::
+++  royl-cell
+  |=  rn
+  ^-  dn
+  ?.  ?=([%d *] +<)  +<
+  =+  ^=  h
+    (dif:si (new:si f.b i.b) (sun:si d.b))
+  [%d a h (add (mul c.b (pow 10 d.b)) e.b)]
+```
+
+#### Examples
+
+```
+> (royl-cell:so (scan "3.14" royl-rn:so))
+[%d s=%.y e=-2 a=314]
+
+> (ryls (royl-cell:so (scan "3.14" royl-rn:so)))
+.3.14
 ```
 
 ---
@@ -480,41 +461,39 @@ Intermediate parsed float convereter
 
 Parse signed dime
 
-#### Accepts
-
-#### Produces
-
-Parsing rule. Parses a signed number into a `++dime`.
+Parsing `rule`. Parse a `@s` to a `dime`.
 
 #### Source
 
 ```hoon
-      ++  tash
-        ~+
-        =+  ^=  neg
-            |=  {syn/? mol/dime}  ^-  dime
-            ?>  =('u' (end 3 1 p.mol))
-            [(cat 3 's' (rsh 3 1 p.mol)) (new:si syn q.mol)]
-        ;~  pfix  hep
-          ;~  pose
-            (cook |=(a/dime (neg | a)) bisk)
-            ;~(pfix hep (cook |=(a/dime (neg & a)) bisk))
-          ==
-        ==
-      ::
+++  tash
+  ~+
+  =+  ^=  neg
+      |=  [syn=? mol=dime]  ^-  dime
+      ?>  =('u' (end 3 p.mol))
+      [(cat 3 's' (rsh 3 p.mol)) (new:si syn q.mol)]
+  ;~  pfix  hep
+    ;~  pose
+      (cook |=(a=dime (neg | a)) bisk)
+      ;~(pfix hep (cook |=(a=dime (neg & a)) bisk))
+    ==
+  ==
 ```
 
 #### Examples
 
 ```
-    > (scan "-20" tash:so)
-    [p=~.sd q=39]
-    > (,[%sd @sd] (scan "-20" tash:so))
-    [%sd -20]
-    > (,[%sd @sd] (scan "--20" tash:so))
-    [%sd --20]
-    > (,[%sx @sx] (scan "--0x2e" tash:so))
-    [%sx --0x2e]
+> (scan "-20" tash:so)
+[p=~.sd q=39]
+
+> ;;([%sd @sd] (scan "-20" tash:so))
+[%sd -20]
+
+> ;;([%sd @sd] (scan "--20" tash:so))
+[%sd --20]
+
+> ;;([%sx @sx] (scan "--0x2e" tash:so))
+[%sx --0x2e]
 ```
 
 ---
@@ -525,82 +504,115 @@ Parse coins without `~` prefix
 
 Parsing rule. Parses coins after a leading sig, `~`.
 
-#### Accepts
-
-#### Produces
-
 #### Source
 
 ```hoon
-      ++  twid
-        ;~  pose
-          (cook |=(a/@ [%blob (cue a)]) ;~(pfix (just '0') vum:ag))
-          (stag ~ crub)
-        ==
-      ::
+++  twid
+  ~+
+  ;~  pose
+    %+  stag  %blob
+    %+  sear  |=(a=@ (mole |.((cue a))))
+    ;~(pfix (just '0') vum:ag)
+  ::
+    (stag %$ crub)
+  ==
 ```
 
 #### Examples
 
 ```
-    > (scan "zod" twid:so)
-    [~ [%p 0]]
-    > (scan ".sam" twid:so)
-    [~ [%ta 7.168.371]]
-    > `@ud`~.sam
-    7.168.371
-    > `@t`~.sam
-    'sam'
-    > (scan "0ph" twid:so)
-    [%blob [1 1]]
+> (scan "zod" twid:so)
+[%$ [%p 0]]
+
+> (scan ".sam" twid:so)
+[%$ [%ta 7.168.371]]
+
+> (scan "0ph" twid:so)
+[%blob [1 1]]
+```
+
+---
+
+### `++when:so`
+
+Parse date
+
+Parsing `rule`. Parse a `@da`-formatted date string (sans the leading `~`) to a
+`date`.
+
+#### Source
+
+```hoon
+++  when
+  ~+
+  ;~  plug
+    %+  cook
+      |=([a=@ b=?] [b a])
+    ;~(plug dim:ag ;~(pose (cold | hep) (easy &)))
+    ;~(pfix dot mot:ag)   ::  month
+    ;~(pfix dot dip:ag)   ::  day
+    ;~  pose
+      ;~  pfix
+        ;~(plug dot dot)
+        ;~  plug
+          dum:ag
+          ;~(pfix dot dum:ag)
+          ;~(pfix dot dum:ag)
+          ;~(pose ;~(pfix ;~(plug dot dot) (most dot qix:ab)) (easy ~))
+        ==
+      ==
+      (easy [0 0 0 ~])
+    ==
+  ==
+```
+
+#### Examples
+
+```
+> `date`(scan "2000.1.1..12.00.00..ffff" when:so)
+[[a=%.y y=2.000] m=1 t=[d=1 h=12 m=0 s=0 f=~[0xffff]]]
 ```
 
 ---
 
 ### `++zust:so`
 
-Parse prefixed dimes from `@if`, `@f`, `@rd`
+Parse dimes from `@i`, `@f`, `@r` or `@q`
 
-Parsing rule. Parses an atom of either `@if` (IP address), `@f`
-(loobean), or `rf`(floating point) into a `++dime`.
-
-#### Accepts
-
-#### Produces
+Parsing rule. Parses an atom of either `@if` (IP address), `@f` (loobean), `@r`
+(floating point) into a `dime`. The `@q` alone requires a leading `~`.
 
 #### Source
 
 ```hoon
-      ++  zust
-        ;~  pose
-          (stag %is bip:ag)
-          (stag %if lip:ag)
-          (stag %f ;~(pose (cold & (just 'y')) (cold | (just 'n'))))
-          royl
-        ==
-      --
+++  zust
+  ~+
+  ;~  pose
+    (stag %is bip:ag)
+    (stag %if lip:ag)
+    royl
+    (stag %f ;~(pose (cold & (just 'y')) (cold | (just 'n'))))
+    (stag %q ;~(pfix sig feq:ag))
+  ==
 ```
 
 #### Examples
 
 ```
-    > (scan "127.0.0.1" zust:so)
-    [%if q=2.130.706.433]
+> (scan "~sampel" zust:so)
+[%q 1.135]
 
-    > (scan "af.0.0.0.0.e7a5.30d2.7" zust:so)
-    [%is q=908.651.950.243.594.834.993.091.554.288.205.831]
+> (scan "y" zust:so)
+[%f %.y]
 
-    > (,[%is @is] (scan "af.0.0.0.0.e7a5.30d2.7" zust:so))
-    [%is .af.0.0.0.0.e7a5.30d2.7]
+> (scan "127.0.0.1" zust:so)
+[%if 2.130.706.433]
 
-    > (,[%is @ux] (scan "af.0.0.0.0.e7a5.30d2.7" zust:so))
-    [%is 0xaf.0000.0000.0000.0000.e7a5.30d2.0007]
+> (scan "af.0.0.0.0.e7a5.30d2.7" zust:so)
+[%is 908.651.950.243.594.834.993.091.554.288.205.831]
 
-    > (scan "y" zust:so)
-    [%f %.y]
-
-    > (scan "12.09" zust:so)
-    [%rd .~12.00999999999999]
+> (scan "12.09" zust:so)
+[%rs .12.09]
 ```
 
 ---

--- a/content/docs/hoon/reference/stdlib/table-of-contents.md
+++ b/content/docs/hoon/reference/stdlib/table-of-contents.md
@@ -18,6 +18,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#abssi' title="Absolute value (signed integer)"><code>++abs:si</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#abel' title="Compiler alias"><code>++abel</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#ace' title="Parse space"><code>++ace</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#a-coco' title="Render decimal"><code>++a-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#add' title="Add"><code>++add</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addff' title="Add (floating point)"><code>++add:ff</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addfl' title="Add (with exact/rounded flag)"><code>++add:fl</code></a>
@@ -90,6 +91,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1b/#cap' title="Tree head"><code>++cap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#cass' title="To lowercase"><code>++cass</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#cat' title="Concatenate"><code>++cat</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#c-coco' title="Render base58check"><code>++c-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#cen' title="Parse % (cen)"><code>++cen</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#cetyo' title="Days in a century"><code>++cet:yo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#chafa' title="Decode base58check character"><code>++cha:fa</code></a>
@@ -124,6 +126,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#dne' title="Render decimal"><code>++d:ne</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#date' title="Parsed date"><code>+$date</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#dayyo' title="Seconds in day"><code>++day:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#d-coco' title="Render decimal with min length"><code>++d-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#dec' title="Decrement"><code>++dec</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#delby' title="Delete (map)"><code>++del:by</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#delin' title="Delete (set)"><code>++del:in</code></a>
@@ -175,9 +178,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#eadfl' title="Exact add"><code>++ead:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#each' title="Mold of fork between two types"><code>++each</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#easy' title="Always parse"><code>++easy</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ed-coco' title="Format with decimal place"><code>++ed-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#edge' title="Parsing location metadata"><code>+$edge</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#effob' title="murmur3-based pseudorandom function"><code>++eff:ob</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#egcd' title="Extended Euclidean algorithm"><code>++egcd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#em-coco' title="Render in numeric base"><code>++em-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emnfl' title="Minimum exponent"><code>++emn:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emufl' title="Exact multiply"><code>++emu:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emxfl' title="Maximum exponent"><code>++emx:fl</code></a>
@@ -465,6 +470,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#oldsi' title="Sign and absolute value"><code>++old:si</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#oust' title="Remove from list"><code>++oust</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#outfe' title="Maximum integer value"><code>++out:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ox-coco' title="Format dot-separated digits in numeric base"><code>++ox-co:co</code></a>
 
 ### p
 
@@ -477,7 +483,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1b/#peg' title="Address within address"><code>++peg</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#pal' title="Parse ( (pal)"><code>++pal</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#par' title="Parse ) (par)"><code>++par</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#perdso' title="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#perdso' title="Parsing coin literal without prefixes"><code>++perd:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#perk' title="Parse cube fork"><code>++perk</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pevab' title="Parse 1-5 @uv base-32 chars"><code>++pev:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pewab' title="Parse <= 5 in base 64"><code>++pew:ab</code></a>
@@ -527,6 +533,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#raufl' title="Various roundings (floating point)"><code>++rau:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#rawog' title="Random bits"><code>++raw:og</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#rawsog' title="Random bits continuation"><code>++raws:og</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#r-coco' title="Render floating point"><code>++r-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#re' title="Prettyprinting engine (tank)"><code>++re</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#rear' title="Last item in list"><code>++rear</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rearco' title="Prepend and render atom as tape"><code>++rear:co</code></a>
@@ -534,7 +541,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#reel' title="Right fold (list)"><code>++reel</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#remsi' title="Remainder (signed integer)"><code>++rem:si</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rendco' title="Render coin lot as tape"><code>++rend:co</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rentco' title="Render coin lot as span"><code>++rent:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rentco' title="Render coin as knot"><code>++rent:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rep' title="Assemble single"><code>++rep</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#repby' title="Reduce to product (map)"><code>++rep:by</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#repin' title="Accumulate elements (set)"><code>++rep:in</code></a>
@@ -543,6 +550,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#ribby' title="Transform + product (map)"><code>++rib:by</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rip' title="Disassemble"><code>++rip</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rnat' title="Print null"><code>++rn:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ro-coco' title="Format dot-prefixed bloqs in numeric base"><code>++ro-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rolfe' title="Roll left"><code>++rol:fe</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#roll' title="Left fold (list)"><code>++roll</code></a>
 <code>++rood</code>
@@ -550,7 +558,12 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4g/#rose' title="Parse to each"><code>++rose</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#roufl' title="Round to nearest float with 113bit significand"><code>++rou:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#roylso' title="Parse dime float"><code>++royl:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#roylcellso' title="(Undocumented)"><code>++roylcell:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-cellso' title="Convert rn to dn"><code>++royl-cell:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rhso' title="Parse half-precision float"><code>++royl-rh:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rqso' title="Parse quad-precision float"><code>++royl-rq:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rdso' title="Parse double-precision float"><code>++royl-rd:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rsso' title="Parse single-precision float"><code>++royl-rs:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rnso' title="Parse real number"><code>++royl-rn:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rsh' title="Rightshift"><code>++rsh</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rtat' title="Print cord, including escape characters"><code>++rt:at</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rtaat' title="Print cord, including escape characters"><code>++rta:at</code></a>
@@ -584,6 +597,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sbff' title="Sign bit"><code>++sb:ff</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#scag' title="Prefix (produce front of list)"><code>++scag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4g/#scan' title="Parse tape or crash"><code>++scan</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#s-coco' title="Render hex list"><code>++s-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#scot' title="Render dime as cord"><code>++scot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#scow' title="Render dime as tape"><code>++scow</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#seaff' title="Convert from IEEE float to fn"><code>++sea:ff</code></a>
@@ -783,6 +797,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <code>++vang</code>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vase' title="Typed data"><code>++vase</code></a>
 <code>++vast</code>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#v-coco' title="Render base-32 with minimum length"><code>++v-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#ven' title="Axis syntax parser"><code>++ven</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vise' title="Convert during reboot"><code>++vise</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#vit' title="Parse base 64 digit"><code>++vit</code></a>
@@ -798,9 +813,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#wain' title="List of cords"><code>+$wain</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#wall' title="List of list of characters"><code>+$wall</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#wash' title="Render tank at width"><code>++wash</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#w-coco' title="Render base-64 with minimum length"><code>++w-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#weld' title="Concatenate two lists"><code>++weld</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#weldnl' title="Concatenate nullterminated nouns"><code>++weld:nl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#welp' title="Perfect concatenate (lists)"><code>++welp</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#whenso' title="Parse date"><code>++when:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#wick' title="Knot unescape"><code>++wick</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#winre' title="Render at indent"><code>++win:re</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#wing' title="Address in subject"><code>++wing</code></a>
@@ -816,6 +833,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### x
 
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#x-coco' title="Render hex with minimum length"><code>++x-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#xne' title="Render hexadecimal digit as atom of ASCII byte value"><code>++x:ne</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#xeb' title="Binary logarithm"><code>++xeb</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#xpdfl' title="Expand signed and unsigned integer cell"><code>++xpd:fl</code></a>
@@ -824,6 +842,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yall' title="Time since beginning of time"><code>++yall</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yawn' title="Days since beginning of time"><code>++yawn</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#y-coco' title="Render decimal with at least two digits"><code>++y-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#year' title="Date to @d"><code>++year</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yell' title="Tarp from atomic date"><code>++yell</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yelp' title="Determine if leapweek"><code>++yelp</code></a>
@@ -838,11 +857,12 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zagmu' title="Add bottom into top"><code>++zag:mu</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#zap' title="Parse ! (zap)"><code>++zap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zartun' title="Reverse look up in 255 sub box"><code>++zart:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#z-coco' title="Render '0x'-prefixed hex"><code>++z-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#zerfl' title="Produce zero as float"><code>++zer:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zigmu' title="Subtract bottom from top"><code>++zig:mu</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#zing' title="Turn lists into single list by promoting elements from sublists"><code>++zing</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zugmu' title="Concatenate into atom"><code>++zug:mu</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#zustso' title="Parse prefixed dimes from IP, loobean, or floating point"><code>++zust:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#zustso' title="Parse dimes from @i, @f, @r or @q"><code>++zust:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zyftun' title="Lookup byte in 256 sub box"><code>++zyft:un</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zyrtun' title="Reverse lookup byte in 256 sub box"><code>++zyrt:un</code></a>
 
@@ -1698,7 +1718,21 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#co' title="Literal rendering engine"><code>++co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rearco' title="Prepend and render atom as tape"><code>++rear:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rendco' title="Render coin lot as tape"><code>++rend:co</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rentco' title="Render coin lot as span"><code>++rent:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rentco' title="Render coin as knot"><code>++rent:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#a-coco' title="Render decimal"><code>++a-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#c-coco' title="Render base58check"><code>++c-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#d-coco' title="Render decimal with min length"><code>++d-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#r-coco' title="Render floating point"><code>++r-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#s-coco' title="Render hex list"><code>++s-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#v-coco' title="Render base-32 with minimum length"><code>++v-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#w-coco' title="Render base-64 with minimum length"><code>++w-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#x-coco' title="Render hex with minimum length"><code>++x-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#y-coco' title="Render decimal with at least two digits"><code>++y-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#z-coco' title="Render '0x'-prefixed hex"><code>++z-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#em-coco' title="Render in numeric base"><code>++em-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ed-coco' title="Format with decimal place"><code>++ed-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ox-coco' title="Format dot-separated digits in numeric base"><code>++ox-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ro-coco' title="Format dot-prefixed bloqs in numeric base"><code>++ro-co:co</code></a>
 
 ### 4l: parsing (atom parsing)
 
@@ -1707,12 +1741,18 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#crubso' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#nuckso' title="Toplevel coin parser"><code>++nuck:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#nuskso' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#perdso' title="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#perdso' title="Parsing coin literal without prefixes"><code>++perd:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#roylso' title="Parse dime float"><code>++royl:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#roylcellso' title="(Undocumented)"><code>++roylcell:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-cellso' title="Convert rn to dn"><code>++royl-cell:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rhso' title="Parse half-precision float"><code>++royl-rh:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rqso' title="Parse quad-precision float"><code>++royl-rq:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rdso' title="Parse double-precision float"><code>++royl-rd:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rsso' title="Parse single-precision float"><code>++royl-rs:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rnso' title="Parse real number"><code>++royl-rn:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#tashso' title="Parse signed dime"><code>++tash:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#twidso' title="Parse coins without ~ prefix"><code>++twid:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#zustso' title="Parse prefixed dimes from IP, loobean, or floating point"><code>++zust:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#whenso' title="Parse date"><code>++when:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#zustso' title="Parse dimes from @i, @f, @r or @q"><code>++zust:so</code></a>
 
 ### 4m: parsing (formatting functions)
 

--- a/lib/glossary.js
+++ b/lib/glossary.js
@@ -1417,6 +1417,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Render decimal",
+    symbol: "a-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#a-coco",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Add",
     symbol: "add",
     usage: "stdlib",
@@ -1879,6 +1886,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Render base58check",
+    symbol: "c-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#c-coco",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Parse % (cen)",
     symbol: "cen",
     usage: "stdlib",
@@ -2093,6 +2107,13 @@ export const glossary = [
     symbol: "day:yo",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/3c/#dayyo",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Render decimal with min length",
+    symbol: "d-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#d-coco",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -2439,6 +2460,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Format with decimal place",
+    symbol: "ed-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#ed-coco",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Parsing location metadata",
     symbol: "edge",
     usage: "stdlib",
@@ -2457,6 +2485,13 @@ export const glossary = [
     symbol: "egcd",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/3a/#egcd",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Render in numeric base",
+    symbol: "em-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#em-coco",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -4266,6 +4301,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Format dot-separated digits in numeric base",
+    symbol: "ox-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#ox-coco",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Initialize fl from ff core",
     symbol: "pa:ff",
     usage: "stdlib",
@@ -4322,7 +4364,7 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "Parses dime/tiple without standard prefixes",
+    name: "Parse coin literal without prefixes",
     symbol: "perd:so",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4l/#perdso",
@@ -4630,6 +4672,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Render floating point",
+    symbol: "r-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#r-coco",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Pretty-printing engine (tank)",
     symbol: "re",
     usage: "stdlib",
@@ -4679,7 +4728,7 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "Render coin lot as span",
+    name: "Render coin as knot",
     symbol: "rent:co",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4k/#rentco",
@@ -4735,6 +4784,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Format dot-prefixed bloqs in numeric base",
+    symbol: "ro-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#ro-coco",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Roll left",
     symbol: "rol:fe",
     usage: "stdlib",
@@ -4777,10 +4833,45 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "(Undocumented)",
+    name: "Convert rn to dn",
     symbol: "royl-cell:so",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4l/#royl-cellso",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Parse half-precision float",
+    symbol: "royl-rh:so",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4l/#royl-rhso",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Parse quad-precision float",
+    symbol: "royl-rq:so",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4l/#royl-rqso",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Parse double-precision float",
+    symbol: "royl-rd:so",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4l/#royl-rdso",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Parse single-precision float",
+    symbol: "royl-rs:so",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4l/#royl-rsso",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Parse real number",
+    symbol: "royl-rn:so",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4l/#royl-rnso",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -4991,6 +5082,13 @@ export const glossary = [
     symbol: "scan",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4g/#scan",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Render hex list",
+    symbol: "s-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#s-coco",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -6310,6 +6408,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Render base-32 with minimum length",
+    symbol: "v-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#v-coco",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Axis syntax parser",
     symbol: "ven",
     usage: "stdlib",
@@ -6391,6 +6496,13 @@ export const glossary = [
     symbol: "wash",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4c/#wash",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Render base-64 with minimum length",
+    symbol: "w-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#w-coco",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -6506,6 +6618,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Render hex with minimum length",
+    symbol: "x-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#x-coco",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Binary logarithm",
     symbol: "xeb",
     usage: "stdlib",
@@ -6531,6 +6650,13 @@ export const glossary = [
     symbol: "yawn",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/3c/#yawn",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Render decimal with at least two digits",
+    symbol: "y-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#y-coco",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -6611,6 +6737,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Render '0x'-prefixed hex",
+    symbol: "z-co:co",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4k/#z-coco",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Produce zero as float",
     symbol: "zer:fl",
     usage: "stdlib",
@@ -6639,7 +6772,7 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "Parse prefixed dimes from IP, loobean, or floating point",
+    name: "Parse dimes from @i, @f, @r or @q",
     symbol: "zust:so",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4l/#zustso",


### PR DESCRIPTION
- 4k
  - change rent:co description
  - add a-co:co, c-co:co, d-co:co, r-co:co, s-co:co, v-co:co, w-co:co, x-co:co,
    y-co:co, z-co:co, em-co:co, ed-co:co, ox-co:co, ro-co:co
  - refresh existing functions
  - update ToC and glossary.js as appropriate
- 4l
  - change ++perd:so, ++royl-cell:so, zust:so description
  - add royl-rh, royl-rq, royl-rd, royl-rs, royl-rn, when:so
  - refresh existing functions
  - update ToC and glossary.js as appropriate

regarding #1137