### PR TITLE
update stdlib 4m 4n 4o

### DIFF
--- a/content/docs/hoon/reference/stdlib/4m.md
+++ b/content/docs/hoon/reference/stdlib/4m.md
@@ -12,7 +12,7 @@ Renders a dime `mol` as a cord.
 
 #### Accepts
 
-`mol` is a `++dime`.
+`mol` is a `dime`.
 
 #### Produces
 
@@ -21,28 +21,28 @@ A `cord`.
 #### Source
 
 ```hoon
-    ++  scot  |=(mol/dime ~(rent co %$ mol))
+++  scot
+  ~/  %scot
+  |=(mol=dime ~(rent co %$ mol))
 ```
 
 #### Examples
 
 ```
-    > (scot %p ~pillyt)
-    ~.~pillyt
-    > `@t`(scot %p ~pillyt)
-    '~pillyt'
-    > (scot %ux 0x12)
-    ~.0x12
-    > `@t`(scot %ux 0x12)
-    '0x12'
-    > (scot %if .127.0.0.1)
-    ~..127.0.0.1
-    > `@t`(scot %if .127.0.0.1)
-    '.127.0.0.1'
-    > (scot %ta ~.asd_a)
-    ~.~.asd_a
-    > `@t`(scot %ta ~.asd_a)
-    '~.asd_a'
+> (scot %p ~pillyt)
+~.~pillyt
+
+> `@t`(scot %p ~pillyt)
+'~pillyt'
+
+> `@t`(scot %ux 0x12)
+'0x12'
+
+> `@t`(scot %if .127.0.0.1)
+'.127.0.0.1'
+
+> `@t`(scot %ta ~.asd_a)
+'~.asd_a'
 ```
 
 ---
@@ -55,7 +55,7 @@ Renders a dime `mol` as a tape.
 
 #### Accepts
 
-`mol` is a `++dime`.
+`mol` is a `dime`.
 
 #### Produces
 
@@ -64,20 +64,25 @@ A `tape`.
 #### Source
 
 ```hoon
-    ++  scow  |=(mol/dime ~(rend co %$ mol))
+++  scow
+  ~/  %scow
+  |=(mol=dime ~(rend co %$ mol))
 ```
 
 #### Examples
 
 ```
-    > (scow %p ~pillyt)
-    "~pillyt"
-    > (scow %ux 0x12)
-    "0x12"
-    > (scow %if .127.0.0.1)
-    ".127.0.0.1"
-    > (scow %ta ~.asd_a)
-    "~.asd_a"
+> (scow %p ~pillyt)
+"~pillyt"
+
+> (scow %ux 0x12)
+"0x12"
+
+> (scow %if .127.0.0.1)
+".127.0.0.1"
+
+> (scow %ta ~.asd_a)
+"~.asd_a"
 ```
 
 ---
@@ -86,36 +91,39 @@ A `tape`.
 
 Curried slaw
 
-Produces a `gate` that parses a `term` `txt` to an atom of the
-aura specified by `mod`.
+Produces a `gate` that parses a `knot` `txt` to a `unit` containing the atom of
+the aura specified by `mod`. The `unit` will be null if parsing failed.
 
 #### Accepts
 
-`mod` is a term, an atom of aura `@tas`.
+`mod` is a `knot`.
 
-`txt` is a cord, an atom of aura `@ta`.
+`txt` is a `cord`.
 
 #### Produces
 
-A `gate`.
+A `(unit @)`.
 
 #### Source
 
 ```hoon
-    ++  slat  |=(mod/@tas |=(txt/@ta (slaw mod txt)))
+++  slat  |=(mod=@tas |=(txt=@ta (slaw mod txt)))
 ```
 
 #### Examples
 
 ```
-    > `(unit @p)`((slat %p) '~pillyt')
-    [~ ~pillyt]
-    > `(unit @ux)`((slat %ux) '0x12')
-    [~ 0x12]
-    > `(unit @if)`((slat %if) '.127.0.0.1')
-    [~ .127.0.0.1]
-    > `(unit @ta)`((slat %ta) '~.asd_a')
-    [~ ~.asd_a
+> `(unit @p)`((slat %p) '~pillyt')
+[~ ~pillyt]
+
+> `(unit @ux)`((slat %ux) '0x12')
+[~ 0x12]
+
+> `(unit @if)`((slat %if) '.127.0.0.1')
+[~ .127.0.0.1]
+
+> `(unit @ta)`((slat %ta) '~.asd_a')
+[~ ~.asd_a]
 ```
 
 ---
@@ -129,39 +137,46 @@ Crashes if it fails to parse.
 
 #### Accepts
 
-`mod` is a term, an atom of aura `@tas`.
+`mod` is a `term`
 
-`txt` is a cord, an atom of aura `@ta`.
+`txt` is a `knot`.
 
 #### Produces
 
-The atom of a `(unit @)` from `++slaw`, or crash.
+an atom.
 
 #### Source
 
 ```hoon
-    ++  slav  |=([mod/@tas txt/@ta] (need (slaw mod txt)))
+++  slav  |=([mod=@tas txt=@ta] (need (slaw mod txt)))
 ```
 
 #### Examples
 
 ```
-    > `@p`(slav %p '~pillyt')
-    ~pillyt
-    > `@p`(slav %p '~pillam')
-    ! exit
-    > `@ux`(slav %ux '0x12')
-    0x12
-    > `@ux`(slav %ux '0b10')
-    ! exit
-    > `@if`(slav %if '.127.0.0.1')
-    .127.0.0.1
-    > `@if`(slav %if '.fe80.0.0.202')
-    ! exit
-    > `@ta`(slav %ta '~.asd_a')
-    ~.asd_a
-    > `@ta`(slav %ta '~~asd-a')
-    ! exit
+> `@p`(slav %p '~pillyt')
+~pillyt
+
+> `@p`(slav %p '~pillam')
+! exit
+
+> `@ux`(slav %ux '0x12')
+0x12
+
+> `@ux`(slav %ux '0b10')
+! exit
+
+> `@if`(slav %if '.127.0.0.1')
+.127.0.0.1
+
+> `@if`(slav %if '.fe80.0.0.202')
+! exit
+
+> `@ta`(slav %ta '~.asd_a')
+~.asd_a
+
+> `@ta`(slav %ta '~~asd-a')
+! exit
 ```
 
 ---
@@ -170,13 +185,14 @@ The atom of a `(unit @)` from `++slaw`, or crash.
 
 Parse cord to input aura
 
-Parses a cord `txt` to an atom of the aura specified by `mod`.
+Parses a cord `txt` to a `unit` containing the atom of the aura specified by
+`mod`. The `unit` is null if parsing failed.
 
 #### Accepts
 
-`mod` is a term, an atom of aura `@tas`.
+`mod` is a `term`.
 
-`txt` is a cord, an atom of aura `@ta`.
+`txt` is a `knot`.
 
 #### Produces
 
@@ -185,33 +201,65 @@ A `(unit @)`.
 #### Source
 
 ```hoon
-    ++  slaw
-      ~/  %slaw
-      |=  {mod/@tas txt/@ta}
-      ^-  (unit @)
+++  slaw
+  ~/  %slaw
+  |=  [mod=@tas txt=@ta]
+  ^-  (unit @)
+  ?+    mod
+      ::  slow fallback case to the full slay
+      ::
       =+  con=(slay txt)
-      ?.(&(?=({$~ $$ @ @} con) =(p.p.u.con mod)) ~ [~ q.p.u.con])
+      ?.(&(?=([~ %$ @ @] con) =(p.p.u.con mod)) ~ [~ q.p.u.con])
+  ::
+      %da
+    (rush txt ;~(pfix sig (cook year when:so)))
+  ::
+      %p
+    (rush txt ;~(pfix sig fed:ag))
+  ::
+      %ud
+    (rush txt dem:ag)
+  ::
+      %ux
+    (rush txt ;~(pfix (jest '0x') hex:ag))
+  ::
+      %uv
+    (rush txt ;~(pfix (jest '0v') viz:ag))
+  ::
+      %ta
+    (rush txt ;~(pfix ;~(plug sig dot) urs:ab))
+  ::
+      %tas
+    (rush txt sym)
+  ==
 ```
 
 #### Examples
 
 ```
-    > `(unit @p)`(slaw %p '~pillyt')
-    [~ ~pillyt]
-    > `(unit @p)`(slaw %p '~pillam')
-    ~
-    > `(unit @ux)`(slaw %ux '0x12')
-    [~ 0x12]
-    > `(unit @ux)`(slaw %ux '0b10')
-    ~
-    > `(unit @if)`(slaw %if '.127.0.0.1')
-    [~ .127.0.0.1]
-    > `(unit @if)`(slaw %if '.fe80.0.0.202')
-    ~
-    > `(unit @ta)`(slaw %ta '~.asd_a')
-    [~ ~.asd_a]
-    > `(unit @ta)`(slaw %ta '~~asd-a')
-    ~
+> `(unit @p)`(slaw %p '~pillyt')
+[~ ~pillyt]
+
+> `(unit @p)`(slaw %p '~pillam')
+~
+
+> `(unit @ux)`(slaw %ux '0x12')
+[~ 0x12]
+
+> `(unit @ux)`(slaw %ux '0b10')
+~
+
+> `(unit @if)`(slaw %if '.127.0.0.1')
+[~ .127.0.0.1]
+
+> `(unit @if)`(slaw %if '.fe80.0.0.202')
+~
+
+> `(unit @ta)`(slaw %ta '~.asd_a')
+[~ ~.asd_a]
+
+> `(unit @ta)`(slaw %ta '~~asd-a')
+~
 ```
 
 ---
@@ -220,7 +268,7 @@ A `(unit @)`.
 
 Parse cord to coin
 
-Parses a cord `txt` to the unit of a `++coin`.
+Parses a cord `txt` to the unit of a `coin`.
 
 #### Accepts
 
@@ -233,45 +281,31 @@ A `(unit coin)`.
 #### Source
 
 ```hoon
-        ++  slay
-          |=  txt/@ta  ^-  (unit coin)
-          =+  ^=  vex
-              ?:  (gth 0x7fff.ffff txt)                         ::  XX  petty cache
-                ~+  ((full nuck:so) [[1 1] (trip txt)])
-              ((full nuck:so) [[1 1] (trip txt)])
-          ?~  q.vex
-            ~
-          [~ p.u.q.vex]
-        ::
+++  slay
+  |=  txt=@ta  ^-  (unit coin)
+  =+  ^=  vex
+      ?:  (gth 0x7fff.ffff txt)                         ::  XX  petty cache
+        ~+  ((full nuck:so) [[1 1] (trip txt)])
+      ((full nuck:so) [[1 1] (trip txt)])
+  ?~  q.vex
+    ~
+  [~ p.u.q.vex]
 ```
 
 #### Examples
 
 ```
-    > (slay '~pillyt')
-    [~ [% p=[p=~.p q=32.819]]]
-    > (slay '0x12')
-    [~ [% p=[p=~.ux q=18]]]
-    > (slay '.127.0.0.1')
-    [~ [% p=[p=~.if q=2.130.706.433]]]
-    > `@ud`.127.0.0.1
-    2.130.706.433
-    > (slay '._20_0w25_sam__')
-    [ ~
-      [ %many
-        p=~[[% p=[p=~.ud q=20]] [% p=[p=~.uw q=133]] [% p=[p=~.tas q=7.168.371]]]
-      ]
-    ]
-    > `@`%sam
-    7.168.371
-    > (slay '~0ph')
-    [~ [%blob p=[1 1]]]
-    > 0ph
-    ~ <syntax error at [1 2]>
-    > ~0ph
-    [1 1]
-    > `@uv`(jam [1 1])
-    0vph
+> (slay '~pillyt')
+[~ [%$ p=[p=~.p q=13.184]]]
+
+> (slay '0x12')
+[~ [%$ p=[p=~.ux q=18]]]
+
+> (slay '.127.0.0.1')
+[~ [%$ p=[p=~.if q=2.130.706.433]]]
+
+> (slay '!')
+~
 ```
 
 ---
@@ -285,7 +319,7 @@ pretty-printing.
 
 #### Accepts
 
-`bon` is a `++path`.
+`bon` is a `path`.
 
 #### Produces
 
@@ -294,30 +328,31 @@ A `tank`.
 #### Source
 
 ```hoon
-    ++  smyt                                                ::  pretty print path
-      |=  bon/path  ^-  tank
-      :+  %rose  [['/' ~] ['/' ~] ~]
-      (turn bon |=(a/@ [%leaf (trip a)]))
-    ::
+++  smyt
+  |=  bon=path  ^-  tank
+  :+  %rose  [['/' ~] ['/' ~] ~]
+  (turn bon |=(a=@ [%leaf (trip a)]))
 ```
 
 #### Examples
 
 ```
-    > (smyt %)
-    [ %rose
-      p=[p="/" q="/" r="/"]
-        q
-      ~[ [%leaf p="~zod"]
-         [%leaf p="try"]
-         [%leaf p="~2014.10.28..18.36.58..a280"]
-       ]
-    ]
-    > (smyt /as/les/top)
-    [ %rose
-      p=[p="/" q="/" r="/"]
-      q=~[[%leaf p="as"] [%leaf p="les"] [%leaf p="top"]]
-    ]
+> (smyt %)
+[ %rose
+  p=[p="/" q="/" r=""]
+    q
+  ~[
+    [%leaf p="~zod"]
+    [%leaf p="base"]
+    [%leaf p="~2022.1.6..14.22.14..40bf"]
+  ]
+]
+
+> (smyt /as/les/top)
+[ %rose
+  p=[p="/" q="/" r=""]
+  q=~[[%leaf p="as"] [%leaf p="les"] [%leaf p="top"]]
+]
 ```
 
 ---
@@ -339,18 +374,20 @@ A `cord`.
 #### Source
 
 ```hoon
-    ++  spat  |=(pax/path (crip (spud pax)))               ::  path to cord
+++  spat  |=(pax=path (crip (spud pax)))
 ```
 
 #### Examples
 
 ```
-    > (spat %)
-    '~zod/try/~2014.10.28..18.40.20..4287'
-    > (spat %/bin)
-    '~zod/try/~2014.10.28..18.41.12..3bcd/bin'
-    > (spat /as/les/top)
-    '/as/les/top'
+> (spat %)
+'/~zod/base/~2022.1.6..14.23.31..e367'
+
+> (spat %/lib)
+'/~zod/base/~2022.1.6..14.23.43..829e/lib'
+
+> (spat /as/les/top)
+'/as/les/top'
 ```
 
 ---
@@ -372,18 +409,20 @@ A `tape`.
 #### Source
 
 ```hoon
-    ++  spud  |=(pax/path ~(ram re (smyt pax)))             ::  path to tape
+++  spud  |=(pax=path ~(ram re (smyt pax)))
 ```
 
 #### Examples
 
 ```
-    > (spud %)
-    "~zod/try/~2014.10.28..18.40.46..e951"
-    > (spud %/bin)
-    "~zod/try/~2014.10.28..18.41.05..16f2/bin"
-    > (spud /as/les/top)
-    "/as/les/top"
+> (spud %)
+"/~zod/base/~2022.1.6..14.24.35..cddf"
+
+> (spud %/lib)
+"/~zod/base/~2022.1.6..14.24.43..3efb/lib"
+
+> (spud /as/les/top)
+"/as/les/top"
 ```
 
 ---
@@ -392,7 +431,7 @@ A `tape`.
 
 Parse cord to path
 
-Parsing rule. Parses a cord `zep` to a static `++path`.
+Parses a cord `zep` to a static `path`.
 Crashes if it fails to parse.
 
 #### Accepts
@@ -406,31 +445,42 @@ A `path`, or crash.
 #### Source
 
 ```hoon
-    ++  stab                                                ::  parse cord to path
-      =+  fel=;~(pfix fas (more fas urs:ab))
-      |=(zep/@t `path`(rash zep fel))
+++  stab  |=(zep=@t `path`(rash zep stap))
 ```
 
 #### Examples
 
 ```
-    > (stab '/as/lek/tor')
-    /as/lek/tor
+> (stab '/as/lek/tor')
+/as/lek/tor
+```
 
-    > `(pole ,@ta)`(stab '/as/lek/tor')
-    [~.as [~.lek [~.tor ~]]]
+---
 
-    > (stab '~zod/arvo/~2014.10.28..18.48.41..335f/zuse')
-    ~zod/arvo/~2014.10.28..18.48.41..335f/zuse
+## `++stap`
 
-    > `(pole ,@ta)`(stab '~zod/arvo/~2014.10.28..18.48.41..335f/zuse')
-    [~.~zod [~.arvo [~.~2014.10.28..18.48.41..335f [~.zuse ~]]]]
+Path parser
 
-    > (stab '/a/~pillyt/pals/1')
-    /a/~pillyt/pals/1
+Parsing `rule`. Parses a `path`, used internally by `++stab`.
 
-    > `(pole ,@ta)`(stab '/a/~pillyt/pals/1')
-    [~.a [~.~pillyt [~.pals [~.1 ~]]]]
+#### Source
+
+```hoon
+++  stap
+  %+  sear
+    |=  p=path
+    ^-  (unit path)
+    ?:  ?=([~ ~] p)  `~
+    ?.  =(~ (rear p))  `p
+    ~
+  ;~(pfix fas (most fas urs:ab))
+```
+
+#### Examples
+
+```
+> (scan "/foo/bar/baz" stap)
+/foo/bar/baz
 ```
 
 ---

--- a/content/docs/hoon/reference/stdlib/4n.md
+++ b/content/docs/hoon/reference/stdlib/4n.md
@@ -8,7 +8,7 @@ template = "doc.html"
 
 Nock subject to unit
 
-Accepts a nock subject-formula cell and wraps it into a `++unit`.
+Accepts a nock subject-formula cell and wraps it into a `unit`.
 `fol` is pure nock, meaning that nock `11` operations result in a block,
 producing a `~`.
 
@@ -16,36 +16,39 @@ producing a `~`.
 
 `sub` is a subject noun.
 
-`fol` is a formula noun, which is generally a `++nock`.
+`fol` is a formula noun, which is generally a `nock`.
 
 #### Produces
 
-The `++unit` of a noun.
+The `unit` of a noun.
 
 #### Source
 
 ```hoon
-    ++  mack
-      |=  {sub/* fol/*}
-      ^-  (unit)
-      =+  ton=(mink [sub fol] |=({* *} ~))
-      ?.(?=({$0 *} ton) ~ [~ p.ton])
-    ::
+++  mack
+  |=  [sub=* fol=*]
+  ^-  (unit)
+  =/  ton  (mink [sub fol] |~(^ ~))
+  ?.(?=(%0 -.ton) ~ `product.ton)
 ```
 
 #### Examples
 
 ```
-    > (mack [[1 2 3] [0 1]])
-    [~ [1 2 3]]
-    > (mack [41 4 0 1])
-    [~ 42]
-    > (mack [4 0 4])
-    ~
-    > (mack [[[0 2] [1 3]] 4 4 4 4 0 5])
-    [~ 6]
-    > ;;((unit @tas) (mack [[1 %yes %no] 6 [0 2] [0 6] 0 7]))
-    [~ %no]
+> (mack [[1 2 3] [0 1]])
+[~ [1 2 3]]
+
+> (mack [41 4 0 1])
+[~ 42]
+
+> (mack [4 0 4])
+~
+
+> (mack [[[0 2] [1 3]] 4 4 4 4 0 5])
+[~ 6]
+
+> ;;((unit @tas) (mack [[1 %yes %no] 6 [0 2] [0 6] 0 7]))
+[~ %no]
 ```
 
 ---
@@ -55,122 +58,204 @@ The `++unit` of a noun.
 Mock interpreter
 
 Bottom-level mock (virtual nock) interpreter. Produces a
-`++tone`, a nock computation result. If nock 11 is invoked, `sky`
-computes on the subject and produces a `++unit` result. An empty
-result becomes a `%1` `++tone`, indicating a block.
+`tone`, a nock computation result. If nock 12 is invoked, `scry`
+computes on the subject and produces a `(unit (unit))` result. An empty
+result becomes a `%1` `tone`, indicating a block.
 
 #### Accepts
 
-`sub` is the subject as a noun.
+`subject` is the subject as a noun.
 
-`fol` is the formula as a noun.
+`formula` is the formula as a noun.
 
-`sky` is an `%iron` gate invoked with nock operator 11.
+`scry` is an `%iron` gate invoked with nock operator 12.
 
 #### Produces
 
-A `++tone`.
+A `tone`.
 
 #### Source
 
 ```hoon
-    ++  mink
-      ~/  %mink
-      |=  {{sub/* fol/*} gul/$-({* *} (unit (unit)))}
-      =+  tax=*(list {@ta *})
-      |-  ^-  tone
-      ?@  fol
-        [%2 tax]
-      ?:  ?=(^ -.fol)
-        =+  hed=$(fol -.fol)
-        ?:  ?=($2 -.hed)
-          hed
-        =+  tal=$(fol +.fol)
-        ?-  -.tal
-          $0  ?-(-.hed $0 [%0 p.hed p.tal], $1 hed)
-          $1  ?-(-.hed $0 tal, $1 [%1 (weld p.hed p.tal)])
-          $2  tal
-        ==
-      ?+    fol
-        [%2 tax]
-      ::
-          {$0 b/@}
-        ?:  =(0 b.fol)  [%2 tax]
-        ?:  =(1 b.fol)  [%0 sub]
-        ?:  ?=(@ sub)   [%2 tax]
-        =+  [now=(cap b.fol) lat=(mas b.fol)]
-        $(b.fol lat, sub ?:(=(2 now) -.sub +.sub))
-      ::
-          {$1 b/*}
-        [%0 b.fol]
-      ::
-          {$2 b/{^ *}}
-        =+  ben=$(fol b.fol)
-        ?.  ?=($0 -.ben)  ben
-        ?>(?=(^ p.ben) $(sub -.p.ben, fol +.p.ben))
-        ::?>(?=(^ p.ben) $([sub fol] p.ben)
-      ::
-          {$3 b/*}
-        =+  ben=$(fol b.fol)
-        ?.  ?=($0 -.ben)  ben
-        [%0 .?(p.ben)]
-      ::
-          {$4 b/*}
-        =+  ben=$(fol b.fol)
-        ?.  ?=($0 -.ben)  ben
-        ?.  ?=(@ p.ben)  [%2 tax]
-        [%0 .+(p.ben)]
-      ::
-          {$5 b/*}
-        =+  ben=$(fol b.fol)
-        ?.  ?=($0 -.ben)  ben
-        ?.  ?=(^ p.ben)  [%2 tax]
-        [%0 =(-.p.ben +.p.ben)]
-      ::
-          {$6 b/* c/* d/*}
-        $(fol =>(fol [2 [0 1] 2 [1 c d] [1 0] 2 [1 2 3] [1 0] 4 4 b]))
-      ::
-          {$7 b/* c/*}       $(fol =>(fol [2 b 1 c]))
-          {$8 b/* c/*}       $(fol =>(fol [7 [[0 1] b] c]))
-          {$9 b/* c/*}       $(fol =>(fol [7 c 0 b]))
-          {$10 @ c/*}        $(fol c.fol)
-          {$10 {b/* c/*} d/*}
-        =+  ben=$(fol c.fol)
-        ?.  ?=($0 -.ben)  ben
-        ?:  ?=(?($hunk $hand $lose $mean $spot) b.fol)
-          $(fol d.fol, tax [[b.fol p.ben] tax])
-        $(fol d.fol)
-      ::
-          {$11 b/* c/*}
-        =+  ref=$(fol b.fol)
-        =+  ben=$(fol c.fol)
-        ?.  ?=($0 -.ref)  ref
-        ?.  ?=($0 -.ben)  ben
-        =+  val=(gul p.ref p.ben)
-        ?~(val [%1 p.ben ~] ?~(u.val [%2 [[%hunk (mush p.ben)] tax]] [%0 u.u.val]))
+++  mink  !.
+  ~/  %mink
+  |=  $:  [subject=* formula=*]
+          scry=$-(^ (unit (unit)))
       ==
-    ::
+  =|  trace=(list [@ta *])
+  |^  ^-  tone
+      ?+  formula  [%2 trace]
+          [^ *]
+        =/  head  $(formula -.formula)
+        ?.  ?=(%0 -.head)  head
+        =/  tail  $(formula +.formula)
+        ?.  ?=(%0 -.tail)  tail
+        [%0 product.head product.tail]
+      ::
+          [%0 axis=@]
+        =/  part  (frag axis.formula subject)
+        ?~  part  [%2 trace]
+        [%0 u.part]
+      ::
+          [%1 constant=*]
+        [%0 constant.formula]
+      ::
+          [%2 subject=* formula=*]
+        =/  subject  $(formula subject.formula)
+        ?.  ?=(%0 -.subject)  subject
+        =/  formula  $(formula formula.formula)
+        ?.  ?=(%0 -.formula)  formula
+        %=  $
+          subject  product.subject
+          formula  product.formula
+        ==
+      ::
+          [%3 argument=*]
+        =/  argument  $(formula argument.formula)
+        ?.  ?=(%0 -.argument)  argument
+        [%0 .?(product.argument)]
+      ::
+          [%4 argument=*]
+        =/  argument  $(formula argument.formula)
+        ?.  ?=(%0 -.argument)  argument
+        ?^  product.argument  [%2 trace]
+        [%0 .+(product.argument)]
+      ::
+          [%5 a=* b=*]
+        =/  a  $(formula a.formula)
+        ?.  ?=(%0 -.a)  a
+        =/  b  $(formula b.formula)
+        ?.  ?=(%0 -.b)  b
+        [%0 =(product.a product.b)]
+      ::
+          [%6 test=* yes=* no=*]
+        =/  result  $(formula test.formula)
+        ?.  ?=(%0 -.result)  result
+        ?+  product.result
+              [%2 trace]
+          %&  $(formula yes.formula)
+          %|  $(formula no.formula)
+        ==
+      ::
+          [%7 subject=* next=*]
+        =/  subject  $(formula subject.formula)
+        ?.  ?=(%0 -.subject)  subject
+        %=  $
+          subject  product.subject
+          formula  next.formula
+        ==
+      ::
+          [%8 head=* next=*]
+        =/  head  $(formula head.formula)
+        ?.  ?=(%0 -.head)  head
+        %=  $
+          subject  [product.head subject]
+          formula  next.formula
+        ==
+      ::
+          [%9 axis=@ core=*]
+        =/  core  $(formula core.formula)
+        ?.  ?=(%0 -.core)  core
+        =/  arm  (frag axis.formula product.core)
+        ?~  arm  [%2 trace]
+        %=  $
+          subject  product.core
+          formula  u.arm
+        ==
+      ::
+          [%10 [axis=@ value=*] target=*]
+        ?:  =(0 axis.formula)  [%2 trace]
+        =/  target  $(formula target.formula)
+        ?.  ?=(%0 -.target)  target
+        =/  value  $(formula value.formula)
+        ?.  ?=(%0 -.value)  value
+        =/  mutant=(unit *)
+          (edit axis.formula product.target product.value)
+        ?~  mutant  [%2 trace]
+        [%0 u.mutant]
+      ::
+          [%11 tag=@ next=*]
+        =/  next  $(formula next.formula)
+        ?.  ?=(%0 -.next)  next
+        :-  %0
+        .*  subject
+        [11 tag.formula 1 product.next]
+      ::
+          [%11 [tag=@ clue=*] next=*]
+        =/  clue  $(formula clue.formula)
+        ?.  ?=(%0 -.clue)  clue
+        =/  next
+          =?    trace
+              ?=(?(%hunk %hand %lose %mean %spot) tag.formula)
+            [[tag.formula product.clue] trace]
+          $(formula next.formula)
+        ?.  ?=(%0 -.next)  next
+        :-  %0
+        .*  subject
+        [11 [tag.formula 1 product.clue] 1 product.next]
+      ::
+          [%12 ref=* path=*]
+        =/  ref  $(formula ref.formula)
+        ?.  ?=(%0 -.ref)  ref
+        =/  path  $(formula path.formula)
+        ?.  ?=(%0 -.path)  path
+        =/  result  (scry product.ref product.path)
+        ?~  result
+          [%1 product.path]
+        ?~  u.result
+          [%2 [%hunk product.ref product.path] trace]
+        [%0 u.u.result]
+      ==
+  ::
+  ++  frag
+    |=  [axis=@ noun=*]
+    ^-  (unit)
+    ?:  =(0 axis)  ~
+    |-  ^-  (unit)
+    ?:  =(1 axis)  `noun
+    ?@  noun  ~
+    =/  pick  (cap axis)
+    %=  $
+      axis  (mas axis)
+      noun  ?-(pick %2 -.noun, %3 +.noun)
+    ==
+  ::
+  ++  edit
+    |=  [axis=@ target=* value=*]
+    ^-  (unit)
+    ?:  =(1 axis)  `value
+    ?@  target  ~
+    =/  pick  (cap axis)
+    =/  mutant
+      %=  $
+        axis    (mas axis)
+        target  ?-(pick %2 -.target, %3 +.target)
+      ==
+    ?~  mutant  ~
+    ?-  pick
+      %2  `[u.mutant +.target]
+      %3  `[-.target u.mutant]
+    ==
+  --
 ```
 
 #### Examples
 
 ```
-    > (mink [20 [4 0 1]] $~)
-    [%0 p=21]
-    > (mink [[90 5 3] [0 3]] $~)
-    [%0 p=[5 3]]
-    > (mink 20^[4 0 1] $~)
-    [%0 p=21]
-    > (mink [90 5 3]^[0 3] $~)
-    [%0 p=[5 3]]
-    > (mink [0]^[11 1 20] $~)
-    [%1 p=~[20]]
-    > (mink [0]^[11 1 20] |=(a=* `[40 a]))
-    [%0 p=[40 20]]
-    > (mink [5]^[0 2] $~)
-    [%2 p=~]
-    > (mink [5]^[10 yelp/[0 1] 0 0] $~)
-    [%2 p=~[[~.yelp 5]]]
+> (mink [20 [4 0 1]] ,~)
+[%0 product=21]
+
+> (mink [[[4 5] [6 14 15]] [0 7]] ,~)
+[%0 product=[14 15]]
+
+> (mink [42 12 [0 1] [1 73]] |=(a=^ ``(add (,[@ @] a))))
+[%0 product=115]
+
+> (mink [0 12 [1 0] [1 0]] |=(* ~))
+[%1 block=0]
+
+> (mink [42 0 2] ,~)
+[%2 trace=~]
 ```
 
 ---
@@ -179,9 +264,9 @@ A `++tone`.
 
 Compute formula on subject with hint
 
-Produces a `++toon`, which is either a sucessful, blocked, or
-crashed result. If nock 11 is invoked, `sky` computes on the subject and
-produces a `++unit` result. An empty result becomes a `%1` `++tune`,
+Produces a `toon`, which is either a sucessful, blocked, or
+crashed result. If nock 11 is invoked, `gul` computes on the subject and
+produces a `(unit (unit))` result. An empty result becomes a `%1` `tune`,
 indicating a block.
 
 #### Accepts
@@ -190,94 +275,34 @@ indicating a block.
 
 `fol` is the formula as a noun.
 
-`sky` is an %iron gate invoked with nock operator 11.
+`gul` is an %iron gate invoked with nock operator 11.
 
 #### Produces
 
-The `++unit` of a noun.
+The `unit` of a noun.
 
 #### Source
 
 ```hoon
-    ++  mock
-      |=  {{sub/* fol/*} gul/$-({* *} (unit (unit)))}
-      (mook (mink [sub fol] gul))
-    ::
+++  mock
+  |=  [[sub=* fol=*] gul=$-(^ (unit (unit)))]
+  (mook (mink [sub fol] gul))
 ```
 
 #### Examples
 
 ```
-    > (mock [5 4 0 1] ,~)
-    [%0 p=6]
-    > (mock [~ 11 1 0] |=(* `999))
-    [%0 p=999]
-    > (mock [~ 0 1.337] ,~)
-    [%2 p=~]
-    > (mock [~ 11 1 1.337] ,~)
-    [%1 p=~[1.337]]
-    > (mock [[[4 4 4 4 0 3] 10] 11 9 2 0 1] |=(* `[+<]))
-    [%0 p=14]
-    > (mock [[[4 4 4 4 0 3] 10] 11 9 2 0 1] |=(* `[<+<>]))
-    [%0 p=[49 52 0]]
-    > ;;(tape +:(mock [[[4 4 4 4 0 3] 10] 11 9 2 0 1] |=(* `[<+<>])))
-    "14"
-```
+> (mock [5 4 0 1] ,~)
+[%0 p=6]
 
----
+> (mock [0 12 [0 1] [0 1]] |=(* ``999))
+[%0 p=999]
 
-## `++mong`
+> (mock [42 12 [0 1] [0 1]] |=(* ~))
+[%1 p=42]
 
-Slam gate with sample
-
-Produces a `++toon` computation result from slamming `gat` with
-`sam`, using `sky` to compute or block on nock 11 when applicable.
-
-#### Accepts
-
-`gat` is a noun that is generally a `gate`.
-
-`sam` is a `sample` noun.
-
-`sky` is an %iron gate invoked with nock operator 11.
-
-#### Produces
-
-A `++toon`.
-
-#### Source
-
-```hoon
-    ++  mong
-      |=  {{gat/* sam/*} gul/$-({* *} (unit (unit)))}
-      ^-  toon
-      ?.  &(?=(^ gat) ?=(^ +.gat))
-        [%2 ~]
-      (mock [[-.gat [sam +>.gat]] -.gat] gul)
-    ::
-```
-
-#### Examples
-
-```
-    > (mong [|=(@ 20) ~] ,~)
-    [%0 p=20]
-    > (mong [|=(@ !!) ~] ,~)
-    [%2 p=~]
-    > (mong [|=(a/@ (add 20 a)) ~] ,~)
-    [%0 p=20]
-    > (mong [|=(a/[@ @] (add 20 -.a)) ~] ,~)
-    [%2 p=~]
-    > (mong [|=(a/[@ @] (add 20 -.a)) [4 6]] ,~)
-    [%0 p=24]
-    > (mong [|=(a/@ .^(a)) ~] ,~)
-    [%1 p=~[0]]
-    > (mong [|=(a/@ .^(a)) ~] ,[~ %42])
-    [%0 p=42]
-    > (mong [|=(a/@ .^(a)) ~] |=(a/* [~ a 6]))
-    [%0 p=[0 6]]
-    > (mong [|=(a/@ .^(a)) 8] |=(a/* [~ a 6]))
-    [%0 p=[8 6]]
+> (mock [42 0 2] ,~)
+[%2 p=~]
 ```
 
 ---
@@ -286,70 +311,213 @@ A `++toon`.
 
 Intelligently render crash annotation
 
-Converts a `%2` `++tone` nock stack trace to a list of `++tank`.
-Each may be a tank, cord, `++spot`, or trapped tank.
+Converts a `%2` `tone` nock stack trace to a list of `tank`. Each may be a
+`tank`, `cord`, `spot`, or trapped `tank`.
 
 #### Accepts
 
-`ton` is a `++tone`.
+`ton` is a `tone`.
 
 #### Produces
 
-A `++toon`.
+A `toon`.
 
 #### Source
 
 ```hoon
-    ++  mook
-      |=  ton/tone
-      ^-  toon
-      ?.  ?=({$2 *} ton)  ton
-      :-  %2
-      :: =.  p.ton  (moop p.ton)
-      =+  yel=(lent p.ton)
-      =.  p.ton
-        ?.  (gth yel 256)  p.ton
-        %+  weld
-          (scag 128 p.ton)
-        ^-  (list {@ta *})
-        :_  (slag (sub yel 128) p.ton)
-        :-  %lose
-        %+  rap  3
-        "[skipped {(scow %ud (sub yel 256))} frames]"
-      |-  ^-  (list tank)
-      ?~  p.ton  ~
-      =+  rep=$(p.ton t.p.ton)
-      ?+    -.i.p.ton  rep
-          $hunk  [(tank +.i.p.ton) rep]
-          $lose  [[%leaf (rip 3 (@ +.i.p.ton))] rep]
-          $hand  [[%leaf (scow %p (mug +.i.p.ton))] rep]
-          $mean  :_  rep
-                 ?@  +.i.p.ton  [%leaf (rip 3 (@ +.i.p.ton))]
-                 =+  mac=(mack +.i.p.ton +<.i.p.ton)
-                 ?~(mac [%leaf "####"] (tank u.mac))
-          $spot  :_  rep
-                 =+  sot=(spot +.i.p.ton)
-                 :+  %rose  [":" ~ ~]
-                 :~  (smyt p.sot)
-                     =>  [ud=|=(a/@u (scow %ud a)) q.sot]
-                     leaf+"<[{(ud p.p)} {(ud q.p)}].[{(ud p.q)} {(ud q.q)}]>"
-      ==         ==
+++  mook
+  |=  ton=tone
+  ^-  toon
+  ?.  ?=([%2 *] ton)
+    ton
+  |^  [%2 (turn skip rend)]
+  ::
+  ++  skip
+    ^+  trace.ton
+    =/  yel  (lent trace.ton)
+    ?.  (gth yel 1.024)  trace.ton
+    %+  weld
+      (scag 512 trace.ton)
+    ^+  trace.ton
+    :_  (slag (sub yel 512) trace.ton)
+    :-  %lose
+    (crip "[skipped {(scow %ud (sub yel 1.024))} frames]")
+  ::
+  ::  +rend: raw stack frame to tank
+  ::
+  ::    $%  [%hunk ref=* path]            ::  failed scry ([~ ~])
+  ::        [%lose cord]                  ::  skipped frames
+  ::        [%hand *]                     ::  mug any
+  ::        [%mean $@(cord (trap tank))]  ::  ~_ et al
+  ::        [%spot spot]                  ::  source location
+  ::    ==
+  ::
+  ++  rend
+    |=  [tag=@ta dat=*]
+    ^-  tank
+    ?+    tag
     ::
+      leaf+"mook.{(rip 3 tag)}"
+    ::
+        %hunk
+      ?@  dat  leaf+"mook.hunk"
+      =/  sof=(unit path)  ((soft path) +.dat)
+      ?~  sof  leaf+"mook.hunk"
+      (smyt u.sof)
+    ::
+        %lose
+      ?^  dat  leaf+"mook.lose"
+      leaf+(rip 3 dat)
+    ::
+        %hand
+      leaf+(scow %p (mug dat))
+    ::
+        %mean
+      ?@  dat  leaf+(rip 3 dat)
+      =/  mac  (mack dat -.dat)
+      ?~  mac  leaf+"####"
+      =/  sof  ((soft tank) u.mac)
+      ?~  sof  leaf+"mook.mean"
+      u.sof
+    ::
+        %spot
+      =/  sof=(unit spot)  ((soft spot) dat)
+      ?~  sof  leaf+"mook.spot"
+      :+  %rose  [":" ~ ~]
+      :~  (smyt p.u.sof)
+          =*  l   p.q.u.sof
+          =*  r   q.q.u.sof
+          =/  ud  |=(a=@u (scow %ud a))
+          leaf+"<[{(ud p.l)} {(ud q.l)}].[{(ud p.r)} {(ud q.r)}]>"
+      ==
+    ==
+  --
 ```
 
 #### Examples
 
 ```
-    > (mook [%0 5 4 5 1])
-    [%0 p=[5 4 5 1]]
-    > (mook [%2 ~[[%hunk %rose ["<" "," ">"] ~[[%leaf "err"]]]]])
-    [%2 p=~[[%rose p=[p="<" q="," r=">"] q=[i=[%leaf p="err"] t=~]]]]
-    > (mook [%2 ~[[%malformed %elem] [%lose 'do print']]])
-    [%2 p=~[[%leaf p="do print"]]]
-    > (mook [%2 ~[[%mean |.(>(add 5 6)<)]]])
-    [%2 p=~[[%leaf p="11"]]]
-    > (mook [%2 ~[[%spot /b/repl [1 1]^[1 2]] [%mean |.(!!)]]])
-    [%2 p=~[[%leaf p="/b/repl/:<[1 1].[1 2]>"] [%leaf p="####"]]]
+> (mook [%0 5 4 5 1])
+[%0 p=[5 4 5 1]]
+
+> (mook [%2 ~[[%hunk %rose ["<" "," ">"] ~[[%leaf "err"]]]]])
+[%2 p=~[[%leaf p="mook.hunk"]]]
+
+> (mook [%2 ~[[%mean |.(>(add 5 6)<)]]])
+[%2 p=~[[%leaf p="11"]]]
+
+> (mook [%2 ~[[%spot /b/repl [1 1]^[1 2]] [%mean |.(!!)]]])
+[ %2
+    p
+  ~[
+    [ %rose
+      p=[p=":" q="" r=""]
+        q
+      [   i
+        [ %rose
+          p=[p="/" q="/" r=""]
+          q=[i=[%leaf p="b"] t=[i=[%leaf p="repl"] t=~]]
+        ]
+        t=[i=[%leaf p="<[1 1].[1 2]>"] t=~]
+      ]
+    ]
+    [%leaf p="####"]
+  ]
+]
+```
+
+---
+
+## `++mole`
+
+Typed unitary virtual
+
+Kicks a `trap`, producing its result in a `unit` if successful, or a null `unit`
+if it crashed. Unitized version of [`++mule`](#mule).
+
+#### Accepts
+
+`tap` is a `trap`.
+
+#### Produces
+
+A `(unit *)`, where the `*` will be the type produced by the expression.
+
+#### Source
+
+```hoon
+++  mole
+  ~/  %mole
+  |*  tap=(trap)
+  ^-  (unit _$:tap)
+  =/  mur  (mure tap)
+  ?~(mur ~ `$:tap)
+```
+
+#### Examples
+
+```
+> (mole |.(`@t`(add 50 47)))
+[~ 'a']
+
+> (mole |.(~|('Error!' !!)))
+~
+```
+
+---
+
+## `++mong`
+
+Slam gate with sample
+
+Produces a `toon` computation result from slamming `gat` with
+`sam`, using `gul` to compute or block on nock 11 when applicable.
+
+#### Accepts
+
+`gat` is a noun that is generally a `gate`.
+
+`sam` is a sample noun.
+
+`gul` is an `%iron` gate invoked with nock operator 11.
+
+#### Produces
+
+A `toon`.
+
+#### Source
+
+```hoon
+++  mong
+  |=  [[gat=* sam=*] gul=$-(^ (unit (unit)))]
+  ^-  toon
+  ?.  ?=([* ^] gat)  [%2 ~]
+  (mock [gat(+< sam) %9 2 %0 1] gul)
+```
+
+#### Examples
+
+```
+> (mong [|=(@ 20) ~] ,~)
+[%0 p=20]
+
+> (mong [|=(@ !!) ~] ,~)
+[%2 p=~]
+
+> (mong [|=(a=@ (add 20 a)) ~] ,~)
+[%0 p=20]
+
+> (mong [|=(a=[@ @] (add 20 -.a)) ~] ,~)
+[%2 p=~]
+
+> (mong [|=(a=[@ @] (add 20 -.a)) [4 6]] ,~)
+[%0 p=24]
+
+> (mong [|=(a=@ .^(* a)) 99] |=(^ ``+<))
+[%0 p=[[140 1.853.189.998] 99]]
+
+> (mong [|=(a=@ .^(@ a)) 99] |=([* a=*] ``+((,@ a))))
+[%0 p=100]
 ```
 
 ---
@@ -358,51 +526,81 @@ A `++toon`.
 
 Typed virtual
 
-Kicks a `++trap`, producing its results or any errors that occur along
+Kicks a `trap`, producing its results or any errors that occur along
 the way. Used to lazily compute stack traces.
 
 #### Accepts
 
-`taq` is a `++trap`, generally producing a list of `++tank`s.
+`tap` is a `trap`, generally producing a list of `tank`s.
 
 #### Produces
 
-XX
+An `(each * (list tank))` - `%.y` indicates success and `%.n` indicates a crash.
 
 #### Source
 
 ```hoon
-    ++  mule                                                ::  typed virtual
-      ~/  %mule
-      |*  taq/_|.(**)
-      =+  mud=(mute taq)
-      ?-  -.mud
-        $&  [%& p=$:taq]                                    ::  XX transition
-        $|  [%| p=p.mud]
-      ==
-    ::
+++  mule
+  ~/  %mule
+  |*  tap=(trap)
+  =/  mud  (mute tap)
+  ?-  -.mud
+    %&  [%& p=$:tap]
+    %|  [%| p=p.mud]
+  ==
 ```
 
 #### Examples
 
 ```
-    > (mule |.(leaf/"hello"))
-    [%.y p=[%leaf "hello"]]
-    > (mule |.(!!))
-    [%.n p=~]
-    > (mule |.(.^(a//=pals/1)))
-    [ %.n
-        p
-      ~[
-        [ %rose
-          p=[p="/" q="/" r="/"]
-            q
-          [ i=[%leaf p="a"]
-            t=[i=[%leaf p="~zod"] t=[i=[%leaf p="pals"] t=[i=[%leaf p="1"] t=~]]]
-          ]
-        ]
-      ]
-    ]
+> (mule |.((add 1 1)))
+[%.y p=2]
+
+> (mule |.(~|(%error !!)))
+[%.n p=~[[%leaf p="%error"]]]
+```
+
+---
+
+## `++mure`
+
+Untyped unitary virtual
+
+Kicks a `trap`, producing its results in a `unit` which is null if it crashed.
+The result is just a noun, no type information is preserved.
+
+#### Accepts
+
+A `trap`.
+
+#### Produces
+
+A `(unit *)`.
+
+#### Source
+
+```hoon
+++  mure
+  |=  tap=(trap)
+  ^-  (unit)
+  =/  ton  (mink [tap %9 2 %0 1] |=((pair) ``.*(~ [%12 1+p 1+q])))
+  ?.(?=(%0 -.ton) ~ `product.ton)
+```
+
+#### Examples
+
+```
+> (mure |.(~|(%error !!)))
+~
+
+> (mure |.((add 1 1)))
+[~ 2]
+
+> (mure |.('foo'))
+[~ 7.303.014]
+
+> ((unit @t) (mure |.('foo')))
+[~ 'foo']
 ```
 
 ---
@@ -411,39 +609,115 @@ XX
 
 Untyped virtual
 
-Kicks a `++trap`, producing its result as a noun or the tanks of any
-error that occurs. Similar to `++mule`, but preserves no type
-information.
+Kicks a `trap`, producing its result as a noun or the tanks of any error that
+occurs. Similar to [`++mule`](#mule), but preserves no type information.
 
 #### Accepts
 
-`taq` is a `++trap`.
+`tap` is a `trap`.
 
 #### Produces
 
-Either a noun or a `++list` of `++tank`.
+A `(each * (list tank))`, where `%.y` indicates success and `%.n` indicates
+failure.
 
 #### Source
 
 ```hoon
-    ++  mute                                                ::  untyped virtual
-      |=  taq/_^?(|.(**))
-      ^-  (each * (list tank))
-      =+  ton=(mock [taq 9 2 0 1] |=({* *} ~))
-      ?-  -.ton
-        $0  [%& p.ton]
-        $1  [%| (turn p.ton |=(a/* (smyt (path a))))]
-        $2  [%| p.ton]
-      ==
+++  mute
+  |=  tap=(trap)
+  ^-  (each * (list tank))
+  =/  ton  (mock [tap %9 2 %0 1] |=((pair) ``.*(~ [%12 1+p 1+q])))
+  ?-  -.ton
+    %0  [%& p.ton]
+  ::
+    %1  =/  sof=(unit path)  ((soft path) p.ton)
+        [%| ?~(sof leaf+"mute.hunk" (smyt u.sof)) ~]
+  ::
+    %2  [%| p.ton]
+  ==
 ```
 
 #### Examples
 
 ```
-    >  (mute |.(leaf/"hello"))
-    [%.y p=[1.717.658.988 104 101 108 108 111 0]]
-    > (mute |.(!!))
-    [%.n p=~]
+> (mute |.(leaf+"hello"))
+[%.y p=[1.717.658.988 104 101 108 108 111 0]]
+
+> (mute |.(!!))
+[%.n p=~]
+
+> (mute |.(~|(%error !!)))
+[%.n p=~[[%leaf p="%error"]]]
+
+> (mute |.((cat 3 'foo' 'bar')))
+[%.y p=125.762.588.864.358]
+```
+
+---
+
+## `++slum`
+
+Slam a gate on a sample using raw nock, untyped
+
+Slam `gat` with `sam`. Uses a raw `.*` nock expression internally and does not
+preserve type information for the result. This will crash if evaluation crashes.
+
+#### Examples
+
+```
+> (slum |=([a=@ b=@] (add a b)) [7 9])
+16
+
+> (slum (cury cat 3) ['foo' 'bar'])
+125.762.588.864.358
+
+> (@t (slum (cury cat 3) ['foo' 'bar']))
+'foobar'
+
+> (slum |=(* !!) 42)
+dojo: hoon expression failed
+```
+
+---
+
+## `++soft`
+
+Virtual clam
+
+Clam (mold) noun `fud` with `mold` `han`, producing a `unit` of the result. The
+`unit` is null if clamming failed. This is curried, so the soft-clamming gate can
+be stored and called repeatedly.
+
+#### Accepts
+
+`han` is a `mold`.
+
+`fud` is a noun.
+
+#### Produces
+
+A `(unit *)`, where the `*` will be the type produced by the mold.
+
+#### Source
+
+```hoon
+++  soft
+  |*  han=$-(* *)
+  |=(fud=* (mole |.((han fud))))
+```
+
+#### Examples
+
+```
+> ((soft @t) 97)
+[~ 'a']
+
+> ((soft @t) [1 2])
+~
+
+> ((soft ,[@ux @ux]) ['a' 'b'])
+[~ [0x61 0x62]]
 ```
 
 ---

--- a/content/docs/hoon/reference/stdlib/4o.md
+++ b/content/docs/hoon/reference/stdlib/4o.md
@@ -4,683 +4,1470 @@ weight = 42
 template = "doc.html"
 +++
 
-## `++abel`
+## `+$abel`
 
-Biblical names in hoon are primarily aliases for the compiler.
+Original sin: type
+
+Old type, same as the new `type`.
 
 #### Source
 
 ```hoon
-    ++  abel  typo                                      ::  original sin: type
++$  abel  typo
 ```
 
 #### Examples
 
 ```
-    > *abel
-    %void
+> *abel
+#t/*
 ```
 
 ---
 
-## `++aura`
+## `+$alas`
+
+Alias list
+
+This is the type used in `%brcb` (`|_` door) `hoon` type for `+*` alias arms.
+
+#### Source
+
+```hoon
++$  alas  (list (pair term hoon))
+```
+
+---
+
+## `+$atom`
+
+Just an atom
+
+This is the same as `@`.
+
+#### Source
+
+```hoon
++$  atom  @
+```
+
+#### Examples
+
+```
+> *atom
+0
+
+> `atom`'foo'
+7.303.014
+```
+
+---
+
+## `+$aura`
 
 'type' of atom
 
-By convention, a short name for a category of atom. `++aura` is
-circularly defined, with `@ta` being the `++aura` of the ASCII subset
-commonly used in urbit.
+By convention, a short name for a category of atom. `aura` is circularly
+defined, with `@ta` being the `aura` of the ASCII subset commonly used in urbit.
 
 #### Source
 
 ```hoon
-    ++  aura  ,@ta                                          ::  atom format
++$  aura  @ta
 ```
 
 #### Examples
 
-See also: `++base`, aura reference
+See also: [`+$base`](#base), aura reference
 
 ```
-    > `aura`%ux
-    ~.ux
+> `aura`'ux'
+~.ux
 ```
 
 ---
 
-## `++base`
+## `+$base`
 
 Base type
 
-A base type that nouns are built from. A `++base` is either a noun, cell,
-boolean or null labelled with an aura.
+A base type that nouns are built from. A `base` is either a noun, atom with
+aura, cell, boolean, null, or an empty set.
 
 #### Source
 
 ```hoon
-    ++  base  ?([%atom p=aura] %noun %cell %bean %null)     ::  axils, @ * ^ ? ~
++$  base            ::  base mold
+  $@  $?  %noun     ::  any noun
+          %cell     ::  any cell
+          %flag     ::  loobean
+          %null     ::  ~ == 0
+          %void     ::  empty set
+      ==            ::
+  [%atom p=aura]    ::  atom
 ```
 
 #### Examples
 
 ```
-    > *base
-    %null
+> *base
+%void
 
-    > (ream '=|(^ !!)')
-    [%tsbr p=[%axil p=%cell] q=[%zpzp ~]]
-    > :: p.p is a ++base
-    > (ream '=|(@t !!)')
-    [%tsbr p=[%axil p=[%atom p=~.t]] q=[%zpzp ~]]
-    > (ream '=|(? !!)')
-    [%tsbr p=[%axil p=%bean] q=[%zpzp ~]]
+> (ream '=|(^ !!)')
+[%tsbr p=[%base p=%cell] q=[%zpzp ~]]
 ```
 
 ---
 
-## `++beer`
+## `+$woof`
 
-Tape builder
+Simple embed
 
-Used to build tapes internally.
+An atom or some `hoon`.
 
 #### Source
 
 ```hoon
-    ++  beer  $|(@ [~ p=hoon])                              ::  simple embed
++$  woof  $@(@ [~ p=hoon])
 ```
 
 #### Examples
 
 ```
-    > `beer`'as'
-    29.537
-    > `beer`[~ (ream 'lan')]
-    [~ p=[%cnzz p=~[%lan]]]
+> *woof
+0
+
+> `woof`[~ %base p=%cell]
+[~ p=[%base p=%cell]]
+
+> `woof`'foo'
+7.303.014
 ```
 
 ---
 
-## `++beet`
-
-XML interpolation cases
-
-Used internally.
-
-#### Source
-
-```hoon
-    ++  beet  $|  @                                         ::  advanced embed
-              $%  [%a p=hoon]                               ::  take tape
-                  [%b p=hoon]                               ::  take manx
-                  [%c p=hoon]                               ::  take marl
-                  [%d p=hoon]                               ::  take $+(marl marl)
-                  [%e p=hoon q=(list tuna)]                 ::  element literal
-              ==                                            ::
-```
-
----
-
-## `++chum`
+## `+$chum`
 
 Jet hint information
 
-Jet hint information that must be present in the body of a `~/` or `~%`
-rune. A `++chum` can optionally contain a kelvin version, jet vendor,
-and `"{major}.{minor}"` version number.
+Jet hint information that must be present in the body of a `~/` or `~%` rune. A
+`chum` can optionally contain a kelvin version, jet vendor, and version number.
 
 #### Source
 
 ```hoon
-    ++  chum  $?  lef=term                                  ::  jet name
-                  [std=term kel=@]                          ::  kelvin version
-                  [ven=term pro=term kel=@]                 ::  vendor and product
-                  [ven=term pro=term ver=@ kel=@]           ::  all of the above
-              ==                                            ::
++$  chum  $?  lef=term                                  ::  jet name
+              [std=term kel=@]                          ::  kelvin version
+              [ven=term pro=term kel=@]                 ::  vendor and product
+              [ven=term pro=term ver=@ kel=@]           ::  all of the above
+          ==                                            ::
 ```
 
 #### Examples
 
-XX there's a ++chum in zuse that's politely causing this not to work
-
 ```
-    > `chum`'hi'
-    lef=%hi
+> `chum`'hi'
+lef=%hi
 
-    > (ream '~/(%lob.314 !!)')
-    [%sgfs p=[std=%lob kel=314] q=[%zpzp ~]]
+> (ream '~/(%lob.314 !!)')
+[%sgfs p=[std=%lob kel=314] q=[%zpzp ~]]
 ```
 
 ---
 
-## `++coil`
+## `+$coil`
 
 Tuple of core information
 
-Variance `p`, subject type `q`, and `q`: optional compiled nock, and arms. Used as an
-intermediate step within Section 2fB. Converted by `++core` to %core type.
+Variance `p`, subject type `q`, and `r`: optional compiled nock, and arms. Used
+as an intermediate step during compilation and converted to a core.
 
 #### Source
 
 ```hoon
-    ++  coil  $:  p=?(%gold %iron %lead %zinc)              ::  core type
-                  q=type                                    ::
-                  r=[p=?(~ ^) q=(map term foot)]            ::
-              ==                                            ::
++$  coil  $:  p=garb                               ::  name, wet=dry, vary
+              q=type                               ::  context
+              r=(pair seminoun (map term tome))    ::  chapters
+          ==                                       ::
 ```
 
 ---
 
-## `++foot`
+## `+$garb`
+
+Core metadata
+
+A triple of an optional name, polarity (wet/dry), and variance (`%iron`, etc).
+
+#### Source
+
+```hoon
++$  garb  (trel (unit term) poly vair)
+```
+
+---
+
+## `+$poly`
+
+Polarity
+
+Whether a core is wet or dry.
+
+#### Source
+
+```hoon
++$  poly  ?(%wet %dry)
+```
+
+---
+
+## `+$foot`
 
 Cases of arms by variance model.
 
-`%ash` arms are `dry` and geometric.
-
 #### Source
 
 ```hoon
-    ++  foot  $%  [%ash p=hoon]                           ::  dry arm, geometric
-                  [%elm p=hoon]                           ::  wet arm, generic
-                  [%oak ~]                                ::  XX not used
-                  [%yew p=(map term foot)]                ::  XX not used
-              ==                                          ::
-```
-
-#### Examples
-
-See also: `++ap`, `++ut`
-
-```
-    > *foot
-    [%yew p={}]
-
-    > (ream '|%  ++  $  foo  --')
-    [%brcn p={[p=%$ q=[%ash p=[%cnzz p=~[%foo]]]]}]
-    > +<+:(ream '|%  ++  $  foo  --')
-    t=~[%ash %cnzz %foo]
-    > (foot +<+:(ream '|%  ++  $  foo  --'))
-    [%ash p=[%cnzz p=~[%foo]]]
-    > (foot +<+:(ream '|%  +-  $  foo  --'))
-    [%elm p=[%cnzz p=~[%foo]]]
++$  foot  $%  [%dry p=hoon]    ::  dry arm, geometric
+              [%wet p=hoon]    ::  wet arm, generic
+          ==
 ```
 
 ---
 
-## `++limb`
+## `+$link`
 
-```hoon
-    ++  limb  $|(term $%([%& p=axis] [%| p=@ud q=term]))    ::
-```
+Lexical segment
 
-XX move to `++ut`
-
-Reference into subject by name/axis
-
-See also: section 2fC-2fD
-
-```hoon
-    > (ream '^^$')
-    [%cnzz p=~[[%.n p=2 q=%$]]]
-    > (limb &2:(ream '^^$'))
-    [%.n p=2 q=%$]
-    > (limb &2:(ream '^^^$'))
-    [%.n p=3 q=%$]
-```
-
----
-
-## `++line`
-
-XX move to `++ut`
+Used for documentation.
 
 #### Source
 
 ```hoon
-    ++  line  ,[p=[%leaf p=aura q=@] q=tile]                ::  %kelp case
++$  link                               ::  lexical segment
+          $%  [%chat p=term]           ::  |chapter
+              [%cone p=aura q=atom]    ::  %constant
+              [%frag p=term]           ::  .leg
+              [%funk p=term]           ::  +arm
+          ==
+```
+
+---
+
+## `+$crib`
+
+Summary and details
+
+Summary and details for documentation.
+
+#### Source
+
+```hoon
++$  crib  [summary=cord details=(list sect)]
+```
+
+---
+
+## `+$help`
+
+Documentation
+
+#### Source
+
+```hoon
++$  help  [links=(list link) =crib]
+```
+
+---
+
+## `+$limb`
+
+Wing element
+
+Reference into subject by tree address or name.
+
+#### Source
+
+```hoon
++$  limb  $@  term                                      ::  wing element
+          $%  [%& p=axis]                               ::  by geometry
+              [%| p=@ud q=(unit term)]                  ::  by name
+          ==                                            ::
 ```
 
 #### Examples
 
 ```
-    > (ream '$%([1 a] [%2 b])')
-    [ %bccm
-        p
-      [ %kelp
-          p
-        [ i=[p=[%leaf p=~.ud q=1] q=[%herb p=[%cnzz p=~[%a]]]]
-          t=~[[p=[%leaf p=~.ud q=2] q=[%herb p=[%cnzz p=~[%b]]]]]
-        ]
-      ]
+> (ream '^^$')
+[%wing p=~[[%.n p=2 q=[~ %$]]]]
+```
+
+---
+
+## `+$null`
+
+Null, nil, etc
+
+Just `~`.
+
+#### Source
+
+```hoon
++$  null  ~
+```
+
+#### Examples
+
+```
+> *null
+~
+```
+
+---
+
+## `+$onyx`
+
+Arm activation
+
+#### Source
+
+```hoon
++$  onyx  (list (pair type foot))
+```
+
+---
+
+## `+$opal`
+
+Wing match
+
+Arm or leg of a wing.
+
+#### Source
+
+```hoon
++$  opal                                            ::  limb match
+          $%  [%& p=type]                           ::  leg
+              [%| p=axis q=(set [p=type q=foot])]   ::  arm
+          ==                                        ::
+```
+
+---
+
+## `+$pica`
+
+Prose or code
+
+A `(pair ? cord)`. If `%.y` it's prose and if `%.n` it's code. Used in
+documentation.
+
+#### Source
+
+```hoon
++$  pica  (pair ? cord)
+```
+
+---
+
+## `+$palo`
+
+Wing trace, match
+
+A [`$vein`](#vein) and a [`$opal`](#opal).
+
+#### Source
+
+```hoon
++$  palo  (pair vein opal)
+```
+
+---
+
+## `+$plat`
+
+%hoon, %type, %nock or %tank
+
+#### Source
+
+```hoon
++$  plat
+          $?  %hoon
+              %type
+              %nock
+              %tank
+          ==
+```
+
+---
+
+## `+$pock`
+
+Changes
+
+#### Source
+
+```hoon
++$  pock  (pair axis nock)
+```
+
+---
+
+## `+$port`
+
+Successful wing match
+
+#### Source
+
+```hoon
++$  port  (each palo (pair type nock))
+```
+
+---
+
+## `+$spec`
+
+Structure definition AST.
+
+#### Source
+
+```hoon
++$  spec                                                ::  structure definition
+          $~  [%base %null]                             ::
+          $%  [%base p=base]                            ::  base type
+              [%dbug p=spot q=spec]                     ::  set debug
+              [%leaf p=term q=@]                        ::  constant atom
+              [%like p=wing q=(list wing)]              ::  reference
+              [%loop p=term]                            ::  hygienic reference
+              [%made p=(pair term (list term)) q=spec]  ::  annotate synthetic
+              [%make p=hoon q=(list spec)]              ::  composed spec
+              [%name p=term q=spec]                     ::  annotate simple
+              [%over p=wing q=spec]                     ::  relative to subject
+          ::                                            ::
+              [%bcgr p=spec q=spec]                     ::  $>, filter: require
+              [%bcbc p=spec q=(map term spec)]          ::  $$, recursion
+              [%bcbr p=spec q=hoon]                     ::  $|, verify
+              [%bccb p=hoon]                            ::  $_, example
+              [%bccl p=[i=spec t=(list spec)]]          ::  $:, tuple
+              [%bccn p=[i=spec t=(list spec)]]          ::  $%, head pick
+              [%bcdt p=spec q=(map term spec)]          ::  $., read-write core
+              [%bcgl p=spec q=spec]                     ::  $<, filter: exclude
+              [%bchp p=spec q=spec]                     ::  $-, function core
+              [%bckt p=spec q=spec]                     ::  $^, cons pick
+              [%bcls p=stud q=spec]                     ::  $+, standard
+              [%bcfs p=spec q=(map term spec)]          ::  $/, write-only core
+              [%bcmc p=hoon]                            ::  $;, manual
+              [%bcpm p=spec q=hoon]                     ::  $&, repair
+              [%bcsg p=hoon q=spec]                     ::  $~, default
+              [%bctc p=spec q=(map term spec)]          ::  $`, read-only core
+              [%bcts p=skin q=spec]                     ::  $=, name
+              [%bcpt p=spec q=spec]                     ::  $@, atom pick
+              [%bcwt p=[i=spec t=(list spec)]]          ::  $?, full pick
+              [%bczp p=spec q=(map term spec)]          ::  $!, opaque core
+          ==                                            ::
+```
+
+#### Examples
+
+```
+> *spec
+[%base p=%null]
+
+> `spec`[%bccl ~[leaf+ud+1 leaf+ud+2]]
+[%bccl p=[i=[%leaf p=%ud q=1] t=~[[%leaf p=%ud q=2]]]]
+```
+
+---
+
+## `+$tent`
+
+Model builder
+
+#### Source
+
+```hoon
++$  tent
+          $%  [%| p=wing q=tent r=(list spec)]    ::  ~(p q r...)
+              [%& p=(list wing)]                  ::  a.b:c.d
+          ==                                      ::
+```
+
+---
+
+## `+$tiki`
+
+Test case
+
+This is used when compiling `?-` expressions and similar.
+
+#### Source
+
+```hoon
++$  tiki                                                ::  test case
+          $%  [%& p=(unit term) q=wing]                 ::  simple wing
+              [%| p=(unit term) q=hoon]                 ::  named wing
+          ==                                            ::
+```
+
+---
+
+## `+$skin`
+
+Texture
+
+This type is used for faces and similar by the compiler.
+
+#### Source
+
+```hoon
++$  skin                             ::  texture
+          $@  =term                  ::  name/~[term %none]
+          $%  [%base =base]          ::  base match
+              [%cell =skin =skin]    ::  pair
+              [%dbug =spot =skin]    ::  trace
+              [%leaf =aura =atom]    ::  atomic constant
+              [%help =help =skin]    ::  describe
+              [%name =term =skin]    ::  apply label
+              [%over =wing =skin]    ::  relative to
+              [%spec =spec =skin]    ::  cast to
+              [%wash depth=@ud]      ::  strip faces
+          ==                         ::
+```
+
+---
+
+## `+$tome`
+
+Core chapter
+
+This type is used by the compiler for the contents of arms in cores.
+
+#### Source
+
+```hoon
++$  tome  (pair what (map term hoon))
+```
+
+---
+
+## `+$tope`
+
+Topographic type
+
+Describes the structure of a noun.
+
+#### Source
+
+```hoon
++$  tope              ::  topographic type
+  $@  $?  %&          ::  cell or atom
+          %|          ::  atom
+      ==              ::
+  (pair tope tope)    ::  cell
+```
+
+#### Examples
+
+```
+> *tope
+%.n
+
+> `tope`[%| %&]
+[p=%.n q=%.y]
+```
+
+---
+
+## `++hoot`
+
+Hoon tools
+
+Container core for internally-used XML structure types. XML structure types
+you'd typically use directly are defined in [Standard Library section
+5e](/docs/hoon/reference/stdlib/5e).
+
+#### Source
+
+```hoon
+++  hoot
+  |%
+```
+
+---
+
+### `+$beer:hoot`
+
+Simple embed
+
+Either a tape element or interpolated hoon expression in an XML attribute.
+
+#### Source
+
+```hoon
++$  beer  $@(char [~ p=hoon])
+```
+
+---
+
+### `+$mane:hoot`
+
+XML name+space
+
+XML tag name and optional namespace.
+
+#### Source
+
+```hoon
++$  mane  $@(@tas [@tas @tas])
+```
+
+#### Examples
+
+```
+> (en-xml:html ;foo;)
+"<foo></foo>"
+
+> (en-xml:html ;foo_bar;)
+"<foo:bar></foo:bar>"
+
+> `manx:hoot`;foo_bar;
+[g=[n=[%foo %bar] a=~] c=~]
+
+> `mane:hoot`n.g:`manx`;foo_bar;
+[%foo %bar]
+
+> `mane:hoot`n.g:`manx:hoot`;foo;
+%foo
+```
+
+---
+
+### `+$manx:hoot`
+
+Dynamic XML node
+
+An XML element which may contain text, attributes, and other elements.
+
+`g` is a [`$marx:hoot`](#marxhoot) (a tag) and `c` is a
+[`$marl:hoot`](#marlhoot) (its contents).
+
+#### Source
+
+```hoon
++$  manx  $~([[%$ ~] ~] [g=marx c=marl])
+```
+
+#### Examples
+
+```
+> *manx:hoot
+[g=[n=%$ a=~] c=~
+
+> `manx:hoot`;foo;
+[g=[n=%foo a=~] c=~]
+
+> (en-xml:html `manx:hoot`;foo;)
+"<foo></foo>"
+
+> =a ^-  manx:hoot
+     ;foo
+       ;bar: abc
+       ;baz
+         ;xxx: hello
+       ==
+     ==
+
+> a
+[ g=[n=%foo a=~]
+    c
+  ~[
+    [ g=[n=%bar a=~]
+      c=~[[g=[n=%$ a=~[[n=%$ v="abc"]]] c=~]]
     ]
-    > &3:(ream '$%([1 a] [%2 b])')
-    p=[p=[%leaf p=%ud q=1] q=[%herb p=[%cnzz p=~[%a]]]]
-    > (line &3:(ream '$%([1 a] [%2 b])'))
-    [p=[%leaf p=~.ud q=1] q=[%herb p=[%cnzz p=~[%a]]]]
-```
-
----
-
-## `++metl`
-
-```hoon
-    ++  metl  ?(%gold %iron %zinc %lead)                    ::  core variance
-```
-
-XX move to `++ut`
-
-See also: `++coil`
-
----
-
-## `++nock`
-
-Virtual machine. See Nock.
-
-#### Source
-
-```hoon
-        ++  nock  $&  [p=nock q=nock]                           ::  autocons
-                  [%3 p=nock]                               ::  cell test
-                  [%4 p=nock]                               ::  increment
-                  [%5 p=nock q=nock]                        ::  equality test
-                  [%6 p=nock q=nock r=nock]                 ::  if, then, else
-                  [%7 p=nock q=nock]                        ::  serial compose
-                  [%8 p=nock q=nock]                        ::  push onto subject
-                  [%9 p=@ q=nock]                           ::  select arm and fire
-                  [%10 p=?(@ [p=@ q=nock]) q=nock]          ::  hint
-                  [%11 p=nock]                              ::  grab data from sky
-              ==                                            ::
-```
-
-#### Examples
-
-```
-    > !=([+(.) 20 -<])
-    [[4 0 1] [1 20] 0 4]
-    > (nock !=([+(.) 20]))
-    [p=[%4 p=[%0 p=1]] q=[%1 p=20]]
-```
-
----
-
-## `++null`
-
-```hoon
-    ++  null  ,~                                            ::  null, nil, etc
-```
-
-Used nowhere XX
-
-```
-    > :type; *null
-    ~
-    %~
-```
-
----
-
-## `++port`
-
-XX move to `++ut`
-
-Type and location of core-shaped thing? XX Compiler Internals
-
-#### Source
-
-```hoon
-    ++  port  $:  p=axis                                    ::
-                  $=  q                                     ::
-                  $%  [%& p=type]                           ::
-                      [%| p=axis q=(list ,[p=type q=foot])] ::
-                  ==                                        ::
-              ==                                            ::
-```
-
-#### Examples
-
-```
-    > *port
-    [p=0 q=[%.y p=%void]]
-```
-
----
-
-## `++span`
-
-ASCII atom
-
-A restricted text atom for canonical atom syntaxes. The prefix is `~.`.
-There are no escape sequences except `~~`, which means `~`, and `~-`,
-which means `_`. `-` and `.` encode themselves. No other characters
-besides numbers and lowercase letters are permitted.
-
-#### Source
-
-```hoon
-        ++  span  ,@ta                                     ::  text-atom (ASCII)
-```
-
-#### Examples
-
-```
-    > *span
-    ~.
-
-    > `@t`~.foo
-    'foo'
-    > `@t`~.foo.bar
-    'foo.bar'
-    > `@t`~.foo~~bar
-    'foo~bar'
-    > `@t`~.foo~-bar
-    'foo_bar'
-    > `@t`~.foo-bar
-    'foo-bar'
-```
-
----
-
-## `++tiki`
-
-XX move to `++ut`
-
-#### Source
-
-```hoon
-        ++  tiki                                                ::  test case
-```
-
-#### Examples
-
-```
-A `++wing` or `++hoon`.
-
-    > (ream '=+  a=4  ?-(a @ ~)')
-    [ %tsls
-      p=[%ktts p=p=%a q=[%dtzy p=%ud q=4]]
-        q
-      [ %wthz
-        p=[%.y p=~ q=~[%a]]
-        q=~[[p=[%axil p=[%atom p=~.]] q=[%bczp p=%null]]]
-      ]
-    ]
-    > (ream '=+  a=4  ?-(4 @ ~)')
-    [ %tsls
-      p=[%ktts p=p=%a q=[%dtzy p=%ud q=4]]
-        q
-      [ %wthz
-        p=[%.n p=~ q=[%dtzy p=%ud q=4]]
-        q=~[[p=[%axil p=[%atom p=~.]] q=[%bczp p=%null]]]
-      ]
-    ]
-```
-
----
-
-## `++toga`
-
-Tree of faces
-
-A face, or tree of faces. A `++toga` is applied to anything assigned
-using `^=`.
-
-XX move to `++ut` and rune doc (for \^= examples)
-
-#### Source
-
-```hoon
-        ++  toga                                                ::  face control
-                  [2 p=toga q=toga]                         ::  cell toga
-              ==                                            ::
-```
-
-#### Examples
-
-```
-    > a=1
-    a=1
-    > (ream 'a=1')
-    [%ktts p=p=%a q=[%dtzy p=%ud q=1]]
-    > [a b]=[1 2 3]
-    [a=1 b=[2 3]]
-    > (ream '[a b]=[1 2 3]')
-    [ %ktts
-      p=[%2 p=p=%a q=p=%b]
-      q=[%cltr p=~[[%dtzy p=%ud q=1] [%dtzy p=%ud q=2] [%dtzy p=%ud q=3]]]
-    ]
-
-    > [a ~]=[1 2 3]
-    [a=1 2 3]
-    > (ream '[a ~]=[1 2 3]')
-    [ %ktts
-      p=[%2 p=p=%a q=[%0 ~]]
-      q=[%cltr p=~[[%dtzy p=%ud q=1] [%dtzy p=%ud q=2] [%dtzy p=%ud q=3]]]
-    ]
-```
-
----
-
-## `++tone`
-
-Intermediate Nock computation result
-
-Similar to `++toon`, but stack trace is not yet rendered.
-
-#### Source
-
-```hoon
-        ++  tone  $%  [%0 p=*]                                  ::  success
-```
-
-#### Examples
-
-```
-    > (mink [[20 21] 0 3] ,~)
-    [%0 p=21]
-
-    > (mink [[0] !=(.^(cy//=main/1))] ,~)
-    [%1 p=~[[31.075 1.685.027.454 1.852.399.981 49 0]]]
-    > (path [31.075 1.685.027.454 1.852.399.981 49 0])
-    /cy/~zod/main/1
-
-    > (mink [[1 2] !=(~|(%hi +(.)))] ,~)
-    [%2 p=~[[~.yelp 26.984]]]
-    > (mink [[1 2] !=(!:(+(.)))] ,~)
-    [ %2
-        p
+    [ g=[n=%baz a=~]
+        c
       ~[
-        [ ~.spot
-          [ [ 1.685.027.454
-              7.959.156
-              \/159.445.990.350.374.058.574.398.238.344.143.957.205.628.479.572.65\/
-                8.112.403.878.526
-              \/                                                                  \/
-              0
-            ]
-            [1 20]
-            1
-            24
-          ]
+        [ g=[n=%xxx a=~]
+          c=~[[g=[n=%$ a=~[[n=%$ v="hello"]]] c=~]]
         ]
       ]
     ]
+  ]
+]
+
+> (en-xml:html a)
+"<foo><bar>abc</bar><baz><xxx>hello</xxx></baz></foo>"
 ```
 
 ---
 
-## `++tuna`
+### `+$marl:hoot`
 
-XML template tree
+Dynamic XML nodes
 
-An XML template tree.
-
-#### Source
-
-```hoon
-        ++  tuna                                                ::  tagflow
-                  [%d p=hoon]                               ::  dynamic list
-                  [%e p=hoon q=(list tuna)]                 ::  element
-                  [%f p=(list tuna)]                        ::  subflow
-              ==                                            ::
-```
-
-#### Examples
-
-Leaf %a contains plain-text, %b an empty tag, %c a static list, %d a
-dynamic list, %e a full node element containing a hoon and a list of
-tuna, and %f is a empty node.
-
-See also: `++sail`
-
----
-
-## `++tusk`
-
-List of expressions
-
-List of `++hoon`s. In `:*`, for example, your contents is
-a `++tusk`.
+A list of XML nodes - maybe with interpolation and recursion. See
+[`$tuna:hoot`](#tunahoot).
 
 #### Source
 
 ```hoon
-        ++  tusk  (list hoon)                                   ::
++$  marl  (list tuna)
 ```
 
 #### Examples
 
 ```
-    > (ream '[1 2 3]')
-    [%cltr p=~[[%dtzy p=%ud q=1] [%dtzy p=%ud q=2] [%dtzy p=%ud q=3]]]
-    > (tusk +:(ream '[1 2 3]'))
-    ~[[%dtzy p=%ud q=1] [%dtzy p=%ud q=2] [%dtzy p=%ud q=3]]
+> *marl
+~
+
+> ^-  marl:hoot
+  ;=
+    ;foo: abc
+    ;bar: def
+  ==
+~[
+  [g=[n=%foo a=~] c=~[[g=[n=%$ a=~[[n=%$ v=~['a' 'b' 'c']]]] c=~]]]
+  [g=[n=%bar a=~] c=~[[g=[n=%$ a=~[[n=%$ v=~['d' 'e' 'f']]]] c=~]]]
+]
+
+> %-  en-xml:html
+  ;baz
+    ;=
+      ;foo: abc
+      ;bar: def
+    ==
+  ==
+"<baz><foo>abc</foo><bar>def</bar></baz>"
 ```
 
 ---
 
-## `++hoon`
+### `+$mart:hoot`
 
-Expression
+Dynamic XML attributes
 
-An expression, or AST.
-
-See Rune section of Hoon reference
-
----
-
-## `++tyke`
-
-List of 'maybe' hoons
-
-List of `++unit` `++hoon`, or gaps left to be inferred, in `++path`
-parsing. When you use a path such as `/=main=/pub/src/doc` the path is in fact
-a `++tyke`, where the `=` are inferred from your current path.
+A list of atributes for an XML tag. For each list item, `n` is a
+[`$mane:hoot`](#manehoot) (an attribute name with optional namespace) and `v` is
+a `(list beer:hoot)` (the attribute itself, maybe with interpolated hoon).
 
 #### Source
 
 ```hoon
-        ++  tyke  (list (unit hoon))                            ::
++$  mart  (list [n=mane v=(list beer)])
 ```
 
 #### Examples
 
 ```
-    > (scan "/==as=" porc:vast)
-    [0 ~[~ ~ [~ [%dtzy p=%tas q=29.537]] ~]]
-    > `tyke`+:(scan "/==as=" porc:vast)
-    ~[~ ~ [~ [%dtzy p=%tas q=29.537]] ~]
+> *mart:hoot
+~
+
+> `manx:hoot`;foo.bar;
+[g=[n=%foo a=~[[n=%class v=~['b' 'a' 'r']]]] c=~]
+
+> `mart:hoot`a.g:`manx:hoot`;foo.bar;
+~[[n=%class v=~['b' 'a' 'r']]]
+
+> (en-xml:html ;foo.bar;)
+"<foo class=\"bar\"></foo>"
 ```
 
 ---
 
-## `++typo`
+### `+$marx:hoot`
 
-Pointer for `++type`
+Dynamic XML tag
 
-Pointer for `++type`. `++typo` preserves the previous `++type` in your
-context when upating.
+An XML tag with optional attributes. `n` is a [`$mane:hoot`](#manehoot) (the tag
+name with optional namespace) and `a` is a [`$mart:hoot`](marthoot) (any XML
+attributes).
 
 #### Source
 
 ```hoon
-        ++  typo  type                                          ::  old type
++$  marx  $~([%$ ~] [n=mane a=mart])
 ```
 
 #### Examples
 
-See also: `++seem`, `++vise`, `++type`
+```
+> `manx:hoot`;foo.bar;
+[g=[n=%foo a=~[[n=%class v=~['b' 'a' 'r']]]] c=~]
+
+> `marx:hoot`g:`manx:hoot`;foo.bar;
+[n=%foo a=~[[n=%class v=~['b' 'a' 'r']]]]
+
+> (en-xml:html ;foo.bar;)
+"<foo class=\"bar\"></foo>"
+```
 
 ---
 
-## `++tyre`
+### `+$mare:hoot`
+
+Node or nodes
+
+If `%.y`, a [`$manx:hoot`](#manxhoot) (single XML node). If `%.n`, a
+[`$marl:hoot`](#marlhoot) (list of XML nodes).
+
+#### Source
+
+```hoon
++$  mare  (each manx marl)
+```
+
+#### Examples
+
+```
+> *mare:hoot
+[%.y p=[g=[n=%$ a=~] c=~]]
+
+> `mare:hoot`[%.y ;foo.bar;]
+[%.y p=[g=[n=%foo a=~[[n=%class v=~['b' 'a' 'r']]]] c=~]]
+
+> `mare:hoot`[%.n ~[;foo.bar; ;baz;]]
+[%.n p=~[[g=[n=%foo a=~[[n=%class v=~['b' 'a' 'r']]]] c=~] [g=[n=%baz a=~] c=~]]]
+```
+
+---
+
+### `+$maru:hoot`
+
+Interpolation or nodes
+
+If `%.y`, a [`$tuna:hoot`](#tunahoot). If `%.n`, a [`$marl:hoot`](#marlhoot).
+
+#### Source
+
+```hoon
++$  maru  (each tuna marl)
+```
+
+---
+
+### `+$tuna:hoot`
+
+Maybe interpolation
+
+Kinds of nodes. Either an ordinary [`$manx:hoot`](#manxhoot), or else a plain tape, a
+[`$marl:hoot`](#marlhoot), or a function call.
+
+#### Source
+
+```hoon
++$  tuna
+    $~  [[%$ ~] ~]
+    $^  manx
+    $:  ?(%tape %manx %marl %call)
+        p=hoon
+    ==
+```
+
+---
+
+## `+$hoon`
+
+Hoon AST
+
+See the [Rune section](/docs/hoon/reference/rune) of the Hoon reference for
+details of what many of these relate to.
+
+#### Source
+
+```hoon
++$  hoon                                                ::
+  $~  [%zpzp ~]
+  $^  [p=hoon q=hoon]                                   ::
+  $%                                                    ::
+    [%$ p=axis]                                         ::  simple leg
+  ::                                                    ::
+    [%base p=base]                                      ::  base spec
+    [%bust p=base]                                      ::  bunt base
+    [%dbug p=spot q=hoon]                               ::  debug info in trace
+    [%eror p=tape]                                      ::  assembly error
+    [%hand p=type q=nock]                               ::  premade result
+    [%note p=note q=hoon]                               ::  annotate
+    [%fits p=hoon q=wing]                               ::  underlying ?=
+    [%knit p=(list woof)]                               ::  assemble string
+    [%leaf p=(pair term @)]                             ::  symbol spec
+    [%limb p=term]                                      ::  take limb
+    [%lost p=hoon]                                      ::  not to be taken
+    [%rock p=term q=*]                                  ::  fixed constant
+    [%sand p=term q=*]                                  ::  unfixed constant
+    [%tell p=(list hoon)]                               ::  render as tape
+    [%tune p=$@(term tune)]                             ::  minimal face
+    [%wing p=wing]                                      ::  take wing
+    [%yell p=(list hoon)]                               ::  render as tank
+    [%xray p=manx:hoot]                                 ::  ;foo; templating
+  ::                                            ::::::  cores
+    [%brbc sample=(lest term) body=spec]                ::  |$
+    [%brcb p=spec q=alas r=(map term tome)]             ::  |_
+    [%brcl p=hoon q=hoon]                               ::  |:
+    [%brcn p=(unit term) q=(map term tome)]             ::  |%
+    [%brdt p=hoon]                                      ::  |.
+    [%brkt p=hoon q=(map term tome)]                    ::  |^
+    [%brhp p=hoon]                                      ::  |-
+    [%brsg p=spec q=hoon]                               ::  |~
+    [%brtr p=spec q=hoon]                               ::  |*
+    [%brts p=spec q=hoon]                               ::  |=
+    [%brpt p=(unit term) q=(map term tome)]             ::  |@
+    [%brwt p=hoon]                                      ::  |?
+  ::                                            ::::::  tuples
+    [%clcb p=hoon q=hoon]                               ::  :_ [q p]
+    [%clkt p=hoon q=hoon r=hoon s=hoon]                 ::  :^ [p q r s]
+    [%clhp p=hoon q=hoon]                               ::  :- [p q]
+    [%clls p=hoon q=hoon r=hoon]                        ::  :+ [p q r]
+    [%clsg p=(list hoon)]                               ::  :~ [p ~]
+    [%cltr p=(list hoon)]                               ::  :* p as a tuple
+  ::                                            ::::::  invocations
+    [%cncb p=wing q=(list (pair wing hoon))]            ::  %_
+    [%cndt p=hoon q=hoon]                               ::  %.
+    [%cnhp p=hoon q=hoon]                               ::  %-
+    [%cncl p=hoon q=(list hoon)]                        ::  %:
+    [%cntr p=wing q=hoon r=(list (pair wing hoon))]     ::  %*
+    [%cnkt p=hoon q=hoon r=hoon s=hoon]                 ::  %^
+    [%cnls p=hoon q=hoon r=hoon]                        ::  %+
+    [%cnsg p=wing q=hoon r=(list hoon)]                 ::  %~
+    [%cnts p=wing q=(list (pair wing hoon))]            ::  %=
+  ::                                            ::::::  nock
+    [%dtkt p=spec q=hoon]                               ::  .^  nock 11
+    [%dtls p=hoon]                                      ::  .+  nock 4
+    [%dttr p=hoon q=hoon]                               ::  .*  nock 2
+    [%dtts p=hoon q=hoon]                               ::  .=  nock 5
+    [%dtwt p=hoon]                                      ::  .?  nock 3
+  ::                                            ::::::  type conversion
+    [%ktbr p=hoon]                                      ::  ^|  contravariant
+    [%ktdt p=hoon q=hoon]                               ::  ^.  self-cast
+    [%ktls p=hoon q=hoon]                               ::  ^+  expression cast
+    [%kthp p=spec q=hoon]                               ::  ^-  structure cast
+    [%ktpm p=hoon]                                      ::  ^&  covariant
+    [%ktsg p=hoon]                                      ::  ^~  constant
+    [%ktts p=skin q=hoon]                               ::  ^=  label
+    [%ktwt p=hoon]                                      ::  ^?  bivariant
+    [%kttr p=spec]                                      ::  ^*  example
+    [%ktcl p=spec]                                      ::  ^:  filter
+  ::                                            ::::::  hints
+    [%sgbr p=hoon q=hoon]                               ::  ~|  sell on trace
+    [%sgcb p=hoon q=hoon]                               ::  ~_  tank on trace
+    [%sgcn p=chum q=hoon r=tyre s=hoon]                 ::  ~%  general jet hint
+    [%sgfs p=chum q=hoon]                               ::  ~/  function j-hint
+    [%sggl p=$@(term [p=term q=hoon]) q=hoon]           ::  ~<  backward hint
+    [%sggr p=$@(term [p=term q=hoon]) q=hoon]           ::  ~>  forward hint
+    [%sgbc p=term q=hoon]                               ::  ~$  profiler hit
+    [%sgls p=@ q=hoon]                                  ::  ~+  cache=memoize
+    [%sgpm p=@ud q=hoon r=hoon]                         ::  ~&  printf=priority
+    [%sgts p=hoon q=hoon]                               ::  ~=  don't duplicate
+    [%sgwt p=@ud q=hoon r=hoon s=hoon]                  ::  ~?  tested printf
+    [%sgzp p=hoon q=hoon]                               ::  ~!  type on trace
+  ::                                            ::::::  miscellaneous
+    [%mcts p=marl:hoot]                                 ::  ;=  list templating
+    [%mccl p=hoon q=(list hoon)]                        ::  ;:  binary to nary
+    [%mcfs p=hoon]                                      ::  ;/  [%$ [%$ p ~] ~]
+    [%mcgl p=spec q=hoon r=hoon s=hoon]                 ::  ;<  bind
+    [%mcsg p=hoon q=(list hoon)]                        ::  ;~  kleisli arrow
+    [%mcmc p=spec q=hoon]                               ::  ;;  normalize
+  ::                                            ::::::  compositions
+    [%tsbr p=spec q=hoon]                               ::  =|  push bunt
+    [%tscl p=(list (pair wing hoon)) q=hoon]            ::  =:  q w= p changes
+    [%tsfs p=skin q=hoon r=hoon]                        ::  =/  typed variable
+    [%tsmc p=skin q=hoon r=hoon]                        ::  =;  =/(q p r)
+    [%tsdt p=wing q=hoon r=hoon]                        ::  =.  r with p as q
+    [%tswt p=wing q=hoon r=hoon s=hoon]                 ::  =?  conditional =.
+    [%tsgl p=hoon q=hoon]                               ::  =<  =>(q p)
+    [%tshp p=hoon q=hoon]                               ::  =-  =+(q p)
+    [%tsgr p=hoon q=hoon]                               ::  =>  q w=subject p
+    [%tskt p=skin q=wing r=hoon s=hoon]                 ::  =^  state machine
+    [%tsls p=hoon q=hoon]                               ::  =+  q w=[p subject]
+    [%tssg p=(list hoon)]                               ::  =~  hoon stack
+    [%tstr p=(pair term (unit spec)) q=hoon r=hoon]     ::  =*  new style
+    [%tscm p=hoon q=hoon]                               ::  =,  overload p in q
+  ::                                            ::::::  conditionals
+    [%wtbr p=(list hoon)]                               ::  ?|  loobean or
+    [%wthp p=wing q=(list (pair spec hoon))]            ::  ?-  pick case in q
+    [%wtcl p=hoon q=hoon r=hoon]                        ::  ?:  if=then=else
+    [%wtdt p=hoon q=hoon r=hoon]                        ::  ?.  ?:(p r q)
+    [%wtkt p=wing q=hoon r=hoon]                        ::  ?^  if p is a cell
+    [%wtgl p=hoon q=hoon]                               ::  ?<  ?:(p !! q)
+    [%wtgr p=hoon q=hoon]                               ::  ?>  ?:(p q !!)
+    [%wtls p=wing q=hoon r=(list (pair spec hoon))]     ::  ?+  ?-  w=default
+    [%wtpm p=(list hoon)]                               ::  ?&  loobean and
+    [%wtpt p=wing q=hoon r=hoon]                        ::  ?@  if p is atom
+    [%wtsg p=wing q=hoon r=hoon]                        ::  ?~  if p is null
+    [%wthx p=skin q=wing]                               ::  ?#  if q matches p
+    [%wtts p=spec q=wing]                               ::  ?=  if q matches p
+    [%wtzp p=hoon]                                      ::  ?!  loobean not
+  ::                                            ::::::  special
+    [%zpcm p=hoon q=hoon]                               ::  !,
+    [%zpgr p=hoon]                                      ::  !>
+    [%zpgl p=spec q=hoon]                               ::  !<
+    [%zpmc p=hoon q=hoon]                               ::  !;
+    [%zpts p=hoon]                                      ::  !=
+    [%zppt p=(list wing) q=hoon r=hoon]                 ::  !@
+    [%zpwt p=$@(p=@ [p=@ q=@]) q=hoon]                  ::  !?
+    [%zpzp ~]                                           ::  !!
+  ==                                                    ::
+```
+
+#### Examples
+
+```
+> *hoon
+[%zpzp ~]
+
+> `hoon`(ream '|=([a=@ b=@] [b a])')
+[ %brts
+    p
+  [ %bccl
+      p
+    [ i=[%bcts p=term=%a q=[%base p=[%atom p=~.]]]
+      t=~[[%bcts p=term=%b q=[%base p=[%atom p=~.]]]]
+    ]
+  ]
+  q=[%cltr p=~[[%wing p=~[%b]] [%wing p=~[%a]]]]
+]
+```
+
+---
+
+## `+$tyre`
 
 List, term hoon
 
-Associative list of `++term` `++hoon`, used in jet hint processing.
+Associative list of `term` `hoon`, used in jet hint processing.
 
 #### Source
 
 ```hoon
-        ++  tyre  (list ,[p=term q=hoon])                       ::
++$  tyre  (list [p=term q=hoon])                        ::
 ```
 
 ---
 
-## `++vase`
+## `+$tyke`
 
-Typed data. A `++vase` is used wherever typed data is explicitly worked
-with.
+List of 'maybe' hoons
+
+List of `unit` `hoon`, or gaps left to be inferred, in `path` parsing. When you
+use a path such as `/=base=/gen/code` the path is in fact a `tyke`, where the
+`=` are inferred from your current path.
 
 #### Source
 
 ```hoon
-        ++  vase  ,[p=type q=*]                                 ::  type-value pair
++$  tyke  (list (unit hoon))
+```
+
+---
+
+## `+$nock`
+
+Virtual nock.
+
+See the [Nock documentation](/docs/nock/definition) for details.
+
+#### Source
+
+```hoon
++$  nock  $^  [p=nock q=nock]                      ::  autocons
+          $%  [%1 p=*]                             ::  constant
+              [%2 p=nock q=nock]                   ::  compose
+              [%3 p=nock]                          ::  cell test
+              [%4 p=nock]                          ::  increment
+              [%5 p=nock q=nock]                   ::  equality test
+              [%6 p=nock q=nock r=nock]            ::  if, then, else
+              [%7 p=nock q=nock]                   ::  serial compose
+              [%8 p=nock q=nock]                   ::  push onto subject
+              [%9 p=@ q=nock]                      ::  select arm and fire
+              [%10 p=[p=@ q=nock] q=nock]          ::  edit
+              [%11 p=$@(@ [p=@ q=nock]) q=nock]    ::  hint
+              [%12 p=nock q=nock]                  ::  grab data from sky
+              [%0 p=@]                             ::  axis select
+          ==                                       ::
 ```
 
 #### Examples
 
 ```
-    > `vase`!>(~)
-    [p=[%cube p=0 q=[%atom p=%n]] q=0]
+> !=([+(.) 20 -<])
+[[4 0 1] [1 20] 0 4]
+
+> (nock !=([+(.) 20]))
+[p=[%4 p=[%0 p=1]] q=[%1 p=20]]
 ```
 
 ---
 
-## `++vise`
+## `+$note`
 
-Convert during reboot
+Type annotation
 
-Used to convert from previously-typed data during reboot.
+Used for documentation.
 
 #### Source
 
 ```hoon
-    ++  vise  ,[p=typo q=*]                                 ::  old vase
++$  note                                             ::  type annotation
+          $%  [%help p=help]                         ::  documentation
+              [%know p=stud]                         ::  global standard
+              [%made p=term q=(unit (list wing))]    ::  structure
+          ==                                         ::
+```
+
+---
+
+## `+$type`
+
+Hoon type type
+
+#### Source
+
+```hoon
++$  type  $~  %noun                                ::
+          $@  $?  %noun                            ::  any nouns
+                  %void                            ::  no noun
+              ==                                   ::
+          $%  [%atom p=term q=(unit @)]            ::  atom / constant
+              [%cell p=type q=type]                ::  ordered pair
+              [%core p=type q=coil]                ::  object
+              [%face p=$@(term tune) q=type]       ::  namespace
+              [%fork p=(set type)]                 ::  union
+              [%hint p=(pair type note) q=type]    ::  annotation
+              [%hold p=type q=hoon]                ::  lazy evaluation
+          ==                                       ::
 ```
 
 #### Examples
 
-See also: `++typo`, `++seer`
+```
+> `type`[%cell [%atom %ud ~] [%atom %ud ~]]
+#t/[@ud @ud]
+```
 
 ---
 
-## `++wing`
+## `+$tony`
+
+`$tone` done right
+
+An intermediate Nock computation result. Similar to a
+[`$toon`](/docs/hoon/reference/stdlib/3g#toon) but without a rendered stack
+trace.
+
+#### Source
 
 ```hoon
-    ++  wing  (list limb)                                   ::
++$  tony                               ::  ++tone done right
+          $%  [%0 p=tine q=*]          ::  success
+              [%1 p=(set)]             ::  blocks
+              [%2 p=(list [@ta *])]    ::  error ~_s
+          ==                           ::
 ```
 
-Address in subject. A `++wing` is a path to a value in the subject. A
-term alone is the trivial case of a `++wing`.
+---
 
-See also: `++hoon`
+## `+$tine`
+
+Partial noun
+
+#### Source
+
+```hoon
++$  tine                            ::  partial noun
+          $@  ~                     ::  open
+          $%  [%& p=tine q=tine]    ::  half-blocked
+              [%| p=(set)]          ::  fully blocked
+          ==                        ::
+```
+
+---
+
+## `+$tool`
+
+Type decoration
+
+#### Source
+
+```hoon
++$  tool  $@(term tune)
+```
+
+---
+
+## `+$tune`
+
+Complex
+
+#### Source
+
+```hoon
++$  tune                                  ::  complex
+          $~  [~ ~]                       ::
+          $:  p=(map term (unit hoon))    ::  aliases
+              q=(list hoon)               ::  bridges
+          ==                              ::
+```
+
+---
+
+## `+$typo`
+
+Old type
+
+Same as `$type`
+
+#### Source
+
+```hoon
++$  typo  type
+```
+
+---
+
+## `+$vase`
+
+Type-value pair
+
+Typed data. A `$vase` is used wherever typed data is explicitly worked with.
+
+#### Source
+
+```hoon
++$  vase  [p=type q=*]
+```
+
+#### Examples
 
 ```
-    > (ream 'a.+.c')
-    [%cnzz p=~[%a [%.y p=3] %c]]
-    > (wing +:(ream 'a.+.c'))
-    ~[%a [%.y p=3] %c]
+> *vase
+[#t/* q=0]
+
+> !>([2 2])
+[#t/[@ud @ud] q=[2 2]]
+
+> !>('foo')
+[#t/@t q=7.303.014]
+```
+
+---
+
+## `+$vise`
+
+Old vase
+
+Same as a [`$vase`](#vase).
+
+#### Source
+
+```hoon
++$  vise  [p=typo q=*]
+```
+
+---
+
+## `+$vial`
+
+co/contra/in/bi
+
+Covariant, contravariant, invariant, bivariant.
+
+#### Source
+
+```hoon
++$  vial  ?(%read %rite %both %free)
+```
+
+---
+
+## `+$vair`
+
+in/contra/bi/co
+
+Core variance.
+
+- `%gold` - invariant payload.
+- `%iron` - contravariant sample.
+- `%lead` - bivariant sample.
+- `%zinc` - covariant sample.
+
+See the Hoon School lesson on [type
+polymorphism](/docs/hoon/hoon-school/type-polymorphism) for more details.
+
+#### Source
+
+```hoon
++$  vair  ?(%gold %iron %lead %zinc)
+```
+
+---
+
+## `+$vein`
+
+Search trace
+
+Noun search trace.
+
+#### Source
+
+```hoon
++$  vein  (list (unit axis))
+```
+
+---
+
+## `+$sect`
+
+Paragraph
+
+Used in documentation.
+
+#### Source
+
+```hoon
++$  sect  (list pica)
+```
+
+---
+
+## `+$whit`
+
+Documentation
+
+#### Source
+
+```hoon
++$  whit                                                ::
+          $:  lab=(unit term)                           ::  label
+              boy=(unit (pair cord (list sect)))        ::  body
+              def=(map term (pair cord (list sect)))    ::  definitions
+              use=(set term)                            ::  defs used
+          ==                                            ::
+```
+
+---
+
+## `+$what`
+
+Help slogan/section
+
+#### Source
+
+```hoon
++$  what  (unit (pair cord (list sect)))
+```
+
+---
+
+## `+$wing`
+
+Search path
+
+Address in subject. A `$wing` is a path to a value in the subject. A
+term alone is the trivial case of a `$wing`.
+
+#### Source
+
+```hoon
++$  wing  (list limb)
+```
+
+#### Examples
+
+```
+> (ream 'a.+.c')
+[%wing p=~[%a [%.y p=3] %c]]
+
+> (wing +:(ream 'a.+.c'))
+~[%a [%.y p=3] %c]
+```
+
+---
+
+## `+$block`
+
+Abstract identity of resource awaited
+
+#### Source
+
+```hoon
++$  block
+  path
+```
+
+---
+
+## `+$result`
+
+Internal interpreter result
+
+#### Source
+
+```hoon
++$  result
+  $@(~ seminoun)
+```
+
+---
+
+## `+$thunk`
+
+Fragment constructor
+
+#### Source
+
+```hoon
++$  thunk
+  $-(@ud (unit noun))
+```
+
+---
+
+## `+$doss`
+
+Profiling
+
+#### Source
+
+```hoon
++$  doss
+  $:  mon=moan               ::  sample count
+      hit=(map term @ud)     ::  hit points
+      cut=(map path hump)    ::  cut points
+  ==
+```
+
+---
+
+## `+$moan`
+
+Profiling: sample metric
+
+#### Source
+
+```hoon
++$  moan         ::  sample metric
+  $:  fun=@ud    ::  samples in C
+      noc=@ud    ::  samples in nock
+      glu=@ud    ::  samples in glue
+      mal=@ud    ::  samples in alloc
+      far=@ud    ::  samples in frag
+      coy=@ud    ::  samples in copy
+      euq=@ud    ::  samples in equal
+  ==             ::
+```
+
+---
+
+## `+$hump`
+
+Profiling
+
+#### Source
+
+```hoon
++$  hump
+  $:  mon=moan              ::  sample count
+      out=(map path @ud)    ::  calls out of
+      inn=(map path @ud)    ::  calls into
+  ==
 ```
 
 ---

--- a/content/docs/hoon/reference/stdlib/table-of-contents.md
+++ b/content/docs/hoon/reference/stdlib/table-of-contents.md
@@ -16,7 +16,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ab' title="Primitive parser engine"><code>++ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#absfl' title="Absolute value"><code>++abs:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#abssi' title="Absolute value (signed integer)"><code>++abs:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#abel' title="Compiler alias"><code>++abel</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#abel' title="Original sin: type"><code>+$abel</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#ace' title="Parse space"><code>++ace</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#a-coco' title="Render decimal"><code>++a-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#add' title="Add"><code>++add</code></a>
@@ -29,6 +29,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addrq' title="Add (quadprecision float)"><code>++add:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#aftr' title="Pair after"><code>++aftr</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ag' title="Toplevel atom parser engine"><code>++ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#alas' title="Alias list"><code>+$alas</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#alf' title="Parse alphabetic characters"><code>++alf</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#allby' title="Logical AND (map and wet gate)"><code>++all:by</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#allin' title="Logical AND (set and wet gate)"><code>++all:in</code></a>
@@ -42,7 +43,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#aptin' title="Check correctness (set)"><code>++apt:in</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#aptto' title="Check correctness of queue"><code>++apt:to</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#at' title="Basic printing"><code>++at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#aura' title="'Type' of atom"><code>++aura</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#atom' title="Just an atom"><code>+$atom</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#aura' title="'Type' of atom"><code>+$aura</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#axis' title="Tree address"><code>+$axis</code></a>
 
 ### b
@@ -51,12 +53,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#balto' title="Balance queue"><code>++bal:to</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#bar' title="Parse | (bar)"><code>++bar</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#bas' title="Parse \ (bas)"><code>++bas</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#base' title="Base type"><code>++base</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#base' title="Base type"><code>+$base</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#bass' title="Parser modifier (LSBordered ++list as atom of ++base)"><code>++bass</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bayag' title="Parses binary number"><code>++bay:ag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#bean' title="Boolean"><code>+$bean</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#beer' title="Tape builder"><code>++beer</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#beet' title="XML interpolation cases"><code>++beet</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#beerhoot' title="Simple embed"><code>+$beer:hoot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#bend' title="Conditional composer"><code>++bend</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#bet' title="Parse hep and lus axis syntax"><code>++bet</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#bex' title="Binary exponent"><code>++bex</code></a>
@@ -75,6 +76,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#bite' title="Atom slice specificier"><code>$bite</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bixab' title="Parse hex pair"><code>++bix:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#biskso' title="Parse auraatom pair"><code>++bisk:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#block' title="Abstract identity of resource awaited"><code>+$block</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#bloq' title="Blocksize"><code>$bloq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#bond' title="Replace null"><code>++bond</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#boss' title="Parser modifier: LSB"><code>++boss</code></a>
@@ -96,13 +98,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#cetyo' title="Days in a century"><code>++cet:yo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#chafa' title="Decode base58check character"><code>++cha:fa</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#char' title="Character"><code>+$char</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#chum' title="Jet hint information"><code>++chum</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#chum' title="Jet hint information"><code>+$chum</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#cit' title="Octal digit"><code>++cit</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#clap' title="Combine two units with function"><code>++clap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#clef' title="Compose two units with function"><code>++clef</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#cmpsi' title="Compare (signed integer)"><code>++cmp:si</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#co' title="Literal rendering engine"><code>++co</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#coil' title="Tuple of core information"><code>++coil</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#coil' title="Tuple of core information"><code>+$coil</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#coin' title="Nounliteral syntax cases"><code>+$coin</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#col' title="Parse : (col)"><code>++col</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#cold' title="Replace with constant"><code>++cold</code></a>
@@ -113,6 +115,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#cord' title="UTF8 text"><code>+$cord</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#cork' title="Compose forward"><code>++cork</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#corl' title="Compose backward"><code>++corl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#crib' title="Summary and details"><code>+$crib</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#crip' title="Tape to cord"><code>++crip</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#crubso' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#cue' title="Unpack atom to noun"><code>++cue</code></a>
@@ -159,6 +162,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#doh' title="@p separator"><code>++doh</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#doq' title="Parse double quote"><code>++doq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#dor' title="Depth order"><code>++dor</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#doss' title="Profiling"><code>+$doss</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#dot' title="Parse period"><code>++dot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgff' title="@r to decimal float"><code>++drg:ff</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgfl' title="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
@@ -233,7 +237,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmars' title="Fused multiplyadd (singleprecision float)"><code>++fma:rs</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmarq' title="Fused multiplyadd (quadprecision float)"><code>++fma:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#fo' title="Modulo prime"><code>++fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#foot' title="Cases of arms by variance model"><code>++foot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#foot' title="Cases of arms by variance model"><code>+$foot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#fore' title="Pair before"><code>++fore</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fosrh' title="@rs to @rh"><code>++fos:rh</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#frafo' title="Divide (modular base)"><code>++fra:fo</code></a>
@@ -250,6 +254,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#gap' title="Plural whitespace"><code>++gap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#gaq' title="End of line"><code>++gaq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#gar' title="Parse > (gar)"><code>++gar</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#garb' title="Core metadata"><code>+$garb</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#gasby' title="Concatenate (map)"><code>++gas:by</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#gasin' title="Concatenate (set)"><code>++gas:in</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#gasju' title="Concatenate (jug)"><code>++gas:ju</code></a>
@@ -297,6 +302,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#hasju' title="Check contents (jug)"><code>++has:ju</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#hax' title="Parse # (hax)"><code>++hax</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#head' title="Get head of cell"><code>++head</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#help' title="Documentation"><code>+$help</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hefab' title="Parse non-dozzod phonetic pair"><code>++hef:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#here' title="Placebased apply"><code>++here</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#hep' title="Parse  (hep)"><code>++hep</code></a>
@@ -307,8 +313,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#hit' title="Parse single hexadecimal digit"><code>++hit</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hofab' title="Parse 2-4 @q phonetic pair"><code>++hof:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#homo' title="Homogenize list"><code>++homo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#hoon' title="Hoon AST"><code>+$hoon</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#hoot' title="Hoon tools"><code>++hoot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#horyo' title="Seconds in hour"><code>++hor:yo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hufab' title="Parse 1-4 @q phonetic pairs"><code>++huf:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#hump' title="Profiling"><code>+$hump</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#hunt' title="Select between two units by a rule"><code>++hunt</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hyfab' title="Parse four @q phonetic pairs"><code>++hyf:ab</code></a>
 
@@ -361,9 +370,9 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#lien' title="Logical OR on list"><code>++lien</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#lift' title="Curried bind"><code>++lift</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#like' title="Generic edge"><code>++like</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#limb' title="Reference into subject by name/axis"><code>++limb</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#limb' title="Reference into subject by name/axis"><code>+$limb</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#limo' title="Construct list from nullterminated tuple"><code>++limo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#line' title="(Undocumented)"><code>++line</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#link' title="Lexical segment"><code>+$link</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#lipag' title="Parse IPv4 address"><code>++lip:ag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#list' title="Mold constructor (list)"><code>++list</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#lone' title="Mold generator (face on mold)"><code>++lone</code></a>
@@ -391,14 +400,21 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### m
 
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#manxhoot' title="Dynamic XML node"><code>+$manx:hoot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mard' title="Initialize ff (rd core)"><code>++ma:rd</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#marh' title="Initialize ff (rh core)"><code>++ma:rh</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mars' title="Initialize ff (rs core)"><code>++ma:rs</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#marq' title="Initialize ff (rq core)"><code>++ma:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mack' title="Nock subject to unit"><code>++mack</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2l/#malt' title="Map from list"><code>++malt</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#manehoot' title="XML name+space"><code>+$mane:hoot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2o/#map' title="Mold generator (map)"><code>++map</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#marby' title="Add with validation (map)"><code>++mar:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marehoot' title="Node or nodes"><code>+$mare:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marlhoot' title="Dynamic XML nodes"><code>+$marl:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marthoot' title="Dynamic XML attributes"><code>+$mart:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#maruhoot' title="Interpolation or nodes"><code>+$maru:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marxhoot' title="Dynamic XML tag"><code>+$marx:hoot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1b/#mas' title="Address within head/tail"><code>++mas</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#mask' title="Match character"><code>++mask</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#mat' title="Lengthencode"><code>++mat</code></a>
@@ -409,15 +425,16 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#mes' title="Parse hexabyte"><code>++mes</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#mesc' title="Escape special characters"><code>++mesc</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#met' title="Measure"><code>++met</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#metl' title="(Undocumented)"><code>++metl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#min' title="Minimum (atom)"><code>++min</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mink' title="Mock (virtual Nock) interpreter"><code>++mink</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#mityo' title="Seconds in minute"><code>++mit:yo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2d/#mix' title="Binary XOR (atom)"><code>++mix</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#mixed-case-symbol' title="Mixed-case term"><code>++mixed-case-symbol</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#moan' title="Profiling: sample metric"><code>+$moan</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mock' title="Compute formula on subject with hint"><code>++mock</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#mod' title="Modulus (atom)"><code>++mod</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#mohyo' title="Days in month"><code>++moh:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mole' title="Typed unitary virtual"><code>++mole</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2l/#molt' title="Map from pair list"><code>++molt</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mong' title="Slam gate with sample"><code>++mong</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mook' title="Intelligently render crash annotation"><code>++mook</code></a>
@@ -437,6 +454,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulrs' title="Multiply (singleprecision float)"><code>++mul:rs</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulrq' title="Multiply (quadprecision float)"><code>++mul:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mule' title="Typed virtual"><code>++mule</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mure' title="Untyped unitary virtual"><code>++mure</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mute' title="Untyped virtual"><code>++mute</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#murn' title="Maybe transform"><code>++murn</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#my' title="Map from raw noun"><code>++my</code></a>
@@ -455,12 +473,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#nipto' title="Remove root of queue"><code>++nip:to</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#nix' title="Parse letters and underscore"><code>++nix</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#nl' title="Noun to container operations"><code>++nl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#nock' title="Virtual machine (see Nock)"><code>++nock</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#nock' title="Virtual nock"><code>+$nock</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2d/#not' title="Binary NOT (atom)"><code>++not</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#note' title="Type annotation"><code>+$note</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#noun' title="Any noun"><code>+$noun</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#nuckso' title="Toplevel coin parser"><code>++nuck:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#nud' title="Parse numeric character"><code>++nud</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#null' title="(Undocumented)"><code>++null</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#null' title="Null, nil, etc"><code>+$null</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#nuskso' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
 
 ### o
@@ -468,6 +487,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#ob' title="Reversible scrambling v2"><code>++ob</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#og' title="Container arm for SHA256 powered RNG"><code>++og</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#oldsi' title="Sign and absolute value"><code>++old:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#onyx' title="Arm activation"><code>+$onyx</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#opal' title="Wing match"><code>+$opal</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#oust' title="Remove from list"><code>++oust</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#outfe' title="Maximum integer value"><code>++out:fe</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ox-coco' title="Format dot-separated digits in numeric base"><code>++ox-co:co</code></a>
@@ -482,20 +503,25 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#path' title="Like unix path"><code>+$path</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1b/#peg' title="Address within address"><code>++peg</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#pal' title="Parse ( (pal)"><code>++pal</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#palo' title="Wing trace, match"><code>+$palo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#par' title="Parse ) (par)"><code>++par</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#perdso' title="Parsing coin literal without prefixes"><code>++perd:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#perk' title="Parse cube fork"><code>++perk</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pevab' title="Parse 1-5 @uv base-32 chars"><code>++pev:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pewab' title="Parse <= 5 in base 64"><code>++pew:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#pfix' title="Discard first rule"><code>++pfix</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#pica' title="Prose or code"><code>+$pica</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#pint' title="Parsing range"><code>+$pint</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pivab' title="Parse 5 @uv base-32 chars"><code>++piv:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#piwab' title="Parse 5 @uw base-64 chars"><code>++piw:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#plat' title="%hoon, %type, %nock or %tank"><code>+$plat</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#plug' title="Parse to tuple"><code>++plug</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#plus' title="List of at least one match"><code>++plus</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#po' title="Phonetic base"><code>++po</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#pock' title="Changes"><code>+$pock</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#pole' title="Mold generator of faceless list"><code>++pole</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#port' title="(Undocumented)"><code>++port</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#poly' title="Polarity"><code>+$poly</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#port' title="Successful wing match"><code>+$port</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#pose' title="Parse options"><code>++pose</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2g/#pow' title="Computes a to the power of b"><code>++pow</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#prcfl' title="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
@@ -545,6 +571,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rep' title="Assemble single"><code>++rep</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#repby' title="Reduce to product (map)"><code>++rep:by</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#repin' title="Accumulate elements (set)"><code>++rep:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#result' title="Internal interpreter result"><code>+$result</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rev' title="Reverse"><code>++rev</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rfat' title="Print loobean"><code>++rf:at</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#ribby' title="Transform + product (map)"><code>++rib:by</code></a>
@@ -607,6 +634,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#searq' title="Convert from quadprecision float to fn"><code>++sea:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#sear' title="Conditional ++cook"><code>++sear</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sebab' title="Parse 1"><code>++seb:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#sect' title="Paragraph"><code>+$sect</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sedab' title="Parse nonzero decimal digit"><code>++sed:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#sel' title="Parse [ (sel)"><code>++sel</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#mic' title="Parse ; (mic)"><code>++mic</code></a>
@@ -649,6 +677,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sixab' title="Parse a hexadecimal digit"><code>++six:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#skid' title="Separate list into two lists from slammed elments"><code>++skid</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#skim' title="Produce list of elements from boolean gate"><code>++skim</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#skin' title="Texture"><code>+$skin</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#skip' title="Produce list of elements failing boolean gate"><code>++skip</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#slag' title="Produce all elements from index in list"><code>++slag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#slat' title="Curried slaw"><code>++slat</code></a>
@@ -657,12 +686,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#slay' title="Parse cord to coin"><code>++slay</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slog' title="Deify printf"><code>++slog</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#slug' title="Use gate to parse delimited list"><code>++slug</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#slum' title="Slam a gate on a sample using raw nock, untyped"><code>++slum</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#smyt' title="Render path as tank"><code>++smyt</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#snag' title="Produce element at specific index (list)"><code>++snag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#snagnl' title="Produce element from list at specific nullterminated noun"><code>++snag:nl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#snip' title="Drop tail off list"><code>++snip</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#snoc' title="Append noun to list"><code>++snoc</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#so' title="Coin parser engine"><code>++so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#soft' title="Virtual clam"><code>++soft</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#some' title="Wrap value in unit"><code>++some</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#soq' title="Parse ' (soq)"><code>++soq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#sort' title="Quicksort (list)"><code>++sort</code></a>
@@ -670,9 +701,9 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sowab' title="Parse @uw base-64 letter/symbol"><code>++sow:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#soxab' title="Parse hexadecimal letter"><code>++sox:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#soz' title="Parse triple singlequote"><code>++soz</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#span' title="ASCII atom"><code>++span</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#spat' title="Render path as cord"><code>++spat</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#spdfl' title="Produce smallest denormalized float"><code>++spd:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#spec' title="Structure definition AST"><code>+$spec</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#spin' title="Gate to list (with state)"><code>++spin</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#spnfl' title="Produce smallest normal float"><code>++spn:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#spot' title="Stack trace line"><code>+$spot</code></a>
@@ -687,6 +718,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtrq' title="Produce square root of quadprecision float"><code>++sqt:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#stab' title="Parse cord to path"><code>++stab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stag' title="Add label"><code>++stag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#stap' title="Path parser"><code>++stap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#star' title="Produce list of matches"><code>++star</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#step' title="Atom size or offset, in bloqs"><code>++step</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stet' title="Add faces to rangeparser pairs in list"><code>++stet</code></a>
@@ -737,18 +769,20 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tedab' title="Parse 1-999 decimal"><code>++ted:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#teff' title="UTF8 length"><code>++teff</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#tailob' title="Reverse +feis"><code>++tail:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tent' title="Model builder"><code>+$tent</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tepab' title="Parse non-doz leading phonetic byte"><code>++tep:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#term' title="Hoon constant"><code>+$term</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#test' title="Test for equality"><code>++test</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#thunk' title="Fragment constructor"><code>+$thunk</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tidab' title="Parse 3 decimal digits"><code>++tid:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tiki' title="(Undocumented)"><code>++tiki</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tiki' title="Test case"><code>+$tiki</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tilab' title="Parse 3 lowercase letters"><code>++til:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tine' title="Partial noun"><code>+$tine</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tipab' title="Leading phonetic byte"><code>++tip:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tiqab' title="Trailing phonetic syllable"><code>++tiq:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#tis' title="Parse = (tis)"><code>++tis</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#to' title="Queue operations"><code>++to</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#todpo' title="Fetch suffix"><code>++tod:po</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#toga' title="Tree of faces"><code>++toga</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toiff' title="Round IEEE float to nearest signed integer"><code>++toi:ff</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toifl' title="Round float to nearest signed integer"><code>++toi:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toird' title="Round doubleprecision float to nearest signed integer"><code>++toi:rd</code></a>
@@ -757,12 +791,17 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toirq' title="Round quadprecision float to nearest signed integer"><code>++toi:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#tojfl' title="Round unsigned and signed integer to float"><code>++toj:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#tokfa' title="Compute base58check checksum"><code>++tok:fa</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tome' title="Core chapter"><code>+$tome</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#tone' title="Nock result (error report)"><code>+$tone</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tony' title="$tone done right"><code>+$tony</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tool' title="Type decoration"><code>+$tool</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#toon' title="Nock result (stack trace)"><code>+$toon</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tope' title="Topographic type"><code>+$tope</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#topto' title="Produce head of queue"><code>++top:to</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#tospo' title="Fetch prefix"><code>++tos:po</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#tosrh' title="Convert halfprecision float to singleprecision float"><code>++tos:rh</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tour' title="UTF-32 clusters"><code>+$tour</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#type' title="Hoon type type"><code>+$type</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#trap' title="Core with one arm $"><code>++trap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#tree' title="Mold generator (tree)"><code>++tree</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#trel' title="Mold generator (tuple of three types)"><code>++trel</code></a>
@@ -770,14 +809,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#trip' title="Cord to tape"><code>++trip</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tuba' title="UTF8 to UTF32 tape"><code>++tuba</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tufa' title="UTF32 to UTF8 tape"><code>++tufa</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tuna' title="XML template tree"><code>++tuna</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tuft' title="UTF32 to UTF8 text"><code>++tuft</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tunahoot' title="Maybe interpolation"><code>+$tuna:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tune' title="Complex"><code>+$tune</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#turn' title="Gate to list"><code>++turn</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tusk' title="List of expressions"><code>++tusk</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#twidso' title="Parse coins without ~ prefix"><code>++twid:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyke' title="List of 'maybe' hoons"><code>++tyke</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#typo' title="Pointer for ++type"><code>++typo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyre' title="List, term hoon"><code>++tyre</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyke' title="List of 'maybe' hoons"><code>+$tyke</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#typo' title="Old type"><code>+$typo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyre' title="List, term hoon"><code>+$tyre</code></a>
 
 ### u
 
@@ -795,11 +834,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#vne' title="Render base 32"><code>++v:ne</code></a>
 <code>++vang</code>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vase' title="Typed data"><code>++vase</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vair' title="Core variance"><code>+$vair</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vase' title="Type-value pair"><code>+$vase</code></a>
 <code>++vast</code>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#v-coco' title="Render base-32 with minimum length"><code>++v-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vein' title="Search trace"><code>+$vein</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#ven' title="Axis syntax parser"><code>++ven</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vise' title="Convert during reboot"><code>++vise</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vial' title="co/contra/in/bi"><code>+$vial</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vise' title="Old vase"><code>+$vise</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#vit' title="Parse base 64 digit"><code>++vit</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#vizag' title="Parse base 32 digit with dot separators"><code>++viz:ag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#voyab' title="Parse bas, soq, or bix"><code>++voy:ab</code></a>
@@ -817,13 +859,16 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#weld' title="Concatenate two lists"><code>++weld</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#weldnl' title="Concatenate nullterminated nouns"><code>++weld:nl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#welp' title="Perfect concatenate (lists)"><code>++welp</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#what' title="Help slogan/section"><code>+$what</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#whenso' title="Parse date"><code>++when:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#whit' title="Documentation"><code>+$whit</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#wick' title="Knot unescape"><code>++wick</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#winre' title="Render at indent"><code>++win:re</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#wing' title="Address in subject"><code>++wing</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#wing' title="Search path"><code>+$wing</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#wizag' title="Parse base 64 number"><code>++wiz:ag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#woad' title="Unescape cord"><code>++woad</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#wood' title="Escape cord"><code>++wood</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#woof' title="Simple embed"><code>+$woof</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#wonk' title="Product from edge"><code>++wonk</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#wredun' title="Restore structure"><code>++wred:un</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#wrenun' title="Conceal structure"><code>++wren:un</code></a>
@@ -1766,45 +1811,89 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#spat' title="Render path as cord"><code>++spat</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#spud' title="Render path as tape"><code>++spud</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#stab' title="Parse cord to path"><code>++stab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#stap' title="Path parser"><code>++stap</code></a>
 
 ### 4n: parsing (virtualization)
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mack' title="Nock subject to unit"><code>++mack</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mink' title="Mock (virtual Nock) interpreter"><code>++mink</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mock' title="Compute formula on subject with hint"><code>++mock</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mong' title="Slam gate with sample"><code>++mong</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mook' title="Intelligently render crash annotation"><code>++mook</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mole' title="Typed unitary virtual"><code>++mole</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mong' title="Slam gate with sample"><code>++mong</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mule' title="Typed virtual"><code>++mule</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mure' title="Untyped unitary virtual"><code>++mure</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mute' title="Untyped virtual"><code>++mute</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#slum' title="Slam a gate on a sample using raw nock, untyped"><code>++slum</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#soft' title="Virtual clam"><code>++soft</code></a>
 
 ### 4o: parsing (molds)
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#abel' title="Compiler alias"><code>++abel</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#aura' title="'Type' of atom"><code>++aura</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#base' title="Base type"><code>++base</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#beer' title="Tape builder"><code>++beer</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#beet' title="XML interpolation cases"><code>++beet</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#chum' title="Jet hint information"><code>++chum</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#coil' title="Tuple of core information"><code>++coil</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#foot' title="Cases of arms by variance model"><code>++foot</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#limb' title="Reference into subject by name/axis"><code>++limb</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#line' title="(Undocumented)"><code>++line</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#metl' title="(Undocumented)"><code>++metl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#nock' title="Virtual machine (see Nock)"><code>++nock</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#null' title="(Undocumented)"><code>++null</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#port' title="(Undocumented)"><code>++port</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#span' title="ASCII atom"><code>++span</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tiki' title="(Undocumented)"><code>++tiki</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#toga' title="Tree of faces"><code>++toga</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tone'><code>+$tone</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tuna' title="XML template tree"><code>++tuna</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tusk' title="List of expressions"><code>++tusk</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyke' title="List of 'maybe' hoons"><code>++tyke</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#typo' title="Pointer for ++type"><code>++typo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyre' title="List, term hoon"><code>++tyre</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vase' title="Typed data"><code>++vase</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vise' title="Convert during reboot"><code>++vise</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#wing' title="Address in subject"><code>++wing</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#abel' title="Original sin: type"><code>+$abel</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#alas' title="Alias list"><code>+$alas</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#atom' title="Just an atom"><code>+$atom</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#aura' title="'Type' of atom"><code>+$aura</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#base' title="Base type"><code>+$base</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#woof' title="Simple embed"><code>+$woof</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#chum' title="Jet hint information"><code>+$chum</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#coil' title="Tuple of core information"><code>+$coil</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#garb' title="Core metadata"><code>+$garb</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#poly' title="Polarity"><code>+$poly</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#foot' title="Cases of arms by variance model"><code>+$foot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#link' title="Lexical segment"><code>+$link</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#crib' title="Summary and details"><code>+$crib</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#help' title="Documentation"><code>+$help</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#limb' title="Reference into subject by name/axis"><code>+$limb</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#null' title="Null, nil, etc"><code>+$null</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#onyx' title="Arm activation"><code>+$onyx</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#opal' title="Wing match"><code>+$opal</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#pica' title="Prose or code"><code>+$pica</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#palo' title="Wing trace, match"><code>+$palo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#plat' title="%hoon, %type, %nock or %tank"><code>+$plat</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#pock' title="Changes"><code>+$pock</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#port' title="Successful wing match"><code>+$port</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#spec' title="Structure definition AST"><code>+$spec</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tent' title="Model builder"><code>+$tent</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tiki' title="Test case"><code>+$tiki</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#skin' title="Texture"><code>+$skin</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tome' title="Core chapter"><code>+$tome</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tope' title="Topographic type"><code>+$tope</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#hoot' title="Hoon tools"><code>++hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#beerhoot' title="Simple embed"><code>+$beer:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#manehoot' title="XML name+space"><code>+$mane:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#manxhoot' title="Dynamic XML node"><code>+$manx:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marlhoot' title="Dynamic XML nodes"><code>+$marl:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marthoot' title="Dynamic XML attributes"><code>+$mart:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marxhoot' title="Dynamic XML tag"><code>+$marx:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marehoot' title="Node or nodes"><code>+$mare:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#maruhoot' title="Interpolation or nodes"><code>+$maru:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tunahoot' title="Maybe interpolation"><code>+$tuna:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#hoon' title="Hoon AST"><code>+$hoon</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyre' title="List, term hoon"><code>+$tyre</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyke' title="List of 'maybe' hoons"><code>+$tyke</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#nock' title="Virtual nock"><code>+$nock</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#note' title="Type annotation"><code>+$note</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#type' title="Hoon type type"><code>+$type</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tony' title="$tone done right"><code>+$tony</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tine' title="Partial noun"><code>+$tine</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tool' title="Type decoration"><code>+$tool</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tune' title="Complex"><code>+$tune</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#typo' title="Old type"><code>+$typo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vase' title="Type-value pair"><code>+$vase</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vise' title="Old vase"><code>+$vise</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vial' title="co/contra/in/bi"><code>+$vial</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vair' title="Core variance"><code>+$vair</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vein' title="Search trace"><code>+$vein</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#sect' title="Paragraph"><code>+$sect</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#whit' title="Documentation"><code>+$whit</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#what' title="Help slogan/section"><code>+$what</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#wing' title="Search path"><code>+$wing</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#block' title="Abstract identity of resource awaited"><code>+$block</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#result' title="Internal interpreter result"><code>+$result</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#thunk' title="Fragment constructor"><code>+$thunk</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#doss' title="Profiling"><code>+$doss</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#moan' title="Profiling: sample metric"><code>+$moan</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#hump' title="Profiling"><code>+$hump</code></a>
 
 ### 5a: compiler utilities
 

--- a/lib/glossary.js
+++ b/lib/glossary.js
@@ -1403,7 +1403,7 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "Compiler alias",
+    name: "Original sin: type",
     symbol: "abel",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#abel",
@@ -1491,6 +1491,13 @@ export const glossary = [
     symbol: "ag",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4j/#ag",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Alias list",
+    symbol: "alas",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#alas",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -1585,6 +1592,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Just an atom",
+    symbol: "atom",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#atom",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "'Type' of atom",
     symbol: "aura",
     usage: "stdlib",
@@ -1655,17 +1669,10 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "Tape builder",
-    symbol: "beer",
+    name: "Simple embed",
+    symbol: "beer:hoot",
     usage: "stdlib",
-    slug: "https://urbit.org/docs/reference/library/4o/#beer",
-    desc: "Used in the Hoon standard library.",
-  },
-  {
-    name: "XML interpolation cases",
-    symbol: "beet",
-    usage: "stdlib",
-    slug: "https://urbit.org/docs/reference/library/4o/#beet",
+    slug: "https://urbit.org/docs/reference/library/4o/#beerhoot",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -1785,6 +1792,13 @@ export const glossary = [
     symbol: "bisk:so",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4l/#biskso",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Abstract identity of resource awaited",
+    symbol: "block",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#block",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -2044,6 +2058,13 @@ export const glossary = [
     symbol: "crip",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4b/#crip",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Summary and details",
+    symbol: "crib",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#crib",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -2345,6 +2366,13 @@ export const glossary = [
     symbol: "dor",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2f/#dor",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Profiling",
+    symbol: "doss",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#doss",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -2922,6 +2950,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Core metadata",
+    symbol: "garb",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#garb",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Concatenate (map)",
     symbol: "gas:by",
     usage: "stdlib",
@@ -3237,6 +3272,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Documentation",
+    symbol: "help",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#help",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Place-based apply",
     symbol: "here",
     usage: "stdlib",
@@ -3300,6 +3342,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Hoon AST",
+    symbol: "hoon",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#hoon",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Seconds in hour",
     symbol: "hor:yo",
     usage: "stdlib",
@@ -3307,10 +3356,24 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Hoon tools",
+    symbol: "hoot",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#hoot",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Parse 1-4 @q phonetic pairs",
     symbol: "huf:ab",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4j/#hufab",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Profiling",
+    symbol: "hump",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#hump",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -3615,10 +3678,10 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "(Undocumented)",
-    symbol: "line",
+    name: "Lexical segment",
+    symbol: "link",
     usage: "stdlib",
-    slug: "https://urbit.org/docs/reference/library/4o/#line",
+    slug: "https://urbit.org/docs/reference/library/4o/#link",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -3832,6 +3895,20 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "XML name+space",
+    symbol: "mane:hoot",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#manehoot",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Dynamic XML node",
+    symbol: "manx:hoot",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#manxhoot",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Mold generator (map)",
     symbol: "map",
     usage: "stdlib",
@@ -3843,6 +3920,41 @@ export const glossary = [
     symbol: "mar:by",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2i/#marby",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Node or nodes",
+    symbol: "mare:hoot",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#marehoot",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Dynamic XML nodes",
+    symbol: "marl:hoot",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#marlhoot",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Dynamic XML attributes",
+    symbol: "mart:hoot",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#marthoot",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Interpolation or nodes",
+    symbol: "maru:hoot",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#maruhoot",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Dynamic XML tag",
+    symbol: "marx:hoot",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#marxhoot",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -3916,13 +4028,6 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "(Undocumented)",
-    symbol: "metl",
-    usage: "stdlib",
-    slug: "https://urbit.org/docs/reference/library/4o/#metl",
-    desc: "Used in the Hoon standard library.",
-  },
-  {
     name: "Minimum (atom)",
     symbol: "min",
     usage: "stdlib",
@@ -3958,6 +4063,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Profiling: sample metric",
+    symbol: "moan",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#moan",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Compute formula on subject with hint",
     symbol: "mock",
     usage: "stdlib",
@@ -3976,6 +4088,13 @@ export const glossary = [
     symbol: "moh:yo",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/3c/#mohyo",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Typed unitary virtual",
+    symbol: "mole",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4n/#mole",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -4112,6 +4231,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Untyped unitary virtual",
+    symbol: "mure",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4n/#mure",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Untyped virtual",
     symbol: "mute",
     usage: "stdlib",
@@ -4217,7 +4343,7 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "Virtual machine (see Nock)",
+    name: "Virtual Nock",
     symbol: "nock",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#nock",
@@ -4228,6 +4354,13 @@ export const glossary = [
     symbol: "not",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2d/#not",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Type annotation",
+    symbol: "note",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#note",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -4252,7 +4385,7 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "(Undocumented)",
+    name: "Null, nil, etc",
     symbol: "null",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#null",
@@ -4284,6 +4417,20 @@ export const glossary = [
     symbol: "old:si",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/3a/#oldsi",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Arm activation",
+    symbol: "onyx",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#onyx",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Wing match",
+    symbol: "opal",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#opal",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -4319,6 +4466,13 @@ export const glossary = [
     symbol: "pair",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/1c/#pair",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Wing trace, match",
+    symbol: "palo",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#palo",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -4399,6 +4553,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Prose or code",
+    symbol: "pica",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#pica",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Parsing range",
     symbol: "pint",
     usage: "stdlib",
@@ -4417,6 +4578,13 @@ export const glossary = [
     symbol: "piw:ab",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4j/#piwab",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "%hoon, %type, %nock or %tank",
+    symbol: "plat",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#plat",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -4441,6 +4609,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Changes",
+    symbol: "pock",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#pock",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Mold generator of faceless list",
     symbol: "pole",
     usage: "stdlib",
@@ -4448,7 +4623,14 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "(Undocumented)",
+    name: "Polarity (wet/dry)",
+    symbol: "poly",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#poly",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Successful wing match",
     symbol: "port",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#port",
@@ -4753,6 +4935,13 @@ export const glossary = [
     symbol: "rep:in",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2h/#repin",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Internal interpreter result",
+    symbol: "result",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#result",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -5155,6 +5344,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Paragraph",
+    symbol: "sect",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#sect",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Parse non-zero decimal digit",
     symbol: "sed:ab",
     usage: "stdlib",
@@ -5449,6 +5645,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Texture",
+    symbol: "skin",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#skin",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Produce list of elements failing boolean gate",
     symbol: "skip",
     usage: "stdlib",
@@ -5505,6 +5708,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Slam a gate on a sample using raw nock, untyped",
+    symbol: "slum",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4n/#slum",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Render path as tank",
     symbol: "smyt",
     usage: "stdlib",
@@ -5544,6 +5754,13 @@ export const glossary = [
     symbol: "so",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4l/#so",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Virtual clam",
+    symbol: "soft",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4n/#soft",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -5596,13 +5813,6 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "ASCII atom",
-    symbol: "span",
-    usage: "stdlib",
-    slug: "https://urbit.org/docs/reference/library/4o/#span",
-    desc: "Used in the Hoon standard library.",
-  },
-  {
     name: "Render path as cord",
     symbol: "spat",
     usage: "stdlib",
@@ -5614,6 +5824,13 @@ export const glossary = [
     symbol: "spd:fl",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/3b/#spdfl",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Structure definition AST",
+    symbol: "spec",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#spec",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -5712,6 +5929,13 @@ export const glossary = [
     symbol: "stag",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4f/#stag",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Path parser",
+    symbol: "stap",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4m/#stap",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -6016,10 +6240,24 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Fragment constructor",
+    symbol: "thunk",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#thunk",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Parse ` (tic)",
     symbol: "tic",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4h/#tic",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Partial noun",
+    symbol: "tine",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#tine",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -6034,6 +6272,13 @@ export const glossary = [
     symbol: "teff",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4b/#teff",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Model builder",
+    symbol: "tent",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#tent",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -6072,7 +6317,7 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "(Undocumented)",
+    name: "Test case",
     symbol: "tiki",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#tiki",
@@ -6118,13 +6363,6 @@ export const glossary = [
     symbol: "tod:po",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4a/#todpo",
-    desc: "Used in the Hoon standard library.",
-  },
-  {
-    name: "Tree of faces",
-    symbol: "toga",
-    usage: "stdlib",
-    slug: "https://urbit.org/docs/reference/library/4o/#toga",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -6184,10 +6422,31 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Core chapter",
+    symbol: "tome",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#tome",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Nock result (error report)",
     symbol: "tone",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/3g/#tone",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "$tone done right",
+    symbol: "tony",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#tony",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Type decoration",
+    symbol: "tool",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#tool",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -6202,6 +6461,13 @@ export const glossary = [
     symbol: "top:to",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2k/#topto",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Topographic type",
+    symbol: "tope",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#tope",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -6275,13 +6541,6 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "XML template tree",
-    symbol: "tuna",
-    usage: "stdlib",
-    slug: "https://urbit.org/docs/reference/library/4o/#tuna",
-    desc: "Used in the Hoon standard library.",
-  },
-  {
     name: "UTF-32 to UTF-8 text",
     symbol: "tuft",
     usage: "stdlib",
@@ -6289,17 +6548,24 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Maybe interpolation",
+    symbol: "tuna:hoot",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#tunahoot",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Complex",
+    symbol: "tune",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#tune",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Gate to list",
     symbol: "turn",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2b/#turn",
-    desc: "Used in the Hoon standard library.",
-  },
-  {
-    name: "List of expressions",
-    symbol: "tusk",
-    usage: "stdlib",
-    slug: "https://urbit.org/docs/reference/library/4o/#tusk",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -6317,7 +6583,14 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "Pointer for type",
+    name: "Hoon type type",
+    symbol: "type",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#type",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Old type",
     symbol: "typo",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#typo",
@@ -6401,7 +6674,14 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "Typed data",
+    name: "in/contra/bi/co",
+    symbol: "vair",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#vair",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Type-value pair",
     symbol: "vase",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#vase",
@@ -6415,6 +6695,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Search trace",
+    symbol: "vein",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#vein",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Axis syntax parser",
     symbol: "ven",
     usage: "stdlib",
@@ -6422,7 +6709,14 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "Convert during reboot",
+    name: "co/contra/in/bi",
+    symbol: "vial",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#vial",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Old vase",
     symbol: "vise",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#vise",
@@ -6527,6 +6821,20 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Help slogan/section",
+    symbol: "what",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#what",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Documentation",
+    symbol: "whit",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#whit",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Knot unescape",
     symbol: "wick",
     usage: "stdlib",
@@ -6541,7 +6849,7 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
-    name: "Address in subject",
+    name: "Address in subject - search path",
     symbol: "wing",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#wing",
@@ -6566,6 +6874,13 @@ export const glossary = [
     symbol: "wood",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4b/#wood",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Simple embed",
+    symbol: "woof",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/4o/#woof",
     desc: "Used in the Hoon standard library.",
   },
   {


### PR DESCRIPTION
- 4m
  - add ++stap
  - refresh existing functions
  - update ToC and glossary.js as appropriate
- 4n
  - add ++mole, ++mure, ++slum, ++soft
  - refresh existing functions
  - update ToC and glossary.js as appropriate
- 4o
  - change description of $abel, $null, $port,
    $tiki, $hoon, $nock, $typo, $vase, $vise, $wing
  - add $alas, $atom, $woof, $garb, $poly, $crib,
    $help, $onyx, $opal, $pica, $palo, $plat, $pock,
    $spec, $tent, $skin, $tome, $tope, ++hoot, $beer:hoot,
    $mane:hoot, $manx:hoot, $mart:hoot, #marx:hoot,
    $mare:hoot, $maru:hoot, $tuna:hoot, $note, $type,
    $tony, $tine, $tool, $tune, $vial, $vair, $vein,
    $sect, $whit, $what, $block, $result, $thunk, $doss,
    $moan, $hump
  - delete $beer, $beet, $line, $metl, $tone,
    $span, $toga, $tuna, $tusk
  - refresh existing functions
  - update ToC and glossary.js as appropriate

regarding #1137
resolves #1282