### PR TITLE
Add lookup table for irregular forms.

### DIFF
--- a/content/docs/hoon/reference/irregular.md
+++ b/content/docs/hoon/reference/irregular.md
@@ -5,6 +5,35 @@ template = "doc.html"
 aliases = ["docs/reference/hoon-expressions/irregular/"]
 +++
 
+## Quick Lookup of Irregular Forms
+
+| Form | Regular Form |
+| ---- | ------------ |
+| `_foo` | [`$_`](https://urbit.org/docs/hoon/reference/rune/buc#_-buccab), normalizes to an example |
+| `[a=foo b=bar c=baz]` | [`$:`](https://urbit.org/docs/hoon/reference/rune/buc#_-buccol), forms a tuple |
+| `foo=bar` | [`$=`](https://urbit.org/docs/hoon/reference/rune/buc#_-buctis), wraps a face around a value |
+| `?($foo $bar $baz)` | [`$?`](https://urbit.org/docs/hoon/reference/rune/buc#_-bucwut), forms a type union |
+| `(fun arg)` | [`%-`](https://urbit.org/docs/hoon/reference/rune/cen#_-cenhep), calls a gate |
+| `~(arm core arg)` | [`%~`](https://urbit.org/docs/hoon/reference/rune/cen#_-censig), pulls an arm in a door |
+| `foo(x 1, y 2, z 3)` | [`%=`](https://urbit.org/docs/hoon/reference/rune/cen#_-centis), resolve a wing with changes |
+| `[a b]` | [`:-`](https://urbit.org/docs/hoon/reference/rune/col#_-colhep), constructs 2-tuple |
+| `[a b c]` | [`:+`](https://urbit.org/docs/hoon/reference/rune/col#_-collus), constructs 3-tuple |
+| `[a b c d]` | [`:^`](https://urbit.org/docs/hoon/reference/rune/col#_-colket), constructs 4-tuple |
+| `[a b c d e …]` | [`:*`](https://urbit.org/docs/hoon/reference/rune/col#_-coltar), constructs _n_-tuple |
+| `~[a b c]` | [`:~`](https://urbit.org/docs/hoon/reference/rune/col#_-colsig), constructs null-terminated list |
+| `+(42)` | [`.+`](https://urbit.org/docs/hoon/reference/rune/dot#_-dotlus), increments with Nock 4 |
+| `=(a b)` | [`.=`](https://urbit.org/docs/hoon/reference/rune/dot#_-dottis), tests for equality wiht Nock 5 |
+| `` `foo`bar `` | [`^-`](https://urbit.org/docs/hoon/reference/rune/ket#_-kethep), typecasts by explicit type label |
+| `foo=bar` | [`^=`](https://urbit.org/docs/hoon/reference/rune/ket#_-kettis), binds name to value |
+| `*foo` | [`^*`](https://urbit.org/docs/hoon/reference/rune/ket#_-kettar), bunts (produces default mold value) |
+| `,foo` | [`^:`](https://urbit.org/docs/hoon/reference/rune/ket#_-ketcol), produces “factory” gate for type |
+| `:(fun a b c d)` | [`;:`](https://urbit.org/docs/hoon/reference/rune/mic#_-miccol), calls binary function as _n_-ary function |
+| `foo:bar` | [`=<`](https://urbit.org/docs/hoon/reference/rune/tis#_-tisgal), composes two expressions, inverted |
+| `|(foo bar baz)` | [`?|`](https://urbit.org/docs/hoon/reference/rune/wut#_-wutbar), logical OR (loobean) |
+| `&(foo bar baz)` | [`?&`](https://urbit.org/docs/hoon/reference/rune/wut#_-wutpam), logical AND (loobean) |
+| `!foo` | [`?!`](https://urbit.org/docs/hoon/reference/rune/wut#_-wutzap), logical NOT (loobean) |
+| `;html` | Sail builder |
+
 ##### Reading guide
 
 Headings contain runes, phonetics and tokens. Description contains a link to the

--- a/content/docs/hoon/reference/irregular.md
+++ b/content/docs/hoon/reference/irregular.md
@@ -10,29 +10,24 @@ aliases = ["docs/reference/hoon-expressions/irregular/"]
 | Form | Regular Form |
 | ---- | ------------ |
 | `_foo` | [`$_`](https://urbit.org/docs/hoon/reference/rune/buc#_-buccab), normalizes to an example |
-| `[a=foo b=bar c=baz]` | [`$:`](https://urbit.org/docs/hoon/reference/rune/buc#_-buccol), forms a tuple |
 | `foo=bar` | [`$=`](https://urbit.org/docs/hoon/reference/rune/buc#_-buctis), wraps a face around a value |
-| `?($foo $bar $baz)` | [`$?`](https://urbit.org/docs/hoon/reference/rune/buc#_-bucwut), forms a type union |
-| `(fun arg)` | [`%-`](https://urbit.org/docs/hoon/reference/rune/cen#_-cenhep), calls a gate |
+| `?(%foo %bar %baz)` | [`$?`](https://urbit.org/docs/hoon/reference/rune/buc#_-bucwut), forms a type union |
+| `(fun a b c)` | [`%:`](https://urbit.org/docs/hoon/reference/rune/cen#_-cencol), calls a gate with n arguments |
 | `~(arm core arg)` | [`%~`](https://urbit.org/docs/hoon/reference/rune/cen#_-censig), pulls an arm in a door |
 | `foo(x 1, y 2, z 3)` | [`%=`](https://urbit.org/docs/hoon/reference/rune/cen#_-centis), resolve a wing with changes |
-| `[a b]` | [`:-`](https://urbit.org/docs/hoon/reference/rune/col#_-colhep), constructs 2-tuple |
-| `[a b c]` | [`:+`](https://urbit.org/docs/hoon/reference/rune/col#_-collus), constructs 3-tuple |
-| `[a b c d]` | [`:^`](https://urbit.org/docs/hoon/reference/rune/col#_-colket), constructs 4-tuple |
-| `[a b c d e …]` | [`:*`](https://urbit.org/docs/hoon/reference/rune/col#_-coltar), constructs _n_-tuple |
+| `[a b c]` | [`:*`](https://urbit.org/docs/hoon/reference/rune/col#_-coltar) or [`$:`](https://urbit.org/docs/hoon/reference/rune/buc#_-buccol), constructs _n_-tuple in normal mode or its structure in structure mode |
 | `~[a b c]` | [`:~`](https://urbit.org/docs/hoon/reference/rune/col#_-colsig), constructs null-terminated list |
 | `+(42)` | [`.+`](https://urbit.org/docs/hoon/reference/rune/dot#_-dotlus), increments with Nock 4 |
 | `=(a b)` | [`.=`](https://urbit.org/docs/hoon/reference/rune/dot#_-dottis), tests for equality wiht Nock 5 |
-| `` `foo`bar `` | [`^-`](https://urbit.org/docs/hoon/reference/rune/ket#_-kethep), typecasts by explicit type label |
+| `&#96;foo&#96;bar` | [`^-`](https://urbit.org/docs/hoon/reference/rune/ket#_-kethep), typecasts by explicit type label |
 | `foo=bar` | [`^=`](https://urbit.org/docs/hoon/reference/rune/ket#_-kettis), binds name to value |
 | `*foo` | [`^*`](https://urbit.org/docs/hoon/reference/rune/ket#_-kettar), bunts (produces default mold value) |
 | `,foo` | [`^:`](https://urbit.org/docs/hoon/reference/rune/ket#_-ketcol), produces “factory” gate for type |
 | `:(fun a b c d)` | [`;:`](https://urbit.org/docs/hoon/reference/rune/mic#_-miccol), calls binary function as _n_-ary function |
 | `foo:bar` | [`=<`](https://urbit.org/docs/hoon/reference/rune/tis#_-tisgal), composes two expressions, inverted |
-| `|(foo bar baz)` | [`?|`](https://urbit.org/docs/hoon/reference/rune/wut#_-wutbar), logical OR (loobean) |
+| `&#124;(foo bar baz)` | [`?&#124;`](https://urbit.org/docs/hoon/reference/rune/wut#_-wutbar), logical OR (loobean) |
 | `&(foo bar baz)` | [`?&`](https://urbit.org/docs/hoon/reference/rune/wut#_-wutpam), logical AND (loobean) |
 | `!foo` | [`?!`](https://urbit.org/docs/hoon/reference/rune/wut#_-wutzap), logical NOT (loobean) |
-| `;html` | Sail builder |
 
 ##### Reading guide
 


### PR DESCRIPTION
This provides a quick look-up table for irregular forms. We need a fast way for developers to locate an irregular form when they encounter it.

We can debate the best particular form and hyperlinking scheme for the table.

Separately, we need to hook these irregular forms (e.g. dot) into the website search system somehow.