### PR TITLE
Add instructions for  Node.js 17 incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,39 @@ yarn dev
 
 Finally, open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+### Errors with Digital Envelope Routines
+
+Gatsby v4 is not compatible with Webpack v4. If you're building with Node.js v17 or greater, you may experience some issues when building [urbit.org](https://urbit.org). The incompatibility between Gatsby and Webpack will present as the following error message on `yarn dev` or `npm run dev`:
+
+```bash
+Error: error:0308010C:digital envelope routines::unsupported
+    at new Hash (node:internal/crypto/hash:67:19)
+    at Object.createHash (node:crypto:130:10)
+    at module.exports.__webpack_modules__.15660.module.exports (~/urbit.org/node_modules/next/dist/compiled/webpack/bundle4.js:111680:62)
+    at NormalModule._initBuildHash (~/urbit.org/node_modules/next/dist/compiled/webpack/bundle4.js:85092:16)
+    at handleParseError (~/urbit.org/node_modules/next/dist/compiled/webpack/bundle4.js:85146:10)
+    at ~/urbit.org/node_modules/next/dist/compiled/webpack/bundle4.js:85178:5
+    at ~/urbit.org/node_modules/next/dist/compiled/webpack/bundle4.js:85033:12
+    at ~/urbit.org/node_modules/next/dist/compiled/webpack/bundle4.js:51096:3
+    at iterateNormalLoaders (~/urbit.org/node_modules/next/dist/compiled/webpack/bundle4.js:50937:10)
+    at Array.<anonymous> (~/urbit.org/node_modules/next/dist/compiled/webpack/bundle4.js:50928:4) {
+  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
+  library: 'digital envelope routines',
+  reason: 'unsupported',
+  code: 'ERR_OSSL_EVP_UNSUPPORTED'
+}
+```
+
+To work around this error, you can take the following steps:
+
+```bash
+npm install gatsby
+# then
+export NODE_OPTIONS=--openssl-legacy-provider
+```
+
+Adding the `openssl-legacy-provider` option should allow you to build the site successfully.
+
 ## Framework and Library Documentation
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
[Node.js v17 comes with webpack 4 which has some incompatibilities in cryptography suites](https://stackoverflow.com/questions/69665222/node-js-17-0-1-gatsby-error-digital-envelope-routinesunsupported-err-os).  Installing and running urbit.org can still be accomplished using Node.js v17+ using the added commands, at least until the project is upgraded to webpack 5.

This is my limited understanding based on my limited experience w/ JavaScript and some searching of stackoverflow. If I am mistaken, my apologies for this commit - this did, however, work for me to build locally without changing node versions.