### PR TITLE
update stdlib section 5

### DIFF
--- a/content/docs/hoon/reference/stdlib/5a.md
+++ b/content/docs/hoon/reference/stdlib/5a.md
@@ -4,4 +4,501 @@ weight = 43
 template = "doc.html"
 +++
 
-(To be documented)
+These functions are used internally by the compiler. They should not be used
+directly and are only listed here for completeness.
+
+## `++musk`
+
+Nock with block set
+
+#### Source
+
+This function is extremely large, please refer to `hoon.hoon` for the source.
+
+---
+
+## `++bool`
+
+Make loobean
+
+#### Source
+
+```hoon
+++  bool  `type`(fork [%atom %f `0] [%atom %f `1] ~)
+```
+
+---
+
+## `++cell`
+
+Make `%cell` type
+
+#### Source
+
+```hoon
+++  cell
+  ~/  %cell
+  |=  [hed=type tal=type]
+  ^-  type
+  ?:(=(%void hed) %void ?:(=(%void tal) %void [%cell hed tal]))
+```
+
+---
+
+## `++core`
+
+Make `%core` type
+
+#### Source
+
+```hoon
+++  core
+  ~/  %core
+  |=  [pac=type con=coil]
+  ^-  type
+  ?:(=(%void pac) %void [%core pac con])
+```
+
+---
+
+## `++hint`
+
+Make `%hint` type
+
+#### Source
+
+```hoon
+++  hint
+  |=  [p=(pair type note) q=type]
+  ^-  type
+  ?:  =(%void q)  %void
+  ?:  =(%noun q)  %noun
+  [%hint p q]
+```
+
+---
+
+## `++face`
+
+Make `%face` type
+
+#### Source
+
+```hoon
+++  face
+  ~/  %face
+  |=  [giz=$@(term tune) der=type]
+  ^-  type
+  ?:  =(%void der)
+    %void
+  [%face giz der]
+```
+
+---
+
+## `++fork`
+
+Make `%fork` type
+
+#### Source
+
+```hoon
+++  fork
+  ~/  %fork
+  |=  yed=(list type)
+  =|  lez=(set type)
+  |-  ^-  type
+  ?~  yed
+    ?~  lez  %void
+    ?:  ?=([* ~ ~] lez)  n.lez
+    [%fork lez]
+  %=    $
+      yed  t.yed
+      lez
+    ?:  =(%void i.yed)  lez
+    ?:  ?=([%fork *] i.yed)  (~(uni in lez) p.i.yed)
+    (~(put in lez) i.yed)
+  ==
+```
+
+---
+
+## `++cove`
+
+Extract [0 *] axis
+
+#### Source
+
+```hoon
+++  cove
+  |=  nug=nock
+  ?-    nug
+      [%0 *]   p.nug
+      [%11 *]  $(nug q.nug)
+      *        ~_(leaf+"cove" !!)
+  ==
+```
+
+---
+
+## `++comb`
+
+Combine two formulas
+
+#### Source
+
+```hoon
+++  comb
+  ~/  %comb
+  |=  [mal=nock buz=nock]
+  ^-  nock
+  ?:  ?&(?=([%0 *] mal) !=(0 p.mal))
+    ?:  ?&(?=([%0 *] buz) !=(0 p.buz))
+      [%0 (peg p.mal p.buz)]
+    ?:  ?=([%2 [%0 *] [%0 *]] buz)
+      [%2 [%0 (peg p.mal p.p.buz)] [%0 (peg p.mal p.q.buz)]]
+    [%7 mal buz]
+  ?:  ?=([^ [%0 %1]] mal)
+    [%8 p.mal buz]
+  ?:  =([%0 %1] buz)
+    mal
+  [%7 mal buz]
+```
+
+---
+
+## `++cond`
+
+`?:` compile
+
+#### Source
+
+```hoon
+++  cond
+  ~/  %cond
+  |=  [pex=nock yom=nock woq=nock]
+  ^-  nock
+  ?-  pex
+    [%1 %0]  yom
+    [%1 %1]  woq
+    *        [%6 pex yom woq]
+  ==
+```
+
+---
+
+## `++cons`
+
+Make formula cell
+
+#### Source
+
+```hoon
+++  cons
+  ~/  %cons
+  |=  [vur=nock sed=nock]
+  ^-  nock
+  ::  this optimization can remove crashes which are essential
+  ::
+  ::  ?:  ?=([[%0 *] [%0 *]] +<)
+  ::  ?:  ?&(=(+(p.vur) p.sed) =((div p.vur 2) (div p.sed 2)))
+  ::    [%0 (div p.vur 2)]
+  ::  [vur sed]
+  ?:  ?=([[%1 *] [%1 *]] +<)
+    [%1 p.vur p.sed]
+  [vur sed]
+```
+
+---
+
+## `++fitz`
+
+Odor compatibility
+
+#### Source
+
+```hoon
+++  fitz
+  ~/  %fitz
+  |=  [yaz=term wix=term]
+  =+  ^=  fiz
+      |=  mot=@ta  ^-  [p=@ q=@ta]
+      =+  len=(met 3 mot)
+      ?:  =(0 len)
+        [0 %$]
+      =+  tyl=(rsh [3 (dec len)] mot)
+      ?:  &((gte tyl 'A') (lte tyl 'Z'))
+        [(sub tyl 64) (end [3 (dec len)] mot)]
+      [0 mot]
+  =+  [yoz=(fiz yaz) wux=(fiz wix)]
+  ?&  ?|  =(0 p.yoz)
+          =(0 p.wux)
+          &(!=(0 p.wux) (lte p.wux p.yoz))
+      ==
+      |-  ?|  =(%$ p.yoz)
+              =(%$ p.wux)
+              ?&  =((end 3 p.yoz) (end 3 p.wux))
+                  $(p.yoz (rsh 3 p.yoz), p.wux (rsh 3 p.wux))
+              ==
+          ==
+  ==
+```
+
+---
+
+## `++flan`
+
+Loobean &
+
+#### Source
+
+```hoon
+++  flan
+  ~/  %flan
+  |=  [bos=nock nif=nock]
+  ^-  nock
+  ?:  =(bos nif)  bos
+  ?:  =([%0 0] bos)  nif
+  ?:  =([%0 0] nif)  bos
+  ?-    bos
+      [%1 %1]   bos
+      [%1 %0]   nif
+      *
+    ?-    nif
+        [%1 %1]   nif
+        [%1 %0]   bos
+        *       [%6 bos nif [%1 1]]
+    ==
+  ==
+```
+
+---
+
+## `++flip`
+
+Loobean negation
+
+#### Source
+
+```hoon
+++  flip
+  ~/  %flip
+  |=  dyr=nock
+  ?:  =([%0 0] dyr)  dyr
+  [%6 dyr [%1 1] [%1 0]]
+```
+
+---
+
+## `++flor`
+
+Loobean |
+
+#### Source
+
+```hoon
+++  flor
+  ~/  %flor
+  |=  [bos=nock nif=nock]
+  ^-  nock
+  ?:  =(bos nif)  bos
+  ?:  =([%0 0] bos)  nif
+  ?:  =([%0 0] nif)  bos
+  ?-  bos
+      [%1 %1]   nif
+      [%1 %0]   bos
+      *
+    ?-  nif
+        [%1 %1]   bos
+        [%1 %0]   nif
+        *         [%6 bos [%1 0] nif]
+    ==
+  ==
+```
+
+---
+
+## `++hike`
+
+Compiler utility
+
+#### Source
+
+```hoon
+++  hike
+  ~/  %hike
+  |=  [a=axis pac=(list (pair axis nock))]
+  |^  =/  rel=(map axis nock)  (roll pac insert)
+      =/  ord=(list axis)      (sort ~(tap in ~(key by rel)) gth)
+      |-  ^-  nock
+      ?~  ord
+        [%0 a]
+      =/  b=axis  i.ord
+      =/  c=nock  (~(got by rel) b)
+      =/  d=nock  $(ord t.ord)
+      [%10 [b c] d]
+  ::
+  ++  contains
+    |=  [container=axis contained=axis]
+    ^-  ?
+    =/  big=@    (met 0 container)
+    =/  small=@  (met 0 contained)
+    ?:  (lte small big)  |
+    =/  dif=@  (sub small big)
+    =(container (rsh [0 dif] contained))
+  ::
+  ++  parent
+    |=  a=axis
+    `axis`(rsh 0 a)
+  ::
+  ++  sibling
+    |=  a=axis
+    ^-  axis
+    ?~  (mod a 2)
+      +(a)
+    (dec a)
+  ::
+  ++  insert
+    |=  [e=[axe=axis fol=nock] n=(map axis nock)]
+    ^-  (map axis nock)
+    ?:  =/  a=axis  axe.e
+        |-  ^-  ?
+        ?:  =(1 a)  |
+        ?:  (~(has by n) a)
+          &
+        $(a (parent a))
+      ::  parent already in
+      n
+    =.  n
+      ::  remove children
+      %+  roll  ~(tap by n)
+      |=  [[axe=axis fol=nock] m=_n]
+      ?.  (contains axe.e axe)  m
+      (~(del by m) axe)
+    =/  sib  (sibling axe.e)
+    =/  un   (~(get by n) sib)
+    ?~  un   (~(put by n) axe.e fol.e)
+    ::  replace sibling with parent
+    %=  $
+      n  (~(del by n) sib)
+      e  :-  (parent sib)
+         ?:  (gth sib axe.e)
+           (cons fol.e u.un)
+         (cons u.un fol.e)
+    ==
+  --
+```
+
+---
+
+## `++jock`
+
+Compiler utility
+
+#### Source
+
+```hoon
+++  jock
+  |=  rad=?
+  |=  lot=coin  ^-  hoon
+  ?-    -.lot
+      ~
+    ?:(rad [%rock p.lot] [%sand p.lot])
+  ::
+      %blob
+    ?:  rad
+      [%rock %$ p.lot]
+    ?@(p.lot [%sand %$ p.lot] [$(p.lot -.p.lot) $(p.lot +.p.lot)])
+  ::
+      %many
+    [%cltr (turn p.lot |=(a=coin ^$(lot a)))]
+  ==
+```
+
+---
+
+## `++look`
+
+Compiler utility
+
+#### Source
+
+```hoon
+++  look
+  ~/  %look
+  |=  [cog=term dab=(map term hoon)]
+  =+  axe=1
+  |-  ^-  (unit [p=axis q=hoon])
+  ?-  dab
+      ~  ~
+  ::
+      [* ~ ~]
+    ?:(=(cog p.n.dab) [~ axe q.n.dab] ~)
+  ::
+      [* ~ *]
+    ?:  =(cog p.n.dab)
+      [~ (peg axe 2) q.n.dab]
+    ?:  (gor cog p.n.dab)
+      ~
+    $(axe (peg axe 3), dab r.dab)
+  ::
+      [* * ~]
+    ?:  =(cog p.n.dab)
+      [~ (peg axe 2) q.n.dab]
+    ?:  (gor cog p.n.dab)
+      $(axe (peg axe 3), dab l.dab)
+    ~
+  ::
+      [* * *]
+    ?:  =(cog p.n.dab)
+      [~ (peg axe 2) q.n.dab]
+    ?:  (gor cog p.n.dab)
+      $(axe (peg axe 6), dab l.dab)
+    $(axe (peg axe 7), dab r.dab)
+  ==
+```
+
+---
+
+## `++loot`
+
+Compiler utility
+
+#### Source
+
+```hoon
+++  loot
+  ~/  %loot
+  |=  [cog=term dom=(map term tome)]
+  =+  axe=1
+  |-  ^-  (unit [p=axis q=hoon])
+  ?-  dom
+      ~  ~
+  ::
+      [* ~ ~]
+    %+  bind  (look cog q.q.n.dom)
+    |=((pair axis hoon) [(peg axe p) q])
+  ::
+      [* ~ *]
+    =+  yep=(look cog q.q.n.dom)
+    ?^  yep
+      [~ (peg (peg axe 2) p.u.yep) q.u.yep]
+    $(axe (peg axe 3), dom r.dom)
+  ::
+      [* * ~]
+    =+  yep=(look cog q.q.n.dom)
+    ?^  yep
+      [~ (peg (peg axe 2) p.u.yep) q.u.yep]
+    $(axe (peg axe 3), dom l.dom)
+  ::
+      [* * *]
+    =+  yep=(look cog q.q.n.dom)
+    ?^  yep
+      [~ (peg (peg axe 2) p.u.yep) q.u.yep]
+    =+  pey=$(axe (peg axe 6), dom l.dom)
+    ?^  pey  pey
+    $(axe (peg axe 7), dom r.dom)
+  ==
+```
+
+---

--- a/content/docs/hoon/reference/stdlib/5a.md
+++ b/content/docs/hoon/reference/stdlib/5a.md
@@ -213,7 +213,7 @@ Make formula cell
 
 ## `++fitz`
 
-Odor compatibility
+Aura compatibility
 
 #### Source
 

--- a/content/docs/hoon/reference/stdlib/5b.md
+++ b/content/docs/hoon/reference/stdlib/5b.md
@@ -4,4 +4,84 @@ weight = 44
 template = "doc.html"
 +++
 
-(To be documented)
+These functions are used internally by the compiler. They should not be used
+directly and are only listed here for completeness.
+
+## `++ah`
+
+Tiki engine
+
+#### Source
+
+```hoon
+++  ah
+  |_  tik=tiki
+  ++  blue
+    |=  gen=hoon
+    ^-  hoon
+    ?.  &(?=(%| -.tik) ?=(~ p.tik))  gen
+    [%tsgr [%$ 3] gen]
+  ::
+  ++  teal
+    |=  mod=spec
+    ^-  spec
+    ?:  ?=(%& -.tik)  mod
+    [%over [%& 3]~ mod]
+  ::
+  ++  tele
+    |=  syn=skin
+    ^-  skin
+    ?:  ?=(%& -.tik)  syn
+    [%over [%& 3]~ syn]
+  ::
+  ++  gray
+    |=  gen=hoon
+    ^-  hoon
+    ?-  -.tik
+      %&  ?~(p.tik gen [%tstr [u.p.tik ~] [%wing q.tik] gen])
+      %|  [%tsls ?~(p.tik q.tik [%ktts u.p.tik q.tik]) gen]
+    ==
+  ::
+  ++  puce
+    ^-  wing
+    ?-  -.tik
+      %&  ?~(p.tik q.tik [u.p.tik ~])
+      %|  [[%& 2] ~]
+    ==
+  ::
+  ++  wthp  |=  opt=(list (pair spec hoon))
+            %+  gray  %wthp
+            [puce (turn opt |=([a=spec b=hoon] [a (blue b)]))]
+  ++  wtkt  |=([sic=hoon non=hoon] (gray [%wtkt puce (blue sic) (blue non)]))
+  ++  wtls  |=  [gen=hoon opt=(list (pair spec hoon))]
+            %+  gray  %wtls
+            [puce (blue gen) (turn opt |=([a=spec b=hoon] [a (blue b)]))]
+  ++  wtpt  |=([sic=hoon non=hoon] (gray [%wtpt puce (blue sic) (blue non)]))
+  ++  wtsg  |=([sic=hoon non=hoon] (gray [%wtsg puce (blue sic) (blue non)]))
+  ++  wthx  |=(syn=skin (gray [%wthx (tele syn) puce]))
+  ++  wtts  |=(mod=spec (gray [%wtts (teal mod) puce]))
+  --
+::
+```
+
+---
+
+## `++ax`
+
+Spec engine
+
+#### Source
+
+This core is very large, refer to `hoon.hoon` for the source.
+
+---
+
+## `++ap`
+
+Hoon engine
+
+#### Source
+
+This core is very large, refer to `hoon.hoon` for the source.
+
+---

--- a/content/docs/hoon/reference/stdlib/5c.md
+++ b/content/docs/hoon/reference/stdlib/5c.md
@@ -4,7 +4,439 @@ weight = 45
 template = "doc.html"
 +++
 
-(To be fully documented)
+## `++ut`
+
+Hoon compiler backend
+
+#### Source
+
+This core is too large to include here, refer to `hoon.hoon` for the source.
+
+---
+
+## `++us`
+
+Pretty-printer backend
+
+#### Source
+
+This core is too large to include here, refer to `hoon.hoon` for the source.
+
+---
+
+## `++cain`
+
+Tank pretty-print
+
+Pretty-print a `vase` as a `tank` using `++deal`. This is the same as
+[`++sell`](#sell).
+
+#### Accepts
+
+A `vase`.
+
+#### Produces
+
+A `tank`.
+
+#### Source
+
+```hoon
+++  cain  sell
+```
+
+#### Examples
+
+```
+> (cain !>(['foo' 'bar']))
+[%rose p=[p=" " q="[" r="]"] q=~[[%leaf p="'foo'"] [%leaf p="'bar'"]]]
+```
+
+---
+
+## `++noah`
+
+Tape pretty-print
+
+Pretty-print a `vase` as a `tape`. This is the same as [`++text`](#text).
+
+#### Accepts
+
+A `vase`.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  noah  text
+```
+
+#### Examples
+
+```
+> (noah !>(['foo' 'bar']))
+"['foo' 'bar']"
+```
+
+---
+
+## `++onan`
+
+Vise to vase
+
+Convert a `vise` (old `vase`) to the new `vase`. This is the same as
+[`++seer`](#seer).
+
+#### Accepts
+
+A `vise`.
+
+#### Produces
+
+A `vase`.
+
+#### Source
+
+```hoon
+++  onan  seer
+```
+
+#### Examples
+
+```
+> (onan `vise`!>(['foo' 'bar']))
+[#t/[@t @t] q=[7.303.014 7.496.034]]
+```
+
+---
+
+## `++levi`
+
+Type nests or crash
+
+Check if type `b` nests under type `a`. Produces `%.y` if it nests and crashes
+if it does not.
+
+#### Accepts
+
+`a` is a `type`.
+
+`b` is a `type`.
+
+#### Produces
+
+A `?`.
+
+#### Source
+
+```hoon
+++  levi
+  |=  [a=type b=type]
+  (~(nest ut a) & b)
+```
+
+#### Examples
+
+```
+> (levi -:!>('foo') -:!>(%foo))
+%.y
+
+> (levi -:!>(%foo) -:!>('foo'))
+-need.%foo
+-have.@t
+nest-fail
+```
+
+---
+
+## `++text`
+
+Tape pretty-print
+
+Pretty print vase `vax` as a `tape`.
+
+#### Accepts
+
+`vax` is a `vase`.
+
+#### Produces
+
+A `tape`.
+
+#### Source
+
+```hoon
+++  text
+  |=  vax=vase  ^-  tape
+  ~(ram re (sell vax))
+```
+
+#### Examples
+
+```
+> (text !>(['foo' 'bar']))
+"['foo' 'bar']"
+```
+
+---
+
+## `++seem`
+
+Promote typo
+
+Convert `typo` (old type) to the new `type`.
+
+#### Accepts
+
+`toy` is a `typo`.
+
+#### Produces
+
+A `type`.
+
+#### Source
+
+```hoon
+++  seem  |=(toy=typo `type`toy)
+```
+
+#### Examples
+
+```
+> (seem -:!>('foo'))
+#t/@t
+```
+
+---
+
+## `++seer`
+
+Promote vise
+
+Convert a `vise` (old `vase`) to the new `vase`.
+
+#### Accepts
+
+`vix` is a `vise`.
+
+#### Produces
+
+A `vase`.
+
+#### Source
+
+```hoon
+++  seer  |=(vix=vise `vase`vix)
+```
+
+#### Examples
+
+```
+> (seer !>('foo'))
+[#t/@t q=7.303.014]
+```
+
+---
+
+## `++sell`
+
+Pretty-print vase to a tank
+
+Pretty-print vase `vax` to a `tank` using `++deal:us`.
+
+#### Accepts
+
+`vax` is a `vase`.
+
+#### Produces
+
+A `tank`.
+
+#### Source
+
+```hoon
+++  sell
+  ~/  %sell
+  |=  vax=vase
+  ^-  tank
+  ~|  %sell
+  (~(deal us p.vax) q.vax)
+```
+
+#### Examples
+
+```
+> (sell !>(['foo' 'bar']))
+[%rose p=[p=" " q="[" r="]"] q=~[[%leaf p="'foo'"] [%leaf p="'bar'"]]]
+```
+
+---
+
+## `++skol`
+
+Pretty-print type to tank
+
+Pretty-print type `typ` to a `tank` using `++duck:ut`.
+
+#### Accepts
+
+`typ` is a `type`.
+
+#### Produces
+
+A `tank`.
+
+#### Source
+
+```hoon
+++  skol
+  |=  typ=type
+  ^-  tank
+  ~(duck ut typ)
+```
+
+#### Examples
+
+```
+> (skol -:!>(['foo' 'bar']))
+[%rose p=[p=" " q="[" r="]"] q=~[[%leaf p="@t"] [%leaf p="@t"]]]
+```
+
+---
+
+## `++slam`
+
+Slam a gate
+
+Slam `gat`, a gate in a `vase`, with `sam`, a sample in a `vase`. Produces a
+`vase` containing the result.
+
+#### Accepts
+
+`gat` is a gate in a `vase`.
+
+`sam` is a noun in a `vase`.
+
+#### Produces
+
+A `vase`.
+
+#### Source
+
+```hoon
+++  slam
+  |=  [gat=vase sam=vase]  ^-  vase
+  =+  :-  ^=  typ  ^-  type
+          [%cell p.gat p.sam]
+      ^=  gen  ^-  hoon
+      [%cnsg [%$ ~] [%$ 2] [%$ 3] ~]
+  =+  gun=(~(mint ut typ) %noun gen)
+  [p.gun (slum q.gat q.sam)]
+```
+
+#### Examples
+
+```
+> (slam !>(|=([a=@ud b=@ud] [b a])) !>([1 2]))
+[#t/[@ud @ud] q=[2 1]]
+```
+
+---
+
+## `++slab`
+
+Test if contains
+
+States whether you can access named wing `cog` in type `typ` using access method `way`.
+
+#### Accepts
+
+`way` is a `?(%read %rite %both)` (A `$vial` without `%free`). This represents
+the access method (read, write, or both read and write).
+
+`cog` is a `@tas`, the name of a wing.
+
+`typ` is a `type`.
+
+#### Produces
+
+A `?`.
+
+#### Source
+
+```hoon
+++  slab
+  |=  [way=?(%read %rite %both) cog=@tas typ=type]
+  ?=  [%& *]
+  (~(fond ut typ) way ~[cog])
+```
+
+```
+> =au |=(a=@ +(a))
+> (slab %read %a -:!>(au))
+%.y
+> (slab %rite %a -:!>(au))
+%.y
+> (slab %both %a -:!>(au))
+%.y
+
+> (slab %both %blah -:!>(au))
+%.n
+
+> =fe ^|(|=(a=@ +(a)))
+> (slab %read %a -:!>(fe))
+%.n
+> (slab %rite %a -:!>(fe))
+%.y
+> (slab %both %a -:!>(fe))
+%.n
+```
+
+---
+
+## `++slap`
+
+Untyped vase `.*`
+
+Compile hoon `gen` with subject `vax` using `.*`, producing a `vase` of the
+result.
+
+#### Accepts
+
+`vax` is a noun in a `vase`, and is the subject.
+
+`gen` is some `hoon`.
+
+#### Produces
+
+A `vase`.
+
+#### Source
+
+```hoon
+++  slap
+  |=  [vax=vase gen=hoon]  ^-  vase
+  =+  gun=(~(mint ut p.vax) %noun gen)
+  [p.gun .*(q.vax q.gun)]
+```
+
+#### Examples
+
+```
+> (slap !>(b='foo') (ream '|=(a=@t [a b])'))
+[#t/<1.qgm [a=@t b=@t]> q=[[[0 6] 0 7] 0 7.303.014]]
+
+> !<($-(@t [@t @t]) (slap !>(b='foo') (ream '|=(a=@t [a b])')))
+<1|xpg [@t @t @t @t]>
+
+> (!<($-(@t [@t @t]) (slap !>(b='foo') (ream '|=(a=@t [a b])'))) 'bar')
+['bar' 'foo']
+```
+
+---
 
 ## `++slog`
 
@@ -78,6 +510,416 @@ A crash, with `a` printed to the terminal.
 > (mean leaf+"foo" ~)
 foo
 dojo: hoon expression failed
+```
+
+---
+
+## `++road`
+
+Evaluate trap
+
+Evaluate a `trap`, producing the result if successful or else
+crashing with a trace.
+
+#### Accepts
+
+A `trap`.
+
+#### Produces
+
+A noun.
+
+#### Source
+
+```hoon
+++  road
+  |*  =(trap *)
+  ^+  $:trap
+  =/  res  (mule trap)
+  ?-  -.res
+    %&  p.res
+    %|  (mean p.res)
+  ==
+```
+
+#### Examples
+
+```
+> (road |.("foo"))
+"foo"
+
+> (road |.(~|('crash!' !!)))
+'crash!'
+dojo: hoon expression failed
+```
+
+---
+
+## `++slew`
+
+Get axis in vase
+
+Get axis `axe` in vase `vax`, producing the resulting `vase` in a `unit` which is null if
+the axis cannot be retrieved.
+
+#### Accepts
+
+`axe` is an atom.
+
+`vax` is a `vase`.
+
+#### Produces
+
+A `(unit vase)`.
+
+#### Source
+
+```hoon
+++  slew
+  |=  [axe=@ vax=vase]  ^-  (unit vase)
+  ?.  |-  ^-  ?
+      ?:  =(1 axe)  &
+      ?.  ?=(^ q.vax)  |
+      $(axe (mas axe), q.vax .*(q.vax [0 (cap axe)]))
+    ~
+  `[(~(peek ut p.vax) %free axe) .*(q.vax [0 axe])]
+```
+
+#### Examples
+
+```
+> (slew 3 !>(['foo' 'bar']))
+[~ [#t/@t q=7.496.034]]
+
+> !<(@t (need (slew 3 !>(['foo' 'bar']))))
+'bar'
+
+> (slew 7 !>(['foo' 'bar']))
+~
+```
+
+---
+
+## `++slim`
+
+Identical to `++seer`
+
+Convert a `vise` (old `vase`) to a `vase`. Identical to [`++seer`](#seer).
+
+#### Accepts
+
+`old` is a `vise`.
+
+#### Produces
+
+A `vase`.
+
+#### Source
+
+```hoon
+++  slim
+  |=  old=vise  ^-  vase
+  old
+```
+
+#### Examples
+
+```
+> (slim !>('foo'))
+[#t/@t q=7.303.014]
+```
+
+---
+
+## `++slit`
+
+Type of slam
+
+The `type` produced if a gate of type `gat` were slammed with a sample of type `sam`.
+
+#### Accepts
+
+`gat` is a `type`.
+
+`sam` is a `type`.
+
+#### Produces
+
+A `type`.
+
+#### Source
+
+```hoon
+++  slit
+  |=  [gat=type sam=type]
+  ?>  (~(nest ut (~(peek ut gat) %free 6)) & sam)
+  (~(play ut [%cell gat sam]) [%cnsg [%$ ~] [%$ 2] [%$ 3] ~])
+```
+
+#### Examples
+
+```
+> (slit -:!>(|*(a=@ [a a])) -:!>(42))
+#t/[@ud @ud]
+
+> (slit -:!>(|*(a=@ [a a])) -:!>('foo'))
+#t/[@t @t]
+```
+
+---
+
+## `++slob`
+
+Superficial arm
+
+#### Source
+
+```hoon
+++  slob
+  |=  [cog=@tas typ=type]
+  ^-  ?
+  ?+  typ  |
+      [%hold *]  $(typ ~(repo ut typ))
+      [%hint *]  $(typ ~(repo ut typ))
+      [%core *]
+    |-  ^-  ?
+    ?~  q.r.q.typ  |
+    ?|  (~(has by q.q.n.q.r.q.typ) cog)
+        $(q.r.q.typ l.q.r.q.typ)
+        $(q.r.q.typ r.q.r.q.typ)
+    ==
+  ==
+```
+
+---
+
+## `++sloe`
+
+Get arms in core
+
+Produces a list of the arms in a core of type `typ`.
+
+#### Accepts
+
+`typ` is a type.
+
+#### Produces
+
+A `(list term)`.
+
+#### Source
+
+```hoon
+++  sloe
+  |=  typ=type
+  ^-  (list term)
+  ?+    typ  ~
+      [%hold *]  $(typ ~(repo ut typ))
+      [%hint *]  $(typ ~(repo ut typ))
+      [%core *]
+    %-  zing
+    %+  turn  ~(tap by q.r.q.typ)
+      |=  [* b=tome]
+    %+  turn  ~(tap by q.b)
+      |=  [a=term *]
+    a
+  ==
+```
+
+#### Examples
+
+```
+> (sloe -:!>(|=(@ 1)))
+~[%$]
+
+> =cr |%
+      ++  foo  1
+      ++  bar  2
+      ++  baz  3
+      --
+
+> (sloe -:!>(cr))
+~[%foo %baz %bar]
+
+> (sloe -:!>(42))
+~
+```
+
+---
+
+## `++slop`
+
+Cons two vases
+
+Produce the vase of a cell of vases `hed` and `tal`.
+
+#### Accepts
+
+`hed` is a `vase`.
+
+`tal` is a `vase`.
+
+#### Produces
+
+A `vase`.
+
+#### Source
+
+```hoon
+++  slop
+  |=  [hed=vase tal=vase]
+  ^-  vase
+  [[%cell p.hed p.tal] [q.hed q.tal]]
+```
+
+#### Examples
+
+```
+> (slop !>('foo') !>(42))
+[#t/[@t @ud] q=[7.303.014 42]]
+
+> !<([@t @ud] (slop !>('foo') !>(42)))
+['foo' 42]
+```
+
+---
+
+## `++slot`
+
+Got axis in vase
+
+Get axis `axe` in vase `vax`, returning it in a `vase`. Crashes if the axis
+cannot be retrieved.
+
+#### Accepts
+
+`axe` is an atom.
+
+`vax` is a `vase`.
+
+#### Produces
+
+A `vase`.
+
+#### Source
+
+```hoon
+++  slot
+  |=  [axe=@ vax=vase]  ^-  vase
+  [(~(peek ut p.vax) %free axe) .*(q.vax [0 axe])]
+```
+
+#### Examples
+
+```
+> (slot 3 !>(['foo' 'bar']))
+[#t/@t q=7.496.034]
+
+> !<(@t (slot 3 !>(['foo' 'bar'])))
+'bar'
+
+> (slot 7 !>(['foo' 'bar']))
+dojo: hoon expression failed
+```
+
+---
+
+## `++slym`
+
+Slam without sample-type
+
+Slam `gat`, a gate in a `vase`, with `sam`, a `noun`. The type of `sam` is
+ignored and the type of the resulting vase is determined by the gate alone.
+
+#### Accepts
+
+`gat` is a `vase`.
+
+`sam` is a noun.
+
+#### Produces
+
+A `vase`.
+
+#### Source
+
+```hoon
+++  slym
+  |=  [gat=vase sam=*]  ^-  vase
+  (slap gat(+<.q sam) [%limb %$])
+```
+
+#### Examples
+
+```
+> (slym !>(|*(a=@ux [a a])) 'foo')
+[#t/[@ux @ux] q=[7.303.014 7.303.014]]
+
+> (slym !>(|*(a=@ux [a a])) "foobar")
+[#t/[@ux @ux] q=[[102 111 111 98 97 114 0] 102 111 111 98 97 114 0]]
+```
+
+---
+
+## `++sped`
+
+Reconstruct type
+
+#### Source
+
+```hoon
+++  sped
+  |=  vax=vase
+  ^-  vase
+  :_  q.vax
+  ?@  q.vax  (~(fuse ut p.vax) [%atom %$ ~])
+  ?@  -.q.vax
+    ^=  typ
+    %-  ~(play ut p.vax)
+    [%wtgr [%wtts [%leaf %tas -.q.vax] [%& 2]~] [%$ 1]]
+  (~(fuse ut p.vax) [%cell %noun %noun])
+```
+
+---
+
+## `++swat`
+
+Deferred `++slap`
+
+This is the same as [`++slap`](#slap) except `tap` is the subject `vase`
+encapsulated in a `trap`, and a `(trap vase)` is produced.
+
+#### Accepts
+
+`tap` is a `(trap vase)`.
+
+`gen` is `hoon`.
+
+#### Produces
+
+A `(trap vase)`.
+
+#### Source
+
+```hoon
+++  swat
+  |=  [tap=(trap vase) gen=hoon]
+  ^-  (trap vase)
+  =/  gun  (~(mint ut p:$:tap) %noun gen)
+  |.  ~+
+  [p.gun .*(q:$:tap q.gun)]
+```
+
+#### Examples
+
+```
+> %.  10
+  !<  $-(@ @)
+  %-  road
+  %+  swat
+    |.(!>(add-42=(cury add 42)))
+  (ream '|=(a=@ (add-42 a))')
+52
 ```
 
 ---

--- a/content/docs/hoon/reference/stdlib/5d.md
+++ b/content/docs/hoon/reference/stdlib/5d.md
@@ -4,4 +4,318 @@ weight = 46
 template = "doc.html"
 +++
 
-(To be documented)
+## `++vang`
+
+Set `++vast` parameters
+
+#### Source
+
+```hoon
+++  vang                                                ::  set ++vast params
+  |=  [bug=? wer=path]                                  ::  bug: debug mode
+  %*(. vast bug bug, wer wer)                           ::  wer: where we are
+```
+
+---
+
+## `++vast`
+
+Main parsing core
+
+### Source
+
+This core is too large to include here, please refer to `hoon.hoon` for the
+source.
+
+---
+
+### `++vest`
+
+Parse hoon
+
+Parsing `rule`. Parse hoon of any form.
+
+#### Source
+
+```hoon
+++  vest
+  ~/  %vest
+  |=  tub=nail
+  ^-  (like hoon)
+  %.  tub
+  %-  full
+  (ifix [gay gay] tall:vast)
+```
+
+#### Examples
+
+```
+> (rash '(add 1 1)' vest)
+[%cncl p=[%wing p=~[%add]] q=~[[%sand p=%ud q=1] [%sand p=%ud q=1]]]
+
+> (rash '%+  add\0a  1\0a1' vest)
+[%cnls p=[%wing p=~[%add]] q=[%sand p=%ud q=1] r=[%sand p=%ud q=1]]
+```
+
+---
+
+### `++vice`
+
+Parse wide-form hoon
+
+Parse `txt`, a `knot` containing wide-form hoon, to `hoon`.
+
+#### Accepts
+
+`txt` is a `@ta`.
+
+#### Produces
+
+`hoon`.
+
+#### Source
+
+```hoon
+++  vice
+  |=  txt=@ta
+  ^-  hoon
+  (rash txt wide:vast)
+```
+
+#### Examples
+
+```
+> (vice '(add 1 1)')
+[%cncl p=[%wing p=~[%add]] q=~[[%sand p=%ud q=1] [%sand p=%ud q=1]]]
+
+> (vice '%+  add\0a  1\0a1')
+{1 3}
+syntax error
+```
+
+---
+
+## `++make`
+
+Compile cord to nock
+
+Compile `txt`, a cord containing hoon, to `nock`.
+
+#### Accepts
+
+`txt` is a `@`.
+
+#### Produces
+
+`nock`.
+
+#### Source
+
+```hoon
+++  make
+  |=  txt=@
+  q:(~(mint ut %noun) %noun (ream txt))
+```
+
+#### Examples
+
+```
+> (make '[. . .]')
+[p=[%0 p=1] q=[p=[%0 p=1] q=[%0 p=1]]]
+
+> .*(42 (make '[. . .]'))
+[42 42 42]
+```
+
+---
+
+## `++rain`
+
+Parse with % path
+
+Parse `txt`, a cord containing hoon, to `hoon`. Any `%` path short-hands are
+replaced with the path given in `bon`. If parsing fails, `bon` is also printed
+to the terminal.
+
+#### Accepts
+
+`bon` is a `path`.
+
+`txt` is an atom.
+
+#### Produces
+
+`hoon`.
+
+#### Source
+
+```hoon
+++  rain
+  |=  [bon=path txt=@]
+  ^-  hoon
+  =+  vaz=vast
+  ~|  bon
+  (scan (trip txt) (full (ifix [gay gay] tall:vaz(wer bon))))
+```
+
+#### Examples
+
+```
+> (rain /a/b/c '%')
+[%clsg p=~[[%sand p=%ta q=97] [%sand p=%ta q=98] [%sand p=%ta q=99]]]
+
+> !<(path (slap !>(~) (rain /a/b/c '%')))
+/a/b/c
+
+> (rain / '(add 1 1)')
+[%cncl p=[%wing p=~[%add]] q=~[[%sand p=%ud q=1] [%sand p=%ud q=1]]]
+
+> !<(@ud (slap !>(add=add) (rain / '(add 1 1)')))
+2
+```
+
+---
+
+## `++ream`
+
+Parse cord to hoon
+
+Parse cord `txt` to `hoon`.
+
+#### Accepts
+
+`txt` is an atom.
+
+#### Produces
+
+`hoon`.
+
+#### Source
+
+```hoon
+++  ream
+  |=  txt=@
+  ^-  hoon
+  (rash txt vest)
+```
+
+#### Examples
+
+```
+> !<(tape (slap !>(~) (ream '"foobar"')))
+"foobar"
+```
+
+---
+
+## `++reck`
+
+Parse hoon file
+
+Parse `bon` to `hoon`. `bon` is a `path` to a .hoon file without the mark.
+
+#### Accepts
+
+`bon` is a `path`.
+
+#### Produces
+
+`hoon`.
+
+#### Source
+
+```hoon
+++  reck
+  |=  bon=path
+  (rain bon .^(@t %cx (weld bon `path`[%hoon ~])))
+```
+
+#### Examples
+
+```
+> (reck %/gen/code)
+[ %clhp
+  p=[%rock p=%tas q=7.954.803]
+    q
+  [ %brts
+      p
+    [ %bccl
+        p
+      [   i
+        [ %bccl
+            p
+          [   i
+            [%bcts p=term=%now q=[%base p=[%atom p=~.da]]]
+              t
+......(truncated for brevity)..........
+```
+
+---
+
+## `++ride`
+
+End-to-end compiler
+
+Parse and compile cord `txt`, producing a pair of its `type` and compiled
+`nock`. The `typ` argument specifies the `type` of the subject.
+
+#### Accepts
+
+`typ` is a `type`
+
+`txt` is an atom.
+
+#### Produces
+
+A `(pair type nock)`.
+
+#### Source
+
+```hoon
+++  ride
+  |=  [typ=type txt=@]
+  ^-  (pair type nock)
+  ~>  %slog.[0 leaf/"ride: parsing"]
+  =/  gen  (ream txt)
+  ~>  %slog.[0 leaf/"ride: compiling"]
+  ~<  %slog.[0 leaf/"ride: compiled"]
+  (~(mint ut typ) %noun gen)
+```
+
+#### Examples
+
+```
+ride: parsing
+ride: compiling
+ride: compiled
+> (ride -:!>(.) '(add 2 2)')
+[ #t/@
+    q
+  [ %8
+    p=[%9 p=36 q=[%0 p=1.023]]
+      q
+    [ %9
+      p=2
+        q
+      [ %10
+          p
+        [ p=6
+            q
+          [ p=[%7 p=[%0 p=3] q=[%1 p=2]]
+            q=[%7 p=[%0 p=3] q=[%1 p=2]]
+          ]
+        ]
+        q=[%0 p=2]
+      ]
+    ]
+  ]
+]
+
+ride: parsing
+ride: compiling
+> (ride %noun '(add 2 2)')
+-find.add
+dojo: hoon expression failed
+```
+
+---

--- a/content/docs/hoon/reference/stdlib/5d.md
+++ b/content/docs/hoon/reference/stdlib/5d.md
@@ -99,7 +99,8 @@ syntax error
 
 Compile cord to nock
 
-Compile `txt`, a cord containing hoon, to `nock`.
+Compile `txt`, an `atom` containing hoon source code as little-endian UTF-8
+text, to `nock`.
 
 #### Accepts
 
@@ -133,9 +134,9 @@ Compile `txt`, a cord containing hoon, to `nock`.
 
 Parse with % path
 
-Parse `txt`, a cord containing hoon, to `hoon`. Any `%` path short-hands are
-replaced with the path given in `bon`. If parsing fails, `bon` is also printed
-to the terminal.
+Parse `txt`, an `atom` containing hoon source code as little-endian UTF-8 text,
+to `hoon`. Any `%` path short-hands are replaced with the path given in `bon`.
+If parsing fails, `bon` is also printed to the terminal.
 
 #### Accepts
 
@@ -180,7 +181,8 @@ to the terminal.
 
 Parse cord to hoon
 
-Parse cord `txt` to `hoon`.
+Parse `txt`, an `atom` containing hoon source code as little-endian UTF-8 text,
+to `hoon`.
 
 #### Accepts
 

--- a/content/docs/hoon/reference/stdlib/5e.md
+++ b/content/docs/hoon/reference/stdlib/5e.md
@@ -1,7 +1,332 @@
 +++
-title = "5e: Caching Compiler"
+title = "5e: Molds and mold builders"
 weight = 47
 template = "doc.html"
 +++
 
-(To be documented)
+## `+$mane`
+
+XML name+space
+
+XML tag name and optional namespace.
+
+#### Source
+
+```hoon
++$  mane  $@(@tas [@tas @tas])
+```
+
+#### Examples
+
+```
+> (en-xml:html ;foo;)
+"<foo></foo>"
+
+> (en-xml:html ;foo_bar;)
+"<foo:bar></foo:bar>"
+
+> `manx`;foo_bar;
+[g=[n=[%foo %bar] a=~] c=~]
+
+> `mane`n.g:`manx`;foo_bar;
+[%foo %bar]
+
+> `mane`n.g:`manx`;foo;
+%foo
+```
+
+---
+
+## `+$manx`
+
+Dynamic XML node
+
+An XML element which may contain text, attributes, and other elements.
+
+`g` is a [`$marx`](#marx) (a tag) and `c` is a
+[`$marl`](#marl) (its contents).
+
+#### Source
+
+```hoon
++$  manx  $~([[%$ ~] ~] [g=marx c=marl])
+```
+
+#### Examples
+
+```
+> *manx
+[g=[n=%$ a=~] c=~
+
+> `manx`;foo;
+[g=[n=%foo a=~] c=~]
+
+> (en-xml:html `manx`;foo;)
+"<foo></foo>"
+
+> =a ^-  manx
+     ;foo
+       ;bar: abc
+       ;baz
+         ;xxx: hello
+       ==
+     ==
+
+> a
+[ g=[n=%foo a=~]
+    c
+  ~[
+    [ g=[n=%bar a=~]
+      c=~[[g=[n=%$ a=~[[n=%$ v="abc"]]] c=~]]
+    ]
+    [ g=[n=%baz a=~]
+        c
+      ~[
+        [ g=[n=%xxx a=~]
+          c=~[[g=[n=%$ a=~[[n=%$ v="hello"]]] c=~]]
+        ]
+      ]
+    ]
+  ]
+]
+
+> (en-xml:html a)
+"<foo><bar>abc</bar><baz><xxx>hello</xxx></baz></foo>"
+```
+
+---
+
+## `+$marl`
+
+XML node list
+
+A list of XML nodes ([`$marx`](#marx)).
+
+#### Source
+
+```hoon
++$  marl  (list manx)
+```
+
+#### Examples
+
+```
+> *marl
+~
+
+> ^-  marl
+  ;=
+    ;foo: abc
+    ;bar: def
+  ==
+~[
+  [g=[n=%foo a=~] c=~[[g=[n=%$ a=~[[n=%$ v=~['a' 'b' 'c']]]] c=~]]]
+  [g=[n=%bar a=~] c=~[[g=[n=%$ a=~[[n=%$ v=~['d' 'e' 'f']]]] c=~]]]
+]
+
+> %-  en-xml:html
+  ;baz
+    ;=
+      ;foo: abc
+      ;bar: def
+    ==
+  ==
+"<baz><foo>abc</foo><bar>def</bar></baz>"
+```
+
+---
+
+## `+$mars`
+
+XML cdata
+
+#### Source
+
+```hoon
++$  mars  [t=[n=%$ a=[i=[n=%$ v=tape] t=~]] c=~]
+```
+
+---
+
+## `+$mart`
+
+XML attributes
+
+A list of atributes for an XML tag. For each list item, `n` is a
+[`$mane`](#mane) (an attribute name with optional namespace) and `v` is
+a `tape` (the attribute itself).
+
+#### Source
+
+```hoon
++$  mart  (list [n=mane v=tape])
+```
+
+#### Examples
+
+```
+> *mart
+~
+
+> `manx`;foo.bar;
+[g=[n=%foo a=~[[n=%class v="bar"]]] c=~]
+
+> `mart`a.g:`manx`;foo.bar;
+~[[n=%class v="bar"]]
+
+> (en-xml:html ;foo.bar;)
+"<foo class=\"bar\"></foo>"
+```
+
+---
+
+## `+$marx`
+
+Dynamic XML tag
+
+An XML tag with optional attributes. `n` is a [`$mane`](#mane) (the tag
+name with optional namespace) and `a` is a [`$mart`](marthoot) (any XML
+attributes).
+
+#### Source
+
+```hoon
++$  marx  $~([%$ ~] [n=mane a=mart])
+```
+
+#### Examples
+
+```
+> `manx`;foo.bar;
+[g=[n=%foo a=~[[n=%class v="bar"]]] c=~]
+
+> `marx`g:`manx`;foo.bar;
+[n=%foo a=~[[n=%class v="bar"]]]
+
+> (en-xml:html ;foo.bar;)
+"<foo class=\"bar\"></foo>"
+```
+
+---
+
+## `+$mite`
+
+MIME type
+
+This type represents a MIME type like `text/plain` as a `path`.
+
+#### Source
+
+```hoon
++$  mite  (list @ta)
+```
+
+#### Examples
+
+```
+> `mite`/text/plain
+/text/plain
+```
+
+---
+
+## `+$pass`
+
+Public key
+
+This type is used for a ship's public key, as an atom.
+
+#### Source
+
+```hoon
++$  pass  @
+```
+
+---
+
+## `+$ring`
+
+Private key
+
+This type is used for a ship's private key, as an atom.
+
+#### Source
+
+```hoon
++$  ring  @
+```
+
+---
+
+## `+$ship`
+
+Network identity
+
+Just an `@p`
+
+#### Source
+
+```hoon
++$  ship  @p
+```
+
+#### Examples
+
+```
+> *ship
+~zod
+
+> `ship`~sampel-palnet
+~sampel-palnet
+```
+
+---
+
+## `+$shop`
+
+Urbit/DNS identity
+
+Either a [`$ship`](#ship) or a domain name as a `path`.
+
+#### Source
+
+```hoon
++$  shop  (each ship (list @ta))
+```
+
+---
+
+## `+$spur`
+
+ship desk case spur
+
+The part of a Clay `path` after the `%`.
+
+#### Source
+
+```hoon
++$  spur  path
+```
+
+---
+
+## `+$time`
+
+Galactic time
+
+Just a `@da`
+
+#### Source
+
+```hoon
++$  time  @da
+```
+
+#### Examples
+
+```
+> *time
+~2000.1.1
+```
+
+---

--- a/content/docs/hoon/reference/stdlib/5f.md
+++ b/content/docs/hoon/reference/stdlib/5f.md
@@ -1,171 +1,194 @@
 +++
-title = "5f: Molds and Mold-Builders"
+title = "5f: Profiling support"
 weight = 48
 template = "doc.html"
 +++
 
-## `++mane`
+## `++pi-heck`
 
-XML name
-
-An XML name (tag name or attribute name) with an optional namespace. Parsed by
-`++name:de-xml:html` in `zuse.hoon`, rendered by `++name:en-xml:html` in `zuse.hoon`.
+Profiling utility
 
 #### Source
 
 ```hoon
-        ++  mane  $@(@tas [@tas @tas])                          ::  XML name/space
-```
-
-#### Examples
-
-See also: `++sail`
-
-```
-    > *mane
-    %$
-
-    > `mane`n.g:`manx`;div:namespace;
-    %div
-    > `mane`n.g:`manx`;div_namespace;
-    [%div %namespace]
+++  pi-heck
+    |=  [nam=@tas day=doss]
+    ^-  doss
+    =+  lam=(~(get by hit.day) nam)
+    day(hit (~(put by hit.day) nam ?~(lam 1 +(u.lam))))
 ```
 
 ---
 
-## `++manx`
+## `++pi-noon`
 
-XML node.
-
-Parsed by `++apex` within `++apex:de-xml:html` in `zuse.hoon`, rendered by `++apex:en-xml:html` in `zuse.hoon`.
+Sample trace
 
 #### Source
 
 ```hoon
-        ++  manx  {g/marx c/marl}                              ::  XML node
-```
-
-#### Examples
-
-See also: `++sail` doc
-
----
-
-## `++marl`
-
-List of XML nodes
-
-A list of `++manx`.
-
-#### Source
-
-```hoon
-        ++  marl  (list manx)                                   ::  XML node list
-```
-
-#### Examples
-
----
-
-## `++mars`
-
-XML CDATA
-
-Implicitly produced by `++chrd` within `++chrd:de-xml:html`
-
-#### Source
-
-```hoon
-    ++  mars  {t/{n/$$ a/{i/{n/$$ v/tape} t/$~}} c/$~}      ::  XML cdata
-```
-
-#### Examples
-
----
-
-## `++mart`
-
-List of XML attributes
-
-Each `++mart` is a list of pairs of `++mane` and
-`++tape`.
-
-Parsed by `++attr:de-xml:html` in `zuse.hoon`, rendered by `++attr:en-xml:html` in `zuse.hoon`.
-
-#### Source
-
-```hoon
-    ++  mart  (list {n/mane v/tape})                       ::  XML attributes
-```
-
-#### Examples
-
----
-
-## `++marx`
-
-XML tag
-
-A `++marx` is a pair of a tag name, `++mane` and a list of attributes,
-`++mart`. Parsed by `++head:de-xml:html` in `zuse.hoon`, rendered within `++de-xml:html` in `zuse.hoon`.
-
-#### Source
-
-```hoon
-    ++  marx  {n/mane a/mart}                              ::  XML tag
-```
-
-#### Examples
-
----
-
-## `++pass`
-
-Atom alias
-
-Used primarily in crypto.
-
-#### Source
-
-```hoon
-        ++  pass  @                                            ::  public key
+++  pi-noon
+  |=  [mot=term paz=(list path) day=doss]
+  =|  lax=(unit path)
+  |-  ^-  doss
+  ?~  paz  day(mon (pi-mope mot mon.day))
+  %=    $
+      paz  t.paz
+      lax  `i.paz
+      cut.day
+    %+  ~(put by cut.day)  i.paz
+    ^-  hump
+    =+  nax=`(unit path)`?~(t.paz ~ `i.t.paz)
+    =+  hup=`hump`=+(hup=(~(get by cut.day) i.paz) ?^(hup u.hup [*moan ~ ~]))
+    :+  (pi-mope mot mon.hup)
+      ?~  lax  out.hup
+      =+  hag=(~(get by out.hup) u.lax)
+      (~(put by out.hup) u.lax ?~(hag 1 +(u.hag)))
+    ?~  nax  inn.hup
+    =+  hag=(~(get by inn.hup) u.nax)
+    (~(put by inn.hup) u.nax ?~(hag 1 +(u.hag)))
+  ==
 ```
 
 ---
 
-## `++ring`
+## `++pi-mope`
 
-Atom alias
-
-Used primarily in crypto.
+Add sample
 
 #### Source
 
 ```hoon
-        ++  ring  @                                            ::  private key
+++  pi-mope
+  |=  [mot=term mon=moan]
+  ?+  mot  mon
+    %fun  mon(fun +(fun.mon))
+    %noc  mon(noc +(noc.mon))
+    %glu  mon(glu +(glu.mon))
+    %mal  mon(mal +(mal.mon))
+    %far  mon(far +(far.mon))
+    %coy  mon(coy +(coy.mon))
+    %euq  mon(euq +(euq.mon))
+  ==
 ```
 
 ---
 
-## `++time`
+## `++pi-moth`
 
-Absolute date
-
-The `@da` aura designates an absolute date atom.
+Count sample
 
 #### Source
 
 ```hoon
-        ++  time  @da                                          ::  galactic time
+++  pi-moth
+  |=  mon=moan  ^-  @ud
+  :(add fun.mon noc.mon glu.mon mal.mon far.mon coy.mon euq.mon)
 ```
 
-#### Examples
+---
 
-See also: `++date`, aura reference
+## `++pi-mumm`
 
+Print sample
+
+#### Source
+
+```hoon
+++  pi-mumm
+  |=  mon=moan  ^-  tape
+  =+  tot=(pi-moth mon)
+  ;:  welp
+    ^-  tape
+    ?:  =(0 noc.mon)  ~
+    (welp (scow %ud (div (mul 100 noc.mon) tot)) "n ")
+  ::
+    ^-  tape
+    ?:  =(0 fun.mon)  ~
+    (welp (scow %ud (div (mul 100 fun.mon) tot)) "c ")
+  ::
+    ^-  tape
+    ?:  =(0 glu.mon)  ~
+    (welp (scow %ud (div (mul 100 glu.mon) tot)) "g ")
+  ::
+    ^-  tape
+    ?:  =(0 mal.mon)  ~
+    (welp (scow %ud (div (mul 100 mal.mon) tot)) "m ")
+  ::
+    ^-  tape
+    ?:  =(0 far.mon)  ~
+    (welp (scow %ud (div (mul 100 far.mon) tot)) "f ")
+  ::
+    ^-  tape
+    ?:  =(0 coy.mon)  ~
+    (welp (scow %ud (div (mul 100 coy.mon) tot)) "y ")
+  ::
+    ^-  tape
+    ?:  =(0 euq.mon)  ~
+    (welp (scow %ud (div (mul 100 euq.mon) tot)) "e ")
+  ==
 ```
-    > `time`~2014.1.1
-    ~2014.1.1
+
+---
+
+## `++pi-tell`
+
+Produce dump
+
+#### Source
+
+```hoon
+++  pi-tell
+  |=  day=doss
+  ^-  (list tape)
+  ?:  =(day *doss)  ~
+  =+  tot=(pi-moth mon.day)
+  ;:  welp
+    [(welp "events: " (pi-mumm mon.day)) ~]
+  ::
+    %+  turn
+      %+  sort  ~(tap by hit.day)
+      |=  [a=[* @] b=[* @]]
+      (lth +.a +.b)
+    |=  [nam=term num=@ud]
+    :(welp (trip nam) ": " (scow %ud num))
+    ["" ~]
+  ::
+    %-  zing
+    ^-  (list (list tape))
+    %+  turn
+      %+  sort  ~(tap by cut.day)
+      |=  [one=(pair path hump) two=(pair path hump)]
+      (gth (pi-moth mon.q.one) (pi-moth mon.q.two))
+    |=  [pax=path hup=hump]
+    =+  ott=(pi-moth mon.hup)
+    ;:  welp
+      [(welp "label: " (spud pax)) ~]
+      [(welp "price: " (scow %ud (div (mul 100 ott) tot))) ~]
+      [(welp "shape: " (pi-mumm mon.hup)) ~]
+    ::
+      ?:  =(~ out.hup)  ~
+      :-  "into:"
+      %+  turn
+        %+  sort  ~(tap by out.hup)
+        |=([[* a=@ud] [* b=@ud]] (gth a b))
+      |=  [pax=path num=@ud]
+      ^-  tape
+      :(welp "  " (spud pax) ": " (scow %ud num))
+    ::
+      ?:  =(~ inn.hup)  ~
+      :-  "from:"
+      %+  turn
+        %+  sort  ~(tap by inn.hup)
+        |=([[* a=@ud] [* b=@ud]] (gth a b))
+      |=  [pax=path num=@ud]
+      ^-  tape
+      :(welp "  " (spud pax) ": " (scow %ud num))
+    ::
+      ["" ~]
+      ~
+    ==
+  ==
 ```
 
 ---

--- a/content/docs/hoon/reference/stdlib/5g.md
+++ b/content/docs/hoon/reference/stdlib/5g.md
@@ -1,7 +1,0 @@
-+++
-title = "5g: profiling support"
-weight = 49
-template = "doc.html"
-+++
-
-(To be documented)

--- a/content/docs/hoon/reference/stdlib/_index.md
+++ b/content/docs/hoon/reference/stdlib/_index.md
@@ -15,207 +15,255 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### a
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ab' title="Primitive parser engine"><code>++ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#abs-fl' title="Absolute value"><code>++abs:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#abs-si' title="Absolute value (signed integer)"><code>++abs:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#abel' title="Compiler alias"><code>++abel</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#absfl' title="Absolute value"><code>++abs:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#abssi' title="Absolute value (signed integer)"><code>++abs:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#abel' title="Original sin: type"><code>+$abel</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#ace' title="Parse space"><code>++ace</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#a-coco' title="Render decimal"><code>++a-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#add' title="Add"><code>++add</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#add-ff' title="Add (floating point)"><code>++add:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#add-fl' title="Add (with exact/rounded flag)"><code>++add:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#add-ja' title="Prepend to list"><code>++add:ja</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#add-rd' title="Add (double-precision float)"><code>++add:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#add-rh' title="Add (half-precision float)"><code>++add:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#add-rs' title="Add (single-precision float)"><code>++add:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#add-rq' title="Add (quad-precision float)"><code>++add:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ag' title="Top-level atom parser engine"><code>++ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addff' title="Add (floating point)"><code>++add:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addfl' title="Add (with exact/rounded flag)"><code>++add:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#addja' title="Prepend to list"><code>++add:ja</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addrd' title="Add (doubleprecision float)"><code>++add:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addrh' title="Add (halfprecision float)"><code>++add:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addrs' title="Add (singleprecision float)"><code>++add:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addrq' title="Add (quadprecision float)"><code>++add:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#aftr' title="Pair after"><code>++aftr</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ag' title="Toplevel atom parser engine"><code>++ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/#ah' title="Tiki engine"><code>++ah</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#alas' title="Alias list"><code>+$alas</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#alf' title="Parse alphabetic characters"><code>++alf</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#all-by' title="Logical AND (map and wet gate)"><code>++all:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#all-in' title="Logical AND (set and wet gate)"><code>++all:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#allby' title="Logical AND (map and wet gate)"><code>++all:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#allin' title="Logical AND (set and wet gate)"><code>++all:in</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#aln' title="Parse alphanumeric characters"><code>++aln</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#alp' title="Parse alphanumeric characters and -"><code>++alp</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#any-by' title="Logical OR (map and wet gate)"><code>++any:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#any-in' title="Logical OR (set and gate)"><code>++any:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#alp' title="Parse alphanumeric characters and "><code>++alp</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#anyby' title="Logical OR (map and wet gate)"><code>++any:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#anyin' title="Logical OR (set and gate)"><code>++any:in</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#aor' title="Alphabetical order"><code>++aor</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ape-ag' title="Parse 0 or rule"><code>++ape:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#apt-by' title="Check correctness (map)"><code>++apt:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#apt-in' title="Check correctness (set)"><code>++apt:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#at' title="(Undocumented)"><code>++at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#aura' title="'Type' of atom"><code>++aura</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#axis' title="Nock axis"><code>++axis</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/#ap' title="Hoon engine"><code>++ap</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#apeag' title="Parse 0 or rule"><code>++ape:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#aptby' title="Check correctness (map)"><code>++apt:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#aptin' title="Check correctness (set)"><code>++apt:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#aptto' title="Check correctness of queue"><code>++apt:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#at' title="Basic printing"><code>++at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#atom' title="Just an atom"><code>+$atom</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#aura' title="'Type' of atom"><code>+$aura</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/#ax' title="Spec engine"><code>++ax</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#axis' title="Tree address"><code>+$axis</code></a>
 
 ### b
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#bal-to' title="Balance queue"><code>++bal:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#bake' title="Convert wet gate to dry gate"><code>++bake</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#balto' title="Balance queue"><code>++bal:to</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#bar' title="Parse | (bar)"><code>++bar</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#bas' title="Parse \ (bas)"><code>++bas</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#base' title="Base type"><code>++base</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#bass' title="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bay-ag' title="Parses binary number"><code>++bay:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#bean' title="Boolean"><code>++bean</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#beer' title="Tape builder"><code>++beer</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#beet' title="XML interpolation cases"><code>++beet</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#base' title="Base type"><code>+$base</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#bass' title="Parser modifier (LSBordered ++list as atom of ++base)"><code>++bass</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bayag' title="Parses binary number"><code>++bay:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#bean' title="Boolean"><code>+$bean</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#beerhoot' title="Simple embed"><code>+$beer:hoot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#bend' title="Conditional composer"><code>++bend</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#bet' title="Parse hep and lus axis syntax"><code>++bet</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#bex' title="Binary exponent"><code>++bex</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bif-ff' title="Converts from fn to @r"><code>++bif:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#bif-by' title="Bifurcate map"><code>++bif:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#bif-in' title="Bifurcate set"><code>++bif:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bifff' title="Converts from fn to @r"><code>++bif:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#bifby' title="Bifurcate map"><code>++bif:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#bifin' title="Bifurcate set"><code>++bif:in</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#biff' title="Unit as argument"><code>++biff</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#bin' title="Binary to atom"><code>++bin</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#bind' title="Non-unit function to unit, producing unit"><code>++bind</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bip-ag' title="Parse IPv6"><code>++bip:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bit-ff' title="fn to @r with rounding"><code>++bit:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bit-rd' title="fn to double-precision binary float"><code>++bit:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bit-rh' title="fn to half-precision float"><code>++bit:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bit-rs' title="fn to single-precision float"><code>++bit:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bit-rq' title="fn to quad-precision float"><code>++bit:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bix-ab' title="Parse hex pair"><code>++bix:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#bisk-so' title="Parse aura-atom pair"><code>++bisk:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#bloq' title="Blocksize"><code>++bloq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#bind' title="Nonunit function to unit, producing unit"><code>++bind</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bipag' title="Parse IPv6"><code>++bip:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bitff' title="fn to @r with rounding"><code>++bit:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bitrd' title="fn to doubleprecision binary float"><code>++bit:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bitrh' title="fn to halfprecision float"><code>++bit:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bitrs' title="fn to singleprecision float"><code>++bit:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bitrq' title="fn to quadprecision float"><code>++bit:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#bite' title="Atom slice specificier"><code>$bite</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bixab' title="Parse hex pair"><code>++bix:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#biskso' title="Parse auraatom pair"><code>++bisk:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#block' title="Abstract identity of resource awaited"><code>+$block</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#bloq' title="Blocksize"><code>$bloq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#bond' title="Replace null"><code>++bond</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#bool' title="Make loobean (compiler utility)"><code>++bool</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#boss' title="Parser modifier: LSB"><code>++boss</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#both' title="Group unit values into pair"><code>++both</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#buc' title="Parse $ (buc)"><code>++buc</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#but' title="Parse binary digit"><code>++but</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#byts' title="bytes, LSB first"><code>+$byts</code></a>
 
 ### c
 
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#cne' title="Render base58check"><code>++c:ne</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#cab' title="Parse _ (cab)"><code>++cab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#cain' title="Tank pretty-print"><code>++cain</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#can' title="Assemble"><code>++can</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1b/#cap' title="Tree head"><code>++cap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#cass' title="To lowercase"><code>++cass</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#cat' title="Concatenate"><code>++cat</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#c-coco' title="Render base58check"><code>++c-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cell' title="Make %cell type (compiler utility)"><code>++cell</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#cen' title="Parse % (cen)"><code>++cen</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#cet-yo' title="Days in a century"><code>++cet:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#char' title="Character"><code>++char</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#chum' title="Jet hint information"><code>++chum</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#cetyo' title="Days in a century"><code>++cet:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#chafa' title="Decode base58check character"><code>++cha:fa</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#char' title="Character"><code>+$char</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#chum' title="Jet hint information"><code>+$chum</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#cit' title="Octal digit"><code>++cit</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#clap' title="Apply function to two units"><code>++clap</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#cmp-si' title="Compare (signed integer)"><code>++cmp:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#clap' title="Combine two units with function"><code>++clap</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#clef' title="Compose two units with function"><code>++clef</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#cmpsi' title="Compare (signed integer)"><code>++cmp:si</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#co' title="Literal rendering engine"><code>++co</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#coil' title="Tuple of core information"><code>++coil</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#coin' title="Noun-literal syntax cases"><code>++coin</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#coil' title="Tuple of core information"><code>+$coil</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#coin' title="Nounliteral syntax cases"><code>+$coin</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#col' title="Parse : (col)"><code>++col</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#cold' title="Replace with constant"><code>++cold</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#com' title="Parse , (com)"><code>++com</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#comb' title="Combine two formulas (compiler utility)"><code>++comb</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#comp' title="Arbitrary compose"><code>++comp</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2d/#con' title="Binary OR"><code>++con</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cond' title="?: compile (compiler utility)"><code>++cond</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cons' title="Make formula cell (compiler utility)"><code>++cons</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#cook' title="Apply gate"><code>++cook</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#cord' title="UTF-8 text"><code>++cord</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#cord' title="UTF8 text"><code>+$cord</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#core' title="Make %core type (compiler utility)"><code>++core</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#cork' title="Compose forward"><code>++cork</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#corl' title="Compose backward"><code>++corl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cove' title="Extract [0 *] axis (compiler utility)"><code>++cove</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#crib' title="Summary and details"><code>+$crib</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#crip' title="Tape to cord"><code>++crip</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#crub-so' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#crubso' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#cue' title="Unpack atom to noun"><code>++cue</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#curr' title="Right-curry a gate"><code>++curr</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#curr' title="Rightcurry a gate"><code>++curr</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#cury' title="Curry left a gate"><code>++cury</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#cuss' title="To uppercase"><code>++cuss</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#cut' title="Slice"><code>++cut</code></a>
 
 ### d
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#d-ne' title="Render decimal"><code>++d:ne</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#date' title="Point in time"><code>++date</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#day-yo' title="Seconds in day"><code>++day:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#dne' title="Render decimal"><code>++d:ne</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#date' title="Parsed date"><code>+$date</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#dayyo' title="Seconds in day"><code>++day:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#d-coco' title="Render decimal with min length"><code>++d-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#dec' title="Decrement"><code>++dec</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#del-by' title="Delete (map)"><code>++del:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#del-in' title="Delete (set)"><code>++del:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#del-ju' title="Delete (jug)"><code>++del:ju</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#delby' title="Delete (map)"><code>++del:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#delin' title="Delete (set)"><code>++del:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#delju' title="Delete (jug)"><code>++del:ju</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#dem' title="Decimal to atom"><code>++dem</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#dem-ag' title="Parse decmal with dots"><code>++dem:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#den-fl' title="Denormalizes (floating point)"><code>++den:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#dep-to' title="Maximum depth (queue)"><code>++dep:to</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#dif-fe' title="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#dif-fo' title='Subtraction (modular base)'><code>++dif:fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#dif-in' title='Difference (set)'><code>++dif:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#dif-si' title="Subtraction (signed integer)"><code>++dif:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#dig-by' title="Address of key (map)"><code>++dig:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#dig-in' title="Address of a in set"><code>++dig:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#dim-ag' title="Parse decimal number"><code>++dim:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#dime' title="Aura-atom pair"><code>++dime</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#din-re' title="(Undocumented)"><code>++din:re</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#demag' title="Parse decmal with dots"><code>++dem:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#denfa' title="Decode base58check"><code>++den:fa</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#denfl' title="Denormalizes (floating point)"><code>++den:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#depto' title="Maximum depth (queue)"><code>++dep:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#difby' title="Difference between maps"><code>++dif:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#diffe' title="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#diffo' title='Subtraction (modular base)'><code>++dif:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#difin' title='Difference (set)'><code>++dif:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#difsi' title="Subtraction (signed integer)"><code>++dif:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#digby' title="Address of key (map)"><code>++dig:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#digin' title="Address of a in set"><code>++dig:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#dimag' title="Parse decimal number"><code>++dim:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#dime' title="Auraatom pair"><code>+$dime</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2d/#dis' title="Binary AND (atoms)"><code>++dis</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#dit' title="Decimal digit"><code>++dit</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#div' title="Divide"><code>++div</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#div-ff' title="Divide (IEEE float)"><code>++div:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#div-fl' title="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#div-rd' title="Double precision float"><code>++div:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#div-rh' title="Divide (half-precision float)"><code>++div:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#div-rs' title="Divide (single-precision float)"><code>++div:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#div-rq' title="Divide (quad-precision float)"><code>++div:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#divff' title="Divide (IEEE float)"><code>++div:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#divfl' title="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#divrd' title="Double precision float"><code>++div:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#divrh' title="Divide (halfprecision float)"><code>++div:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#divrs' title="Divide (singleprecision float)"><code>++div:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#divrq' title="Divide (quadprecision float)"><code>++div:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#dof' title="Hep & optional gap"><code>++dof</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#dog' title="Optional gap"><code>++dog</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#doh' title="@p separator"><code>++doh</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#doq' title="Parse double quote"><code>++doq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#dor' title="Numeric order"><code>++dor</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#dor' title="Depth order"><code>++dor</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#doss' title="Profiling"><code>+$doss</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#dot' title="Parse period"><code>++dot</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drg-ff' title="@r to decimal float"><code>++drg:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drg-fl' title="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drg-rd' title="@rd to decimal float"><code>++drg:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drg-rh' title="@rh to decimal float"><code>++drg:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drg-rs' title="@rs to decimal float"><code>++drg:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drg-rq' title="@rq to decimal float"><code>++drg:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgff' title="@r to decimal float"><code>++drg:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgfl' title="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgrd' title="@rd to decimal float"><code>++drg:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgrh' title="@rh to decimal float"><code>++drg:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgrs' title="@rs to decimal float"><code>++drg:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgrq' title="@rq to decimal float"><code>++drg:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#drop' title="Unit to list"><code>++drop</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#dul-si' title="Modulus (signed integer)"><code>++dul:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#dum-ag' title="Parse decimal with leading zero"><code>++dum:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#dun' title="-- to ~"><code>++dun</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#dulsi' title="Modulus (signed integer)"><code>++dul:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#dumag' title="Parse decimal with leading zero"><code>++dum:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#dun' title=" to ~"><code>++dun</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#duz' title="== to ~"><code>++duz</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#dvr' title="Divide (with remainder)"><code>++dvr</code></a>
 
 ### e
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ead-fl' title="Exact add"><code>++ead:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#eadfl' title="Exact add"><code>++ead:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#each' title="Mold of fork between two types"><code>++each</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#easy' title="Always parse"><code>++easy</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#edge' title="Parsing location metadata"><code>++edge</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ed-coco' title="Format with decimal place"><code>++ed-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#edge' title="Parsing location metadata"><code>+$edge</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#effob' title="murmur3-based pseudorandom function"><code>++eff:ob</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#egcd' title="Extended Euclidean algorithm"><code>++egcd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emn-fl' title="Minimum exponent"><code>++emn:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emu-fl' title="Exact multiply"><code>++emu:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emx-fl' title="Maximum exponent"><code>++emx:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#em-coco' title="Render in numeric base"><code>++em-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emnfl' title="Minimum exponent"><code>++emn:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emufl' title="Exact multiply"><code>++emu:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emxfl' title="Maximum exponent"><code>++emx:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#encfa' title="Encode base58check"><code>++enc:fa</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#end' title="Tail"><code>++end</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equ-ff' title="Equals (IEEE float)"><code>++equ:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equ-fl' title="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equ-rd' title="Equals (double-precision float)"><code>++equ:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equ-rh' title="Equals (half-precision float)"><code>++equ:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equ-rs' title="Equals (single-precision float)"><code>++equ:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equ-rq' title="Equals (quad-precision float)"><code>++equ:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#era-yo' title="Leap-year period"><code>++era:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exp-ff' title="Get exponent (IEEE float)"><code>++exp:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#exp-fo' title="Exponent (modular base)"><code>++exp:fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exp-rd' title="Exponent (@rd)"><code>++exp:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exp-rh' title="Exponent (half-precision float)"><code>++exp:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exp-rs' title="Exponent (@rs)"><code>++exp:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exp-rq' title="Exponent (quad-precision float)"><code>++exp:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equff' title="Equals (IEEE float)"><code>++equ:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equfl' title="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equrd' title="Equals (doubleprecision float)"><code>++equ:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equrh' title="Equals (halfprecision float)"><code>++equ:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equrs' title="Equals (singleprecision float)"><code>++equ:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equrq' title="Equals (quadprecision float)"><code>++equ:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#erayo' title="Leapyear period"><code>++era:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#expff' title="Get exponent (IEEE float)"><code>++exp:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#expfo' title="Exponent (modular base)"><code>++exp:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exprd' title="Exponent (@rd)"><code>++exp:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exprh' title="Exponent (halfprecision float)"><code>++exp:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exprs' title="Exponent (@rs)"><code>++exp:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exprq' title="Exponent (quadprecision float)"><code>++exp:rq</code></a>
 
 ### f
 
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#fa' title="base58check"><code>++fa</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#face' title="Make %face type (compiler utility)"><code>++face</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#fail' title="Never parse"><code>++fail</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#fall' title="Give unit a default value"><code>++fall</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#fand' title="All indices in list"><code>++fand</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#fas' title="Parse / (fas)"><code>++fas</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#fe' title="Modulo bloq"><code>++fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#fed-ag' title="Parse @p"><code>++fed:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#feen-ob' title="Conceal structure v2"><code>++feen:ob</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#fend-ob' title="Restore structure v2"><code>++fend:ob</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#fice-ob' title="Feistel-like cipher"><code>++fice:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#fedag' title="Parse @p"><code>++fed:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#feob' title="Internal function to +fee"><code>++fe:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#feeob' title="Feistel cipher Fe in B&R (2002)"><code>++fee:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#feenob' title="Reverse +fee"><code>++feen:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#feinob' title="Conceal structure v3"><code>++fein:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#feisob' title="Four-round generalised Feistel cipher over the domain [0, 2^32 - 2^16 - 1]"><code>++feis:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#femab' title="Parse base58check char"><code>++fem:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#fenob' title="Reverse +fe"><code>++fen:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#feqag' title="Parse @q phonetic base"><code>++feq:ag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#fil' title="Fill bloqstream"><code>++fil</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#fimag' title="Parse base58check"><code>++fim:ag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#find' title="First index in list"><code>++find</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#fit-re' title="Fit on one line test"><code>++fit:re</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fli-fl' title="Flip sign"><code>++fli:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#fitz' title="Odor compatibility (compiler utility)"><code>++fitz</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#flag' title="Boolean (flag)"><code>+$flag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#flan' title="Loobean & (compiler utility)"><code>++flan</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#flifl' title="Flip sign"><code>++fli:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#flip' title="Loobean negation (compiler utility)"><code>++flip</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#flit' title="Make filter"><code>++flit</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#flop' title="Reverse list"><code>++flop</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fma-ff' title="Fused multiply-add (IEEE float)"><code>++fma:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fma-fl' title="Fused multiply-add"><code>++fma:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fma-rd' title="Fused multiply-add (@rd)"><code>++fma:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fma-rh' title="Fused multiply-add (half-precision float)"><code>++fma:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fma-rs' title="Fused multiply-add (single-precision float)"><code>++fma:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fma-rq' title="Fused multiply-add (quad-precision float)"><code>++fma:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2e/#fnv' title="FNV scrambler"><code>++fnv</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#flor' title="Loobean | (compiler utility)"><code>++flor</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmaff' title="Fused multiplyadd (IEEE float)"><code>++fma:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmafl' title="Fused multiplyadd"><code>++fma:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmard' title="Fused multiplyadd (@rd)"><code>++fma:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmarh' title="Fused multiplyadd (halfprecision float)"><code>++fma:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmars' title="Fused multiplyadd (singleprecision float)"><code>++fma:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmarq' title="Fused multiplyadd (quadprecision float)"><code>++fma:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#fo' title="Modulo prime"><code>++fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#foot' title="Cases of arms by variance model"><code>++foot</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fos-rh' title="@rs to @rh"><code>++fos:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#fra-fo' title="Divide (modular base)"><code>++fra:fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#fra-si' title="Divide (signed integer)"><code>++fra:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#foot' title="Cases of arms by variance model"><code>+$foot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#fore' title="Pair before"><code>++fore</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#fork' title="Make %fork type (compiler utility)"><code>++fork</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fosrh' title="@rs to @rh"><code>++fos:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#frafo' title="Divide (modular base)"><code>++fra:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#frasi' title="Divide (signed integer)"><code>++fra:si</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#full' title="Parse to end"><code>++full</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#funk' title="Add to tape"><code>++funk</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#fuss' title="Has A or B?"><code>++fuss</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#fyndob' title="Restore structure v3"><code>++fynd:ob</code></a>
 
 ### g
 
@@ -224,86 +272,98 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#gap' title="Plural whitespace"><code>++gap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#gaq' title="End of line"><code>++gaq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#gar' title="Parse > (gar)"><code>++gar</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#gas-by' title="Concatenate (map)"><code>++gas:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#gas-in' title="Concatenate (set)"><code>++gas:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#gas-to' title="Push list into queue"><code>++gas:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#garb' title="Core metadata"><code>+$garb</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#gasby' title="Concatenate (map)"><code>++gas:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#gasin' title="Concatenate (set)"><code>++gas:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#gasju' title="Concatenate (jug)"><code>++gas:ju</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#gasto' title="Push list into queue"><code>++gas:to</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#gate' title="Function"><code>++gate</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#gaw' title="Classic whitespace"><code>++gaw</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#gay' title="Optional gap"><code>++gay</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#get-by' title="Grab unit value"><code>++get:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#get-ja' title="Grab value by key"><code>++get:ja</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#get-ju' title="Retrieve set"><code>++get:ju</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#get-to' title="Head-tail pair"><code>++get:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#getby' title="Grab unit value"><code>++get:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#getja' title="Grab value by key"><code>++get:ja</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#getju' title="Retrieve set"><code>++get:ju</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#getto' title="Headtail pair"><code>++get:to</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#glue' title="Skip delimiter"><code>++glue</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#gon' title="Parse long numbers"><code>++gon</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#gor' title="Hash order"><code>++gor</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#got-by' title="Assert for value (map)"><code>++got:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grd-ff' title="Decimal float to @r"><code>++grd:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grd-fl' title="Decimal to float"><code>++grd:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grd-rd' title="Decimal float to @rd"><code>++grd:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grd-rh' title="Decimal float to @rh"><code>++grd:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grd-rs' title="Decimal float to @rs"><code>++grd:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grd-rq' title="Decimal float to @rq"><code>++grd:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#gor' title="Mug order"><code>++gor</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#gotby' title="Assert for value (map)"><code>++got:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grdff' title="Decimal float to @r"><code>++grd:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grdfl' title="Decimal to float"><code>++grd:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grdrd' title="Decimal float to @rd"><code>++grd:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grdrh' title="Decimal float to @rh"><code>++grd:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grdrs' title="Decimal float to @rs"><code>++grd:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grdrq' title="Decimal float to @rq"><code>++grd:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#gte' title="Greater than / equal"><code>++gte</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gte-ff' title="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gte-fl' title="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gte-rd' title="Greater than / equal (double-precision float)"><code>++gte:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gte-rh' title="Greater than / equal (half-precision float)"><code>++gte:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gte-rs' title="Greater than / equal (single-precision float)"><code>++gte:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gte-rq' title="Greater than / equal (quad-precision float)"><code>++gte:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gteff' title="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gtefl' title="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gterd' title="Greater than / equal (doubleprecision float)"><code>++gte:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gterh' title="Greater than / equal (halfprecision float)"><code>++gte:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gters' title="Greater than / equal (singleprecision float)"><code>++gte:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gterq' title="Greater than / equal (quadprecision float)"><code>++gte:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#gth' title="Greater than"><code>++gth</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gth-ff' title="Greater than (IEEE float)"><code>++gth:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gth-fl' title="Greater than (producing flag)"><code>++gth:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gth-rd' title="Greater than (double-precision float)"><code>++gth:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gth-rh' title="Greater than (half-precision float)"><code>++gth:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gth-rs' title="Greater than (single-precision float)"><code>++gth:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gth-rq' title="Greater than (quad-precision float)"><code>++gth:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gthff' title="Greater than (IEEE float)"><code>++gth:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gthfl' title="Greater than (producing flag)"><code>++gth:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gthrd' title="Greater than (doubleprecision float)"><code>++gth:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gthrh' title="Greater than (halfprecision float)"><code>++gth:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gthrs' title="Greater than (singleprecision float)"><code>++gth:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gthrq' title="Greater than (quadprecision float)"><code>++gth:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#gul' title="Axis syntax < or >"><code>++gul</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#gulf' title="List from range"><code>++gulf</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#gut-by' title="Grab value with defualt"><code>++gut:by</code></a>
 
 ### h
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#hair' title="Parsing line and column"><code>++hair</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#hard' title="Force remold"><code>++hard</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#has-by' title="Key existence check (map)"><code>++has:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#has-in' title="Key existence check (set)"><code>++has:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#has-ju' title="Check contents (jug)"><code>++has:ju</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hafab' title="Parse non-doz phonetic pair"><code>++haf:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#hair' title="Parsing line and column"><code>+$hair</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#hasby' title="Key existence check (map)"><code>++has:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#hasin' title="Key existence check (set)"><code>++has:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#hasju' title="Check contents (jug)"><code>++has:ju</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#hax' title="Parse # (hax)"><code>++hax</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#head' title="Get head of cell"><code>++head</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#here' title="Place-based apply"><code>++here</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#hep' title="Parse - (hep)"><code>++hep</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#help' title="Documentation"><code>+$help</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hefab' title="Parse non-dozzod phonetic pair"><code>++hef:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#here' title="Placebased apply"><code>++here</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#hep' title="Parse  (hep)"><code>++hep</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#hex' title="Hexadecimal to atom"><code>++hex</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hex-ag' title="Parse hexadecimal number"><code>++hex:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hif-ab' title="Parse phonetic pair"><code>++hif:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hexag' title="Parse hexadecimal number"><code>++hex:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hifab' title="Parse phonetic pair"><code>++hif:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#hig' title="Parse single uppercase letter"><code>++hig</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#hike' title="Compiler utility"><code>++hike</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#hint' title="Make %hint type (compiler utility)"><code>++hint</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#hit' title="Parse single hexadecimal digit"><code>++hit</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hofab' title="Parse 2-4 @q phonetic pair"><code>++hof:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#homo' title="Homogenize list"><code>++homo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#hor' title="Horizontal hash order"><code>++hor</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#hor-yo' title="Seconds in hour"><code>++hor:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#huf-ab' title="Parse two phonetic pairs"><code>++huf:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hyf-ab' title="Parse 8 phonetic bytes"><code>++hyf:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#hoon' title="Hoon AST"><code>+$hoon</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#hoot' title="Hoon tools"><code>++hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#horyo' title="Seconds in hour"><code>++hor:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hufab' title="Parse 1-4 @q phonetic pairs"><code>++huf:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#hump' title="Profiling"><code>+$hump</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#hunt' title="Select between two units by a rule"><code>++hunt</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hyfab' title="Parse four @q phonetic pairs"><code>++hyf:ab</code></a>
 
 ### i
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ibl-fl' title="Integer binary logarithm"><code>++ibl:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#iblfl' title="Integer binary logarithm"><code>++ibl:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#ifix' title="Infix"><code>++ifix</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#ind-po' title="Parse suffix"><code>++ind:po</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#ins-po' title="Parse prefix"><code>++ins:po</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#int-by' title="Intersection (map)"><code>++int:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#int-in' title="Intersection (set)"><code>++int:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#inv-fe' title="Inverse order of modular field"><code>++inv:fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#inv-fl' title="Inverse"><code>++inv:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#inv-fo' title="Inverse (signed modulus)"><code>++inv:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#inde' title="Indentation block"><code>++inde</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#indpo' title="Parse suffix"><code>++ind:po</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#inspo' title="Parse prefix"><code>++ins:po</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#intby' title="Intersection (map)"><code>++int:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#intin' title="Intersection (set)"><code>++int:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#invfe' title="Inverse order of modular field"><code>++inv:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#invfl' title="Inverse"><code>++inv:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#invfo' title="Inverse (signed modulus)"><code>++inv:fo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#iny' title="Indentation block"><code>++iny</code></a>
 
 ### j
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#ja' title="Jar engine"><code>++ja</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#jabby' title="Transform value (map)"><code>++jab:by</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#jam' title="Pack noun to atom"><code>++jam</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2o/#jar' title="Mold generator (jar)"><code>++jar</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#jes-yo' title="Maximum 64-bit timestamp"><code>++jes:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#jesyo' title="Maximum 64bit timestamp"><code>++jes:yo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#jest' title="Match a cord"><code>++jest</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#jock' title="Compiler utility"><code>++jock</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#join' title="Add separator between list elements"><code>++join</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#ju' title="Jug operations"><code>++ju</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2o/#jug' title="Mold generator (jug)"><code>++jug</code></a>
@@ -314,44 +374,49 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#kel' title="Parse { (kel)"><code>++kel</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#ker' title="Parse } (ker)"><code>++ker</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#ket' title="Parse ^ (ket)"><code>++ket</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#keyby' title="Set of keys"><code>++key:by</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#knee' title="Recursive parsers"><code>++knee</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#knot' title="Atom type of ASCII characters"><code>++knot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#knot' title="Atom type of ASCII characters"><code>+$knot</code></a>
 
 ### l
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4d/#last' title="Further trace"><code>++last</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#le-nl' title="Construct list from null-terminated noun"><code>++le:nl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#late' title="Put tail"><code>++late</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#lead' title="Put head"><code>++lead</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#lenl' title="Construct list from nullterminated noun"><code>++le:nl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#lent' title="List length"><code>++lent</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#levi' title="Type nests or crash"><code>++levi</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#levy' title="Logical AND on list"><code>++levy</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lfe-fl' title="Maximum"><code>++lfe:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lfn-fl' title="Largest normal float"><code>++lfn:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lfefl' title="Maximum"><code>++lfe:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lfnfl' title="Largest normal float"><code>++lfn:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#lien' title="Logical OR on list"><code>++lien</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#lift' title="Curried bind"><code>++lift</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#like' title="Generic edge"><code>++like</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#limb' title="Reference into subject by name/axis"><code>++limb</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#limo' title="Construct list from null-terminated tuple"><code>++limo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#line' title="(Undocumented)"><code>++line</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#lip-ag' title="Parse IPv4 address"><code>++lip:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#limb' title="Reference into subject by name/axis"><code>+$limb</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#limo' title="Construct list from nullterminated tuple"><code>++limo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#link' title="Lexical segment"><code>+$link</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#lipag' title="Parse IPv4 address"><code>++lip:ag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#list' title="Mold constructor (list)"><code>++list</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#lone' title="Mold generator (face on mold)"><code>++lone</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#lor' title="Leg order"><code>++lor</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#look' title="Compiler utility"><code>++look</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#loot' title="Compiler utility"><code>++loot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#low' title="Parse lowercase letter"><code>++low</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#lsh' title="Left-shift"><code>++lsh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#lsh' title="Leftshift"><code>++lsh</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#lte' title="Less than / equal (atom)"><code>++lte</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lte-ff' title="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lte-fl' title="Less than / equal (producing flag)"><code>++lte:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lte-rd' title="Less than / equal (double-precision float)"><code>++lte:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lte-rh' title="Less than / equal (half-precision float)"><code>++lte:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lte-rs' title="Less than / equal (single-precision float)"><code>++lte:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lte-rq' title="Less than / equal (quad-precision float)"><code>++lte:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lteff' title="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ltefl' title="Less than / equal (producing flag)"><code>++lte:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lterd' title="Less than / equal (doubleprecision float)"><code>++lte:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lterh' title="Less than / equal (halfprecision float)"><code>++lte:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lters' title="Less than / equal (singleprecision float)"><code>++lte:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lterq' title="Less than / equal (quadprecision float)"><code>++lte:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#lth' title="Less than (atom)"><code>++lth</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lth-ff' title="Less than (IEEE float)"><code>++lth:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lth-fl' title="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lth-rd' title="Less than (double-precision float)"><code>++lth:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lth-rh' title="Less than (half-precision float)"><code>++lth:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lth-rs' title="Less than (single-precision float)"><code>++lth:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lth-rq' title="Less than (quad-precision float)"><code>++lth:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lug-fl' title="Central rounding mechanism"><code>++lug:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lthff' title="Less than (IEEE float)"><code>++lth:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lthfl' title="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lthrd' title="Less than (doubleprecision float)"><code>++lth:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lthrh' title="Less than (halfprecision float)"><code>++lth:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lthrs' title="Less than (singleprecision float)"><code>++lth:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lthrq' title="Less than (quadprecision float)"><code>++lth:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lugfl' title="Central rounding mechanism"><code>++lug:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#lus' title="Parse + (lus)"><code>++lus</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4d/#lust' title="Detect new line"><code>++lust</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#less' title="Parse unless"><code>++less</code></a>
@@ -359,455 +424,566 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### m
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ma-rd' title="Initialize ff (rd core)"><code>++ma:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ma-rh' title="Initialize ff (rh core)"><code>++ma:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ma-rs' title="Initialize ff (rs core)"><code>++ma:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ma-rq' title="Initialize ff (rq core)"><code>++ma:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mane' title="XML name+space"><code>++mane</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#manx' title="Dynamic XML node"><code>++manx</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#manxhoot' title="Dynamic XML node"><code>+$manx:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mard' title="Initialize ff (rd core)"><code>++ma:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#marh' title="Initialize ff (rh core)"><code>++ma:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mars' title="Initialize ff (rs core)"><code>++ma:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#marq' title="Initialize ff (rq core)"><code>++ma:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mack' title="Nock subject to unit"><code>++mack</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#make' title="Compile cord to nock"><code>++make</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2l/#malt' title="Map from list"><code>++malt</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#manehoot' title="XML name+space"><code>+$mane:hoot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2o/#map' title="Mold generator (map)"><code>++map</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#mar-by' title="Assert and add (map)"><code>++mar:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#marby' title="Add with validation (map)"><code>++mar:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marehoot' title="Node or nodes"><code>+$mare:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#marl' title="XML node list"><code>++marl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marlhoot' title="Dynamic XML nodes"><code>+$marl:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marthoot' title="Dynamic XML attributes"><code>+$mart:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mars' title="XML cdata"><code>++mars</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mart' title="XML attributes"><code>++mart</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#maruhoot' title="Interpolation or nodes"><code>+$maru:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#marx' title="Dynamic XML tag"><code>++marx</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marxhoot' title="Dynamic XML tag"><code>+$marx:hoot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1b/#mas' title="Address within head/tail"><code>++mas</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#mask' title="Match character"><code>++mask</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#mat' title="Length-encode"><code>++mat</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#mat' title="Lengthencode"><code>++mat</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#mate' title="Choose"><code>++mate</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#max' title="Maximum"><code>++max</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#me-ff' title="Minimum exponent of ff"><code>++me:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#mean' title="Crash and printf"><code>++mean</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#meff' title="Minimum exponent of ff"><code>++me:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#mean' title="Crash and printf"><code>++mean</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#mes' title="Parse hexabyte"><code>++mes</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#mesc' title="Escape special characters"><code>++mesc</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#met' title="Measure"><code>++met</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#metl' title="(Undocumented)"><code>++metl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#min' title="Minimum (atom)"><code>++min</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mink' title="Mock (virtual Nock) interpreter"><code>++mink</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#mit-yo' title="Seconds in minute"><code>++mit:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mite' title="MIME type"><code>++mite</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#mityo' title="Seconds in minute"><code>++mit:yo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2d/#mix' title="Binary XOR (atom)"><code>++mix</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#mixed-case-symbol' title="Mixed-case term"><code>++mixed-case-symbol</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#moan' title="Profiling: sample metric"><code>+$moan</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mock' title="Compute formula on subject with hint"><code>++mock</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#mod' title="Modulus (atom)"><code>++mod</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#moh-yo' title="Days in month"><code>++moh:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#mohyo' title="Days in month"><code>++moh:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mole' title="Typed unitary virtual"><code>++mole</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2l/#molt' title="Map from pair list"><code>++molt</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mong' title="Slam gate with sample"><code>++mong</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mook' title="Intelligently render crash annotation"><code>++mook</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#mor' title="(more) mug order"><code>++mor</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#more' title="Parse list with delimiter"><code>++more</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#most' title="Parse list of at least one match"><code>++most</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#moy-yo' title="Days in months of leap-year"><code>++moy:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#mu' title="Core used to scramble 16-bit atoms"><code>++mu</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2e/#mug' title="FNV-1a scrambler"><code>++mug</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#motag' title="Parse numerical month"><code>++mot:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#moyyo' title="Days in months of leapyear"><code>++moy:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#mu' title="Core used to scramble 16bit atoms"><code>++mu</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2e/#mug' title="FNV1a scrambler"><code>++mug</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2e/#muk' title="Standard MurmurHash3"><code>++muk</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#mul' title="Multiply (atom)"><code>++mul</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mul-ff' title="Multiply (IEEE float)"><code>++mul:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mul-fl' title="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mul-rd' title="Multiply (double-precision float)"><code>++mul:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mul-rh' title="Multiply (quad-precision float)"><code>++mul:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mul-rs' title="Multiply (single-precision float)"><code>++mul:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mul-rq' title="Multiply (quad-precision float)"><code>++mul:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulff' title="Multiply (IEEE float)"><code>++mul:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulfl' title="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulrd' title="Multiply (doubleprecision float)"><code>++mul:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulrh' title="Multiply (quadprecision float)"><code>++mul:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulrs' title="Multiply (singleprecision float)"><code>++mul:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulrq' title="Multiply (quadprecision float)"><code>++mul:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mule' title="Typed virtual"><code>++mule</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mure' title="Untyped unitary virtual"><code>++mure</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#musk' title="Nock with block set (compiler utility)"><code>++musk</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mute' title="Untyped virtual"><code>++mute</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2e/#mum' title="31-bit MurmurHash3 scrambler"><code>++mum</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#murn' title="Maybe transform"><code>++murn</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#my' title="Map from raw noun"><code>++my</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#my-nl' title="Construct map from null-terminated noun"><code>++my:nl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#mynl' title="Construct map from nullterminated noun"><code>++my:nl</code></a>
 
 ### n
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#nail' title="Location, remainder of parsed text"><code>++nail</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#nap-to' title="Remove head of queue"><code>++nap:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#nail' title="Location, remainder of parsed text"><code>+$nail</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#napto' title="Remove head of queue"><code>++nap:to</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ne' title="Digit rendering engine"><code>++ne</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ned-fl' title="Require float"><code>++ned:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#nedfl' title="Require float"><code>++ned:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#need' title="Unwrap unit"><code>++need</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#net-fe' title="Flip endianness"><code>++net:fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#new-si' title="Atom to @s"><code>++new:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#netfe' title="Flip endianness"><code>++net:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#newsi' title="Atom to @s"><code>++new:si</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#next' title="Consume character"><code>++next</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#nip-to' title="Remove root of queue"><code>++nip:to</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#nix' title="Parse letters and -"><code>++nix</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#nipto' title="Remove root of queue"><code>++nip:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#nix' title="Parse letters and underscore"><code>++nix</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#nl' title="Noun to container operations"><code>++nl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#nock' title="Virtual machine (see Nock)"><code>++nock</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#noah' title="Tape pretty-print"><code>++noah</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#nock' title="Virtual nock"><code>+$nock</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2d/#not' title="Binary NOT (atom)"><code>++not</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#noun' title="(Undocumented)"><code>++noun</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#nuck-so' title="Top-level coin parser"><code>++nuck:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#note' title="Type annotation"><code>+$note</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#noun' title="Any noun"><code>+$noun</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#nuckso' title="Toplevel coin parser"><code>++nuck:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#nud' title="Parse numeric character"><code>++nud</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#null' title="(Undocumented)"><code>++null</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#nusk-so' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#null' title="Null, nil, etc"><code>+$null</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#nuskso' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
 
 ### o
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#ob' title="Reversible scrambling v2"><code>++ob</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#og' title="Container arm for SHA-256 powered RNG"><code>++og</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#old-si' title="Sign and absolute value"><code>++old:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#og' title="Container arm for SHA256 powered RNG"><code>++og</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#oldsi' title="Sign and absolute value"><code>++old:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#onan' title="Vise to vase"><code>++onan</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#onyx' title="Arm activation"><code>+$onyx</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#opal' title="Wing match"><code>+$opal</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#oust' title="Remove from list"><code>++oust</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#out-fe' title="Maximum integer value"><code>++out:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#outfe' title="Maximum integer value"><code>++out:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ox-coco' title="Format dot-separated digits in numeric base"><code>++ox-co:co</code></a>
 
 ### p
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#pa-ff' title="Initialize fl from ff core"><code>++pa:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#paff' title="Initialize fl from ff core"><code>++pa:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#padfa' title="base58check padding bytes"><code>++pad:fa</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#pair' title="Mold of pair of types"><code>++pair</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#pam' title="Parse & (pam)"><code>++pam</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#pat' title="Parse @ (pat)"><code>++pat</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#path' title="Filesystem path"><code>++path</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#path' title="Like unix path"><code>+$path</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1b/#peg' title="Address within address"><code>++peg</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#pel' title="Parse ( (pel)"><code>++pel</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#per' title="Parse ) (per)"><code>++per</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#perd-so' title="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pev-ab' title="Parse <=5 in base 32"><code>++pev:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pew-ab' title="Parse <= 5 in base 64"><code>++pew:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#pal' title="Parse ( (pal)"><code>++pal</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#palo' title="Wing trace, match"><code>+$palo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#par' title="Parse ) (par)"><code>++par</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#pass' title="Public key"><code>++pass</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#perdso' title="Parsing coin literal without prefixes"><code>++perd:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#perk' title="Parse cube fork"><code>++perk</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pevab' title="Parse 1-5 @uv base-32 chars"><code>++pev:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pewab' title="Parse <= 5 in base 64"><code>++pew:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#pfix' title="Discard first rule"><code>++pfix</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#pint' title="Parsing range"><code>++pint</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#piv-ab' title="Parse 5 digits in base 32"><code>++piv:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#piw-ab' title="Parse 5 digits in base 64"><code>++piw:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-heck' title="Profiling utility"><code>++pi-heck</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-noon' title="Sample trace"><code>++pi-noon</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-mope' title="Add sample"><code>++pi-mope</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-moth' title="Count sample"><code>++pi-moth</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-mumm' title="Print sample"><code>++pi-mumm</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-tell' title="Produce dump"><code>++pi-tell</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#pica' title="Prose or code"><code>+$pica</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#pint' title="Parsing range"><code>+$pint</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pivab' title="Parse 5 @uv base-32 chars"><code>++piv:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#piwab' title="Parse 5 @uw base-64 chars"><code>++piw:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#plat' title="%hoon, %type, %nock or %tank"><code>+$plat</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#plug' title="Parse to tuple"><code>++plug</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#plus' title="List of at least one match"><code>++plus</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#po' title="Phonetic base"><code>++po</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#pock' title="Changes"><code>+$pock</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#pole' title="Mold generator of faceless list"><code>++pole</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#port' title="(Undocumented)"><code>++port</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#poly' title="Polarity"><code>+$poly</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#port' title="Successful wing match"><code>+$port</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#pose' title="Parse options"><code>++pose</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2g/#pow' title="Computes a to the power of b"><code>++pow</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#prc-fl' title="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#prcfl' title="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#prn' title="Parse any printable character"><code>++prn</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#pro-fo' title="Multiplies b and c modulo a"><code>++pro:fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#pro-si' title="Multiply to signed integer"><code>++pro:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#put-by' title="Add key-value pair (map)"><code>++put:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#put-in' title="Put b in a (set)"><code>++put:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#put-ju' title="Add key-set pair (jar)"><code>++put:ju</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#put-to' title="Insert into queue"><code>++put:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#profo' title="Multiplies b and c modulo a"><code>++pro:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#prosi' title="Multiply to signed integer"><code>++pro:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#punt' title="Unitized parse"><code>++punt</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#putby' title="Add keyvalue pair (map)"><code>++put:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#putin' title="Put b in a (set)"><code>++put:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#putju' title="Add keyset pair (jar)"><code>++put:ju</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#putto' title="Insert into queue"><code>++put:to</code></a>
 
 ### q
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#qad-yo' title="Seconds in 4 years"><code>++qad:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qeb-ab' title="Parse <=4 binary digits"><code>++qeb:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#qadyo' title="Seconds in 4 years"><code>++qad:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#qat' title="Parse chars in blockcord"><code>++qat</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qebab' title="Parse 1-4 binary digits"><code>++qeb:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2o/#qeu' title="Mold generator (queue)"><code>++qeu</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qex-ab' title="Parse <=4 hexadecimal digits"><code>++qex:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qib-ab' title="Parse 4 binary digits"><code>++qib:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qexab' title="Parse 1-4 hex digits"><code>++qex:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qibab' title="Parse 4 binary digits"><code>++qib:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#qit' title="Parse character to cord atom"><code>++qit</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qix-ab' title="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qixab' title="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#quip' title="Mold generator (tuple of list and type)"><code>++quip</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#qut' title="Parse cord"><code>++qut</code></a>
 
 ### r
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#r-at' title="(Undocumented)"><code>++r:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#rad-og' title="Random in range"><code>++rad:og</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#rads-og' title="Random continuation"><code>++rads:og</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#raku-ob' title="Key list"><code>++raku:ob</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#ram-re' title="Flatten tank to tape"><code>++ram:re</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rap' title="Assemble non-zero"><code>++rap</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rat' title="Print term, number or hex"><code>++r:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#radog' title="Random in range"><code>++rad:og</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#radsog' title="Random continuation"><code>++rads:og</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#rain' title="Parse with % path"><code>++rain</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#rakuob' title="Key list"><code>++raku:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#ramre' title="Flatten tank to tape"><code>++ram:re</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rap' title="Assemble nonzero"><code>++rap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4g/#rash' title="Parse or crash"><code>++rash</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#rau-fl' title="Various roundings (floating point)"><code>++rau:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#raw-og' title="Random bits"><code>++raw:og</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#raws-og' title="Random bits continuation"><code>++raws:og</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#re' title="Pretty-printing engine (tank)"><code>++re</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rear-co' title="Prepend and render atom as tape"><code>++rear:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#raufl' title="Various roundings (floating point)"><code>++rau:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#rawog' title="Random bits"><code>++raw:og</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#rawsog' title="Random bits continuation"><code>++raws:og</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#r-coco' title="Render floating point"><code>++r-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#re' title="Prettyprinting engine (tank)"><code>++re</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#ream' title="Parse cord to hoon"><code>++ream</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#rear' title="Last item in list"><code>++rear</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rearco' title="Prepend and render atom as tape"><code>++rear:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#reap' title="Replicate (list)"><code>++reap</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#reck' title="Parse hoon file"><code>++reck</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#reel' title="Right fold (list)"><code>++reel</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#rem-si' title="Remainder (signed integer)"><code>++rem:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rend-co' title="Render coin lot as tape"><code>++rend:co</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rent-co' title="Render coin lot as span"><code>++rent:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#remsi' title="Remainder (signed integer)"><code>++rem:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rendco' title="Render coin lot as tape"><code>++rend:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rentco' title="Render coin as knot"><code>++rent:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rep' title="Assemble single"><code>++rep</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#rep-by' title="Replace by product (map)"><code>++rep:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#rep-in' title="Accumulate elements (set)"><code>++rep:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rf-at' title="(Undocumented)"><code>++rf:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#rib-by' title="Replace values with accumulator (map)"><code>++rib:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#rig-re' title="Wrap tape in / (tank)"><code>++rig:re</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#repby' title="Reduce to product (map)"><code>++rep:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#repin' title="Accumulate elements (set)"><code>++rep:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#result' title="Internal interpreter result"><code>+$result</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rev' title="Reverse"><code>++rev</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rfat' title="Print loobean"><code>++rf:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#ribby' title="Transform + product (map)"><code>++rib:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#ride' title="End-to-end compiler"><code>++ride</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#ring' title="Private key"><code>++ring</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rip' title="Disassemble"><code>++rip</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rn-at' title="(Undocumented)"><code>++rn:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rol-fe' title="Roll left"><code>++rol:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rnat' title="Print null"><code>++rn:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ro-coco' title="Format dot-prefixed bloqs in numeric base"><code>++ro-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#road' title="Evaluate trap"><code>++road</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rolfe' title="Roll left"><code>++rol:fe</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#roll' title="Left fold (list)"><code>++roll</code></a>
 <code>++rood</code>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#ror-fe' title="Roll right"><code>++ror:fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#rou-fl' title="Round to nearest float with 113-bit significand"><code>++rou:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-so' title="Parse dime float"><code>++royl:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-cell-so' title="(Undocumented)"><code>++royl-cell:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rsh' title="Right-shift"><code>++rsh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rt-at' title="(Undocumented)"><code>++rt:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rta-at' title="(Undocumented)"><code>++rta:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rtam-at' title="(Undocumented)"><code>++rtam:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#rub' title="Length-decode"><code>++rub</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rub-at' title="(Undocumented)"><code>++rub:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rud-at' title="(Undocumented)"><code>++rud:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#rule' title="Parsing rule (match this with _)"><code>++rule</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rum-at' title="(Undocumented)"><code>++rum:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#run-by' title="Transform values (map)"><code>++run:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#run-in' title="Apply gate to set"><code>++run:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#rund-ob' title="Reverse single Feistel-like"><code>++rund:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rorfe' title="Roll right"><code>++ror:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4g/#rose' title="Parse to each"><code>++rose</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#roufl' title="Round to nearest float with 113bit significand"><code>++rou:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#roylso' title="Parse dime float"><code>++royl:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-cellso' title="Convert rn to dn"><code>++royl-cell:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rhso' title="Parse half-precision float"><code>++royl-rh:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rqso' title="Parse quad-precision float"><code>++royl-rq:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rdso' title="Parse double-precision float"><code>++royl-rd:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rsso' title="Parse single-precision float"><code>++royl-rs:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rnso' title="Parse real number"><code>++royl-rn:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rsh' title="Rightshift"><code>++rsh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rtat' title="Print cord, including escape characters"><code>++rt:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rtaat' title="Print cord, including escape characters"><code>++rta:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rtamat' title="Print cord with @tas syntax"><code>++rtam:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#rub' title="Lengthdecode"><code>++rub</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rubat' title="Print binary"><code>++rub:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rudat' title="Print atom as integer"><code>++rud:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#rule' title="Parsing rule (match this with _)"><code>+$rule</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rumat' title="Print base-n"><code>++rum:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#runby' title="Transform values (map)"><code>++run:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#runin' title="Apply gate to set"><code>++run:in</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#runt' title="Prepend n times"><code>++runt</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rup-at' title="(Undocumented)"><code>++rup:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rupat' title="Print @p (outdated)"><code>++rup:at</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4g/#rush' title="Parse or null"><code>++rush</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4g/#rust' title="Parse tape or null"><code>++rust</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#rut-by' title="Transform nodes (map)"><code>++rut:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#ruv-at' title="(Undocumented)"><code>++ruv:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rux-at' title="(Undocumented)"><code>++rux:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#rynd-ob' title="Reverse Feistel-like cipher"><code>++rynd:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#rutby' title="Transform nodes (map)"><code>++rut:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#ruvat' title="Print base-64"><code>++ruv:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#ruxat' title="Print hexadecimal"><code>++rux:at</code></a>
 
 ### s
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#same' title="Identity (produces same value)"><code>++same</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#san-ff' title="Signed integer to @r"><code>++san:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#san-fl' title="Signed integer to float"><code>++san:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#san-rd' title="Unsigned integer to @rd"><code>++san:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#san-rh' title="Signed integer to @rh"><code>++san:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#san-rs' title="Signed integer to @rs"><code>++san:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#san-rq' title="Signed integer to @rq"><code>++san:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#sand' title="Soft-cast by aura"><code>++sand</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sanff' title="Signed integer to @r"><code>++san:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sanfl' title="Signed integer to float"><code>++san:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sanrd' title="Unsigned integer to @rd"><code>++san:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sanrh' title="Signed integer to @rh"><code>++san:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sanrs' title="Signed integer to @rs"><code>++san:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sanrq' title="Signed integer to @rq"><code>++san:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#sand' title="Softcast by aura"><code>++sand</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#sane' title="Check aura validity"><code>++sane</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sb-ff' title="Sign bit"><code>++sb:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sbff' title="Sign bit"><code>++sb:ff</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#scag' title="Prefix (produce front of list)"><code>++scag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4g/#scan' title="Parse tape or crash"><code>++scan</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#s-coco' title="Render hex list"><code>++s-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#scot' title="Render dime as cord"><code>++scot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#scow' title="Render dime as tape"><code>++scow</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sea-ff' title="Convert from IEEE float to fn"><code>++sea:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sea-rd' title="Convert from double-precision binary float to fn"><code>++sea:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sea-rh' title="Convert from half-precision float to fn"><code>++sea:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sea-rs' title="Convert from single-precision float to fn"><code>++sea:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sea-rq' title="Convert from quad-precision float to fn"><code>++sea:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#seaff' title="Convert from IEEE float to fn"><code>++sea:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#seard' title="Convert from doubleprecision binary float to fn"><code>++sea:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#searh' title="Convert from halfprecision float to fn"><code>++sea:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sears' title="Convert from singleprecision float to fn"><code>++sea:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#searq' title="Convert from quadprecision float to fn"><code>++sea:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#sear' title="Conditional ++cook"><code>++sear</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#seb-ab' title="Parse 1"><code>++seb:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sed-ab' title="Parse non-zero decimal digit"><code>++sed:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sebab' title="Parse 1"><code>++seb:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#sect' title="Paragraph"><code>+$sect</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sedab' title="Parse nonzero decimal digit"><code>++sed:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#seem' title="Promote typo"><code>++seem</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#seer' title="Promote vise"><code>++seer</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#sel' title="Parse [ (sel)"><code>++sel</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#sem' title="Parse ; (sem)"><code>++sem</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#sell' title="Pretty-print vase to a tank"><code>++sell</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#mic' title="Parse ; (mic)"><code>++mic</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#ser' title="Parse ] (ser)"><code>++ser</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2o/#set' title="Mold generator (set)"><code>++set</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sev-ab' title="Parse non-zero base 32 digit"><code>++sev:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sew-ab' title="Parse non-zero base 64 digit"><code>++sew:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sex-ab' title="Parse nonzero hexadecimal digit"><code>++sex:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sevab' title="Parse nonzero base 32 digit"><code>++sev:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#sew' title="Stitch one atom into another"><code>++sew</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sewab' title="Parse nonzero base 64 digit"><code>++sew:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sexab' title="Parse nonzero hexadecimal digit"><code>++sex:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#sfix' title="Discard second rule"><code>++sfix</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shad' title="Double SHA-256"><code>++shad</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shaf' title="Half SHA-256"><code>++shaf</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shal' title="SHA-512 with length"><code>++shal</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#sham' title="128-bit noun hash"><code>++sham</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shan' title="SHA-1"><code>++shan</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shad' title="Double SHA256"><code>++shad</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shaf' title="Half SHA256"><code>++shaf</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shal' title="SHA512 with length"><code>++shal</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#sham' title="128bit noun hash"><code>++sham</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shan' title="SHA1"><code>++shan</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shas' title="Salted hash"><code>++shas</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shaw' title="Hash to nbits"><code>++shaw</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shax' title="SHA-256"><code>++shax</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shay' title="SHA-256 with length"><code>++shay</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shaz' title="SHA-512"><code>++shaz</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#shep' title="(Undocumented)"><code>++shep</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#shf-fl' title="Shift power"><code>++shf:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shax' title="SHA256"><code>++shax</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shay' title="SHA256 with length"><code>++shay</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shaz' title="SHA512"><code>++shaz</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#shffl' title="Shift power"><code>++shf:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#shim' title="Match character within range"><code>++shim</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#shop' title="(Undocumented)"><code>++shop</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#show' title="(Undocumented)"><code>++show</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#ship' title="Network identity"><code>++ship</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#shop' title="Urbit/DNS identity"><code>++shop</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#show' title="Pretty-printer (deprecated)"><code>++show</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#si' title="Signed integer"><code>++si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#si-nl' title="Construct set from null-terminated noun"><code>++si:nl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sib-ab' title="Parse binary digit"><code>++sib:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sid-ab' title="Parse decimal digit"><code>++sid:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#sinl' title="Construct set from nullterminated noun"><code>++si:nl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sibab' title="Parse binary digit"><code>++sib:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sidab' title="Parse decimal digit"><code>++sid:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#sig' title="Parse ~ (sig)"><code>++sig</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sig-ff' title="Produce sign of IEEE float"><code>++sig:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sig-rd' title="Produce sign of @rd"><code>++sig:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sig-rh' title="Produce sign of half-precision float"><code>++sig:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sig-rs' title="Produce sign of @rs"><code>++sig:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sig-rq' title="Produce sign of quad-precision float"><code>++sig:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sigff' title="Produce sign of IEEE float"><code>++sig:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sigrd' title="Produce sign of @rd"><code>++sig:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sigrh' title="Produce sign of halfprecision float"><code>++sig:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sigrs' title="Produce sign of @rs"><code>++sig:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sigrq' title="Produce sign of quadprecision float"><code>++sig:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2l/#silt' title="Produce set from list"><code>++silt</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#simu' title="First and second"><code>++simu</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#sit-fe' title="Enforce modulo"><code>++sit:fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sit-fo' title="Produce remainder of b modulo a"><code>++sit:fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#siv-ab' title="Parse a base 32 digit"><code>++siv:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#siw-ab' title="Parse a base 64 digit"><code>++siw:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#six-ab' title="Parse a hexadecimal digit"><code>++six:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#sitfe' title="Enforce modulo"><code>++sit:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sitfo' title="Produce remainder of b modulo a"><code>++sit:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sivab' title="Parse a base 32 digit"><code>++siv:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#siwab' title="Parse a base 64 digit"><code>++siw:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sixab' title="Parse a hexadecimal digit"><code>++six:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#skid' title="Separate list into two lists from slammed elments"><code>++skid</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#skim' title="Produce list of elements from boolean gate"><code>++skim</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#skin' title="Texture"><code>+$skin</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#skip' title="Produce list of elements failing boolean gate"><code>++skip</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#skol' title="Pretty-print type to tank"><code>++skol</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slab' title="Test if contains"><code>++slab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#slag' title="Produce all elements from index in list"><code>++slag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slam' title="Slam a gate"><code>++slam</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slap' title="Untyped vase .*"><code>++slap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#slat' title="Curried slaw"><code>++slat</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#slav' title="Demand: parse cord with input aura"><code>++slav</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#slaw' title="Parse cord to input aura"><code>++slaw</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#slay' title="Parse cord to coin"><code>++slay</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#slog' title="Deify printf"><code>++slog</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slew' title="Get axis in vase"><code>++slew</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slim' title="Identical to ++seer"><code>++slim</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slit' title="Type of slam"><code>++slit</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slob' title="Superficial arm"><code>++slob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#sloe' title="Get arms in core"><code>++sloe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slog' title="Deify printf"><code>++slog</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slop' title="Cons two vases"><code>++slop</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slot' title="Got axis in vase"><code>++slot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#slug' title="Use gate to parse delimited list"><code>++slug</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#slum' title="Slam a gate on a sample using raw nock, untyped"><code>++slum</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slym' title="Slam without sample-type"><code>++slym</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#smyt' title="Render path as tank"><code>++smyt</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#snag' title="Produce element at specific index (list)"><code>++snag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#snag-nl' title="Produce element from list at specific null-terminated noun"><code>++snag:nl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#snap' title="Replace item at index"><code>++snap</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#snagnl' title="Produce element from list at specific nullterminated noun"><code>++snag:nl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#snip' title="Drop tail off list"><code>++snip</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#snoc' title="Append noun to list"><code>++snoc</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#so' title="Coin parser engine"><code>++so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#soft' title="Maybe remold"><code>++soft</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#soft' title="Virtual clam"><code>++soft</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#some' title="Wrap value in unit"><code>++some</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#soq' title="Parse ' (soq)"><code>++soq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#sort' title="Quicksort (list)"><code>++sort</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sov-ab' title="Parse base 32 letter"><code>++sov:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sow-ab' title="Parse base 64 letter/symbol"><code>++sow:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sox-ab' title="Parse hexadecimal letter"><code>++sox:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#soz' title="Parse triple single-quote"><code>++soz</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#span' title="ASCII atom"><code>++span</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sovab' title="Parse @uv base-32 letter"><code>++sov:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sowab' title="Parse @uw base-64 letter/symbol"><code>++sow:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#soxab' title="Parse hexadecimal letter"><code>++sox:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#soz' title="Parse triple singlequote"><code>++soz</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#spat' title="Render path as cord"><code>++spat</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#spd-fl' title="Produce smallest denormalized float"><code>++spd:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#spdfl' title="Produce smallest denormalized float"><code>++spd:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#spec' title="Structure definition AST"><code>+$spec</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#sped' title="Reconstruct type"><code>++sped</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#spin' title="Gate to list (with state)"><code>++spin</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#spn-fl' title="Produce smallest normal float"><code>++spn:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#spot' title="Stack trace line"><code>++spot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#spnfl' title="Produce smallest normal float"><code>++spn:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#spot' title="Stack trace line"><code>+$spot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#spud' title="Render path as tape"><code>++spud</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#spun' title="Gate to list (with state)"><code>++spun</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#spur' title="ship desk case spur"><code>++spur</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2g/#sqt' title="Compute square root with remainder"><code>++sqt</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqt-ff' title="Produce square root of IEEE float"><code>++sqt:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqt-fl' title="Produce square root from signed and unsigned integer cell"><code>++sqt:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqt-rd' title="Produce square root of double-precision float"><code>++sqt:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqt-rh' title="Produce square root of half-precision float"><code>++sqt:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqt-rs' title="Produce square root of single-precision float"><code>++sqt:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqt-rq' title="Produce square root of quad-precision float"><code>++sqt:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtff' title="Produce square root of IEEE float"><code>++sqt:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtfl' title="Produce square root from signed and unsigned integer cell"><code>++sqt:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtrd' title="Produce square root of doubleprecision float"><code>++sqt:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtrh' title="Produce square root of halfprecision float"><code>++sqt:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtrs' title="Produce square root of singleprecision float"><code>++sqt:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtrq' title="Produce square root of quadprecision float"><code>++sqt:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#stab' title="Parse cord to path"><code>++stab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stag' title="Add label"><code>++stag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#stap' title="Path parser"><code>++stap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#star' title="Produce list of matches"><code>++star</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stet' title="Add faces to range-parser pairs in list"><code>++stet</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#step' title="Atom size or offset, in bloqs"><code>++step</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stet' title="Add faces to rangeparser pairs in list"><code>++stet</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stew' title="Switch by first"><code>++stew</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stir' title="Parse repeatedly"><code>++stir</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#stud' title="Standard name"><code>+$stud</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stun' title="Parse several times"><code>++stun</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#sub' title="Subtract"><code>++sub</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sub-ff' title="Subtract from IEEE float"><code>++sub:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sub-fl' title="Subtract from signed and unsigned integer cells"><code>++sub:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sub-rd' title="Subtract from double-precision float"><code>++sub:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sub-rh' title="Subtract from half-precision float"><code>++sub:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sub-rs' title="Subtract from single-precision float"><code>++sub:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sub-rq' title="Subtract from quad-precision float"><code>++sub:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#sum-fe' title="Sum two numbers in modular field"><code>++sum:fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sum-fo' title="Modular sum"><code>++sum:fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sum-si' title="Addition (signed integer)"><code>++sum:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sun-ff' title="Unsigned integer to IEEE float"><code>++sun:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sun-fl' title="Unsigned integer to float"><code>++sun:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sun-rd' title="Unsigned integer to double-precision float"><code>++sun:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sun-rh' title="Unsigned integer to half-precision float"><code>++sun:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sun-rs' title="Unsigned integer to single-precision float"><code>++sun:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sun-rq' title="Unsigned integer to quad-precision float"><code>++sun:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sun-si' title="@u to @s"><code>++sun:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#subff' title="Subtract from IEEE float"><code>++sub:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#subfl' title="Subtract from signed and unsigned integer cells"><code>++sub:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#subrd' title="Subtract from doubleprecision float"><code>++sub:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#subrh' title="Subtract from halfprecision float"><code>++sub:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#subrs' title="Subtract from singleprecision float"><code>++sub:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#subrq' title="Subtract from quadprecision float"><code>++sub:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#succ' title="Successor"><code>++succ</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#sumfe' title="Sum two numbers in modular field"><code>++sum:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sumfo' title="Modular sum"><code>++sum:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sumsi' title="Addition (signed integer)"><code>++sum:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sunff' title="Unsigned integer to IEEE float"><code>++sun:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sunfl' title="Unsigned integer to float"><code>++sun:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sunrd' title="Unsigned integer to doubleprecision float"><code>++sun:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sunrh' title="Unsigned integer to halfprecision float"><code>++sun:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sunrs' title="Unsigned integer to singleprecision float"><code>++sun:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sunrq' title="Unsigned integer to quadprecision float"><code>++sun:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sunsi' title="@u to @s"><code>++sun:si</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#swag' title="Infix (list)"><code>++swag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#swat' title="Deferred ++slap"><code>++swat</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#swp' title="Reverse block order"><code>++swp</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#swr-fl' title="Switch rounding mode of floating point"><code>++swr:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#sy' title="Produce set from null-terminated noun"><code>++sy</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#swrfl' title="Switch rounding mode of floating point"><code>++swr:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#sy' title="Produce set from nullterminated noun"><code>++sy</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#sym' title="Term"><code>++sym</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#syn-fl' title="Get sign"><code>++syn:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#syn-si' title="Sign test"><code>++syn:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#synfl' title="Get sign"><code>++syn:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#synsi' title="Sign test"><code>++syn:si</code></a>
 
 ### t
 
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#taft' title="UTF8 to UTF32 cord"><code>++taft</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#tail' title="Get tail of cell"><code>++tail</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#tap-to' title="Queue to list"><code>++tap:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#tapto' title="Queue to list"><code>++tap:to</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#tar' title="Parse * (tar)"><code>++tar</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tang' title="Generic print structure"><code>++tang</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tank' title="Pretty-printing structure"><code>++tank</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#tap-by' title="Listify pairs"><code>++tap:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#tap-in' title="Flatten set into list"><code>++tap:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tape' title="List of characters"><code>++tape</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tarp' title="Parsed time"><code>++tarp</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#tash-so' title="Parse signed dime"><code>++tash:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#tec' title="Parse ` (tec)"><code>++tec</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ted-ab' title="Parse decimal number with <= 3 digits"><code>++ted:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#teff' title="UTF-8 length"><code>++teff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#teil-ob' title="Reverse Feistel-like cipher"><code>++teil:ob</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#term' title="Hoon constant"><code>++term</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tang' title="Bottom-first error"><code>+$tang</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tank' title="Formatted print tree"><code>+$tank</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#tapby' title="Listify pairs"><code>++tap:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#tapin' title="Flatten set into list"><code>++tap:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tape' title="List of characters"><code>+$tape</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tarp' title="Parsed time"><code>+$tarp</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#tashso' title="Parse signed dime"><code>++tash:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#tic' title="Parse ` (tic)"><code>++tic</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tedab' title="Parse 1-999 decimal"><code>++ted:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#teff' title="UTF8 length"><code>++teff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#tailob' title="Reverse +feis"><code>++tail:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tent' title="Model builder"><code>+$tent</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tepab' title="Parse non-doz leading phonetic byte"><code>++tep:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#term' title="Hoon constant"><code>+$term</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#test' title="Test for equality"><code>++test</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tid-ab' title="Parse 3 decimal digits"><code>++tid:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tiki' title="(Undocumented)"><code>++tiki</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#til-ab' title="Parse 3 lowercase letters"><code>++til:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tip-ab' title="Leading phonetic byte"><code>++tip:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tiq-ab' title="Trailing phonetic syllable"><code>++tiq:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#text' title="Tape pretty-print"><code>++text</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#thunk' title="Fragment constructor"><code>+$thunk</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tidab' title="Parse 3 decimal digits"><code>++tid:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tiki' title="Test case"><code>+$tiki</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tilab' title="Parse 3 lowercase letters"><code>++til:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#time' title="Galactic time"><code>++time</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tine' title="Partial noun"><code>+$tine</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tipab' title="Leading phonetic byte"><code>++tip:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tiqab' title="Trailing phonetic syllable"><code>++tiq:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#tis' title="Parse = (tis)"><code>++tis</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#to' title="Queue operations"><code>++to</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#tod-po' title="Fetch suffix"><code>++tod:po</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#toga' title="Tree of faces"><code>++toga</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toi-ff' title="Round IEEE float to nearest signed integer"><code>++toi:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toi-fl' title="Round float to nearest signed integer"><code>++toi:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toi-rd' title="Round double-precision float to nearest signed integer"><code>++toi:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toi-rh' title="Round half-precision float to nearest signed integer"><code>++toi:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toi-rs' title="Round single-precision float to nearest signed integer"><code>++toi:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toi-rq' title="Round quad-precision float to nearest signed integer"><code>++toi:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toj-fl' title="Round unsigned and signed integer to float"><code>++toj:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#tone' title="Nock result (error report)"><code>++tone</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#toon' title="Nock result (stack trace)"><code>++toon</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#top-to' title="Produce head of queue"><code>++top:to</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#tos-po' title="Fetch prefix"><code>++tos:po</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#tos-rh' title="Convert half-precision float to single-precision float"><code>++tos:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#todpo' title="Fetch suffix"><code>++tod:po</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toiff' title="Round IEEE float to nearest signed integer"><code>++toi:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toifl' title="Round float to nearest signed integer"><code>++toi:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toird' title="Round doubleprecision float to nearest signed integer"><code>++toi:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toirh' title="Round halfprecision float to nearest signed integer"><code>++toi:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toirs' title="Round singleprecision float to nearest signed integer"><code>++toi:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toirq' title="Round quadprecision float to nearest signed integer"><code>++toi:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#tojfl' title="Round unsigned and signed integer to float"><code>++toj:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#tokfa' title="Compute base58check checksum"><code>++tok:fa</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tome' title="Core chapter"><code>+$tome</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#tone' title="Nock result (error report)"><code>+$tone</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tony' title="$tone done right"><code>+$tony</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tool' title="Type decoration"><code>+$tool</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#toon' title="Nock result (stack trace)"><code>+$toon</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tope' title="Topographic type"><code>+$tope</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#topto' title="Produce head of queue"><code>++top:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#tospo' title="Fetch prefix"><code>++tos:po</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#tosrh' title="Convert halfprecision float to singleprecision float"><code>++tos:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tour' title="UTF-32 clusters"><code>+$tour</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#type' title="Hoon type type"><code>+$type</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#trap' title="Core with one arm $"><code>++trap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#tree' title="Mold generator (tree)"><code>++tree</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#trel' title="Mold generator (tuple of three types)"><code>++trel</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#trim' title="Tape split"><code>++trim</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#trip' title="Cord to tape"><code>++trip</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tuba' title="UTF-8 to UTF-32 tape"><code>++tuba</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tufa' title="UTF-32 to UTF-8 tape"><code>++tufa</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tuna' title="XML template tree"><code>++tuna</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tuft' title="UTF-32 to UTF-8 text"><code>++tuft</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#turf' title="UTF-8 to UTF-32 cord"><code>++turf</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tuba' title="UTF8 to UTF32 tape"><code>++tuba</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tufa' title="UTF32 to UTF8 tape"><code>++tufa</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tuft' title="UTF32 to UTF8 text"><code>++tuft</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tunahoot' title="Maybe interpolation"><code>+$tuna:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tune' title="Complex"><code>+$tune</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#turn' title="Gate to list"><code>++turn</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tusk' title="List of expressions"><code>++tusk</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#twid-so' title="Parse coins without ~ prefix"><code>++twid:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyke' title="List of 'maybe' hoons"><code>++tyke</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#typo' title="Pointer for ++type"><code>++typo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyre' title="List, term hoon"><code>++tyre</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#twidso' title="Parse coins without ~ prefix"><code>++twid:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyke' title="List of 'maybe' hoons"><code>+$tyke</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#typo' title="Old type"><code>+$typo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyre' title="List, term hoon"><code>+$tyre</code></a>
 
 ### u
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#un' title="Reversible scrambling"><code>++un</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#uni-by' title="Union (map between keys of two lists)"><code>++uni:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#uni-fl' title="Change representation to odd"><code>++uni:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#uni-in' title="Union (sets)"><code>++uni:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#uniby' title="Union, merge (map)"><code>++uni:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#unifl' title="Change representation to odd"><code>++uni:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#uniin' title="Union (sets)"><code>++uni:in</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#unit' title="Mold generator (maybe)"><code>++unit</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#urn-by' title="Turn (with key) (map)"><code>++urn:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#urs-ab' title="Parse span characters"><code>++urs:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#urt-ab' title="Parse non-_ span"><code>++urt:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#unoby' title="General union (map)"><code>++uno:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#urnby' title="Turn (with key) (map)"><code>++urn:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ursab' title="Parse knot characters"><code>++urs:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#urtab' title="Parse knot without underscores"><code>++urt:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#us' title="Pretty-printer backend"><code>++us</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#ut' title="Hoon compiler backend"><code>++ut</code></a>
 
 ### v
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#v-ne' title="Render base 32"><code>++v:ne</code></a>
-<code>++vang</code>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vase' title="Typed data"><code>++vase</code></a>
-<code>++vast</code>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#vne' title="Render base 32"><code>++v:ne</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vair' title="Core variance"><code>+$vair</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vang' title="Set ++vast parameters"><code>++vang</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vase' title="Type-value pair"><code>+$vase</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vast' title="Main parsing core"><code>++vast</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#v-coco' title="Render base-32 with minimum length"><code>++v-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vein' title="Search trace"><code>+$vein</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#ven' title="Axis syntax parser"><code>++ven</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vise' title="Convert during reboot"><code>++vise</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vest' title="Parse hoon"><code>++vest</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vial' title="co/contra/in/bi"><code>+$vial</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vice' title="Parse wide-form hoon"><code>++vice</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vise' title="Old vase"><code>+$vise</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#vit' title="Parse base 64 digit"><code>++vit</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#viz-ag' title="Parse base 32 digit with dot separators"><code>++viz:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#vor' title="Vertical order"><code>++vor</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#voy-ab' title="Parse bas, soq, or bix"><code>++voy:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#vizag' title="Parse base 32 digit with dot separators"><code>++viz:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#voyab' title="Parse bas, soq, or bix"><code>++voy:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#vul' title="Comments to null"><code>++vul</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#vum-ag' title="Parse base 32 string"><code>++vum:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#vumag' title="Parse base 32 string"><code>++vum:ag</code></a>
 
 ### w
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#w-ne' title="Render base 64 digit"><code>++w:ne</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#wack' title="Coin format encode"><code>++wack</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#wain' title="List of cords"><code>++wain</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#wall' title="List of list of characters"><code>++wall</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#wne' title="Render base 64 digit"><code>++w:ne</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#wack' title="Knot escape"><code>++wack</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#wain' title="List of cords"><code>+$wain</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#wall' title="List of list of characters"><code>+$wall</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#wash' title="Render tank at width"><code>++wash</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#w-coco' title="Render base-64 with minimum length"><code>++w-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#weld' title="Concatenate two lists"><code>++weld</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#weld-nl' title="Concatenate null-terminated nouns"><code>++weld:nl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#weldnl' title="Concatenate nullterminated nouns"><code>++weld:nl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#welp' title="Perfect concatenate (lists)"><code>++welp</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#wick' title="Coin format decode"><code>++wick</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#wig-re' title="++win - render tape"><code>++wig:re</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#win-re' title="Render at indent"><code>++win:re</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#wing' title="Address in subject"><code>++wing</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#wiz-ag' title="Parse base 64 number"><code>++wiz:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#what' title="Help slogan/section"><code>+$what</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#whenso' title="Parse date"><code>++when:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#whit' title="Documentation"><code>+$whit</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#wick' title="Knot unescape"><code>++wick</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#winre' title="Render at indent"><code>++win:re</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#wing' title="Search path"><code>+$wing</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#wizag' title="Parse base 64 number"><code>++wiz:ag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#woad' title="Unescape cord"><code>++woad</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#wood' title="Escape cord"><code>++wood</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#woof' title="Simple embed"><code>+$woof</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#wonk' title="Product from edge"><code>++wonk</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#wred-un' title="Restore structure"><code>++wred:un</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#wren-un' title="Conceal structure"><code>++wren:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#wredun' title="Restore structure"><code>++wred:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#wrenun' title="Conceal structure"><code>++wren:un</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#wut' title="Parse ? (wut)"><code>++wut</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#wyt-by' title="Produce depth of tree map"><code>++wyt:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#wyt-in' title="Produce number of elements in set"><code>++wyt:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#wytby' title="Produce depth of tree map"><code>++wyt:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#wytin' title="Produce number of elements in set"><code>++wyt:in</code></a>
 
 ### x
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#x-ne' title="Render hexadecimal digit as atom of ASCII byte value"><code>++x:ne</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#x-coco' title="Render hex with minimum length"><code>++x-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#xne' title="Render hexadecimal digit as atom of ASCII byte value"><code>++x:ne</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#xeb' title="Binary logarithm"><code>++xeb</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#xpd-fl' title="Expand signed and unsigned integer cell"><code>++xpd:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#xpdfl' title="Expand signed and unsigned integer cell"><code>++xpd:fl</code></a>
 
 ### y
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yall' title="Time since beginning of time"><code>++yall</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yawn' title="Days since beginning of time"><code>++yawn</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#y-coco' title="Render decimal with at least two digits"><code>++y-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#year' title="Date to @d"><code>++year</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yell' title="Tarp from atomic date"><code>++yell</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yelp' title="Determine if leap-week"><code>++yelp</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yer-yo' title="Seconds in year"><code>++yer:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yelp' title="Determine if leapweek"><code>++yelp</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yeryo' title="Seconds in year"><code>++yer:yo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yo' title="Time constants core"><code>++yo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yore' title="Date from atomic date"><code>++yore</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yule' title="Daily time to time atom"><code>++yule</code></a>
 
 ### z
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zaft-un' title="Look up in 255 sub box"><code>++zaft:un</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zag-mu' title="Add bottom into top"><code>++zag:mu</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zaftun' title="Look up in 255 sub box"><code>++zaft:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zagmu' title="Add bottom into top"><code>++zag:mu</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#zap' title="Parse ! (zap)"><code>++zap</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zart-un' title="Reverse look up in 255 sub box"><code>++zart:un</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#zer-fl' title="Produce zero as float"><code>++zer:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zig-mu' title="Subtract bottom from top"><code>++zig:mu</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zartun' title="Reverse look up in 255 sub box"><code>++zart:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#z-coco' title="Render '0x'-prefixed hex"><code>++z-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#zerfl' title="Produce zero as float"><code>++zer:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zigmu' title="Subtract bottom from top"><code>++zig:mu</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#zing' title="Turn lists into single list by promoting elements from sublists"><code>++zing</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zug-mu' title="Concatenate into atom"><code>++zug:mu</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#zust-so' title="Parse prefixed dimes from IP, loobean, or floating point"><code>++zust:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zyft-un' title="Lookup byte in 256 sub box"><code>++zyft:un</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zyrt-un' title="Reverse lookup byte in 256 sub box"><code>++zyrt:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zugmu' title="Concatenate into atom"><code>++zug:mu</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#zustso' title="Parse dimes from @i, @f, @r or @q"><code>++zust:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zyftun' title="Lookup byte in 256 sub box"><code>++zyft:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zyrtun' title="Reverse lookup byte in 256 sub box"><code>++zyrt:un</code></a>
 
 ## By Section
 
@@ -835,7 +1011,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 1c: molds and mold builders
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#bloq' title="Blocksize"><code>++bloq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#bite' title="Atom slice specificier"><code>$bite</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#bloq' title="Blocksize"><code>$bloq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#each' title="Mold of fork between two types"><code>++each</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#gate' title="Function"><code>++gate</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#list' title="Mold constructor (list)"><code>++list</code></a>
@@ -843,6 +1020,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#pair' title="Mold of pair of types"><code>++pair</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#pole' title="Mold generator of faceless list"><code>++pole</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#quip' title="Mold generator (tuple of list and type)"><code>++quip</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#step' title="Atom size or offset, in bloqs"><code>++step</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#trap' title="Core with one arm $"><code>++trap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#tree' title="Mold generator (tree)"><code>++tree</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#trel' title="Mold generator (tuple of three types)"><code>++trel</code></a>
@@ -851,12 +1029,15 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 2a: unit logic
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#biff' title="Unit as argument"><code>++biff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#bind' title="Non-unit function to unit, producing unit"><code>++bind</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#bind' title="Nonunit function to unit, producing unit"><code>++bind</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#bond' title="Replace null"><code>++bond</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#both' title="Group unit values into pair"><code>++both</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#clap' title="Apply function to two units"><code>++clap</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#clap' title="Combine two units with function"><code>++clap</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#clef' title="Compose two units with function"><code>++clef</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#drop' title="Unit to list"><code>++drop</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#fall' title="Give unit a default value"><code>++fall</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#flit' title="Make filter"><code>++flit</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#hunt' title="Select between two units by a rule"><code>++hunt</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#lift' title="Curried bind"><code>++lift</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#mate' title="Choose"><code>++mate</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#need' title="Unwrap unit"><code>++need</code></a>
@@ -864,6 +1045,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2b: list logic
 
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#bake' title="Convert wet gate to dry gate"><code>++bake</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#fand' title="All indices in list"><code>++fand</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#find' title="First index in list"><code>++find</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#flop' title="Reverse list"><code>++flop</code></a>
@@ -873,7 +1055,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#lent' title="List length"><code>++lent</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#levy' title="Logical AND on list"><code>++levy</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#lien' title="Logical OR on list"><code>++lien</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#limo' title="Construct list from null-terminated tuple"><code>++limo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#limo' title="Construct list from nullterminated tuple"><code>++limo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#murn' title="Maybe transform"><code>++murn</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#oust' title="Remove from list"><code>++oust</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#reap' title="Replicate (list)"><code>++reap</code></a>
@@ -885,7 +1067,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#skip' title="Produce list of elements failing boolean gate"><code>++skip</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#slag' title="Produce all elements from index in list"><code>++slag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#snag' title="Produce element at specific index (list)"><code>++snag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#snap' title="Replace item at index"><code>++snap</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#snip' title="Drop tail off list"><code>++snip</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#snoc' title="Append noun to list"><code>++snoc</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#sort' title="Quicksort (list)"><code>++sort</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#spin' title="Gate to list (with state)"><code>++spin</code></a>
@@ -899,14 +1081,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 2c: bit arithmetic
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#fe' title="Modulo bloq"><code>++fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#dif-fe' title="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#inv-fe' title="Inverse order of modular field"><code>++inv:fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#net-fe' title="Flip endianness"><code>++net:fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#out-fe' title="Maximum integer value"><code>++out:fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rol-fe' title="Roll left"><code>++rol:fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#ror-fe' title="Roll right"><code>++ror:fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#sit-fe' title="Enforce modulo"><code>++sit:fe</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#sum-fe' title="Sum two numbers in modular field"><code>++sum:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#diffe' title="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#invfe' title="Inverse order of modular field"><code>++inv:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#netfe' title="Flip endianness"><code>++net:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#outfe' title="Maximum integer value"><code>++out:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rolfe' title="Roll left"><code>++rol:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rorfe' title="Roll right"><code>++ror:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#sitfe' title="Enforce modulo"><code>++sit:fe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#sumfe' title="Sum two numbers in modular field"><code>++sum:fe</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#bex' title="Binary exponent"><code>++bex</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#can' title="Assemble"><code>++can</code></a>
@@ -914,12 +1096,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#cut' title="Slice"><code>++cut</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#end' title="Tail"><code>++end</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#fil' title="Fill bloqstream"><code>++fil</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#lsh' title="Left-shift"><code>++lsh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#lsh' title="Leftshift"><code>++lsh</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#met' title="Measure"><code>++met</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rap' title="Assemble non-zero"><code>++rap</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rap' title="Assemble nonzero"><code>++rap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rep' title="Assemble single"><code>++rep</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rip' title="Disassemble"><code>++rip</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rsh' title="Right-shift"><code>++rsh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rev' title="Reverse"><code>++rev</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rsh' title="Rightshift"><code>++rsh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#sew' title="Stitch one atom into another"><code>++sew</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#swp' title="Reverse block order"><code>++swp</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#xeb' title="Binary logarithm"><code>++xeb</code></a>
 
@@ -932,19 +1116,15 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2e: insecure hashing
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2e/#fnv' title="FNV scrambler"><code>++fnv</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2e/#mug' title="FNV-1a scrambler"><code>++mug</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2e/#mug' title="FNV1a scrambler"><code>++mug</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2e/#muk' title="Standard MurmurHash3"><code>++muk</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2e/#mum' title="31-bit MurmurHash3 scrambler"><code>++mum</code></a>
 
 ### 2f: noun ordering
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#aor' title="Alphabetical order"><code>++aor</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#dor' title="Numeric order"><code>++dor</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#gor' title="Hash order"><code>++gor</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#hor' title="Horizontal hash order"><code>++hor</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#lor' title="Leg order"><code>++lor</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#vor' title="Vertical order"><code>++vor</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#dor' title="Depth order"><code>++dor</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#gor' title="Mug order"><code>++gor</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#mor' title="(more) mug order"><code>++mor</code></a>
 
 ### 2g: unsigned powers
 
@@ -954,73 +1134,78 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 2h: set logic
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#in'><code>++in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#all-in' title="Logical AND (set and wet gate)"><code>++all:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#any-in' title="Logical OR (set and gate)"><code>++any:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#apt-in' title="Check correctness (set)"><code>++apt:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#bif-in' title="Bifurcate set"><code>++bif:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#del-in' title="Delete (set)"><code>++del:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#dif-in' title='Difference (set)'><code>++dif:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#dig-in' title="Address of a in set"><code>++dig:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#gas-in' title="Concatenate (set)"><code>++gas:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#has-in' title="Key existence check (set)"><code>++has:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#int-in' title="Intersection (set)"><code>++int:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#put-in' title="Put b in a (set)"><code>++put:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#rep-in' title="Accumulate elements (set)"><code>++rep:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#run-in' title="Apply gate to set"><code>++run:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#tap-in' title="Flatten set into list"><code>++tap:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#uni-in' title="Union (sets)"><code>++uni:in</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#wyt-in' title="Produce number of elements in set"><code>++wyt:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#allin' title="Logical AND (set and wet gate)"><code>++all:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#anyin' title="Logical OR (set and gate)"><code>++any:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#aptin' title="Check correctness (set)"><code>++apt:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#bifin' title="Bifurcate set"><code>++bif:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#delin' title="Delete (set)"><code>++del:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#difin' title='Difference (set)'><code>++dif:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#digin' title="Address of a in set"><code>++dig:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#gasin' title="Concatenate (set)"><code>++gas:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#hasin' title="Key existence check (set)"><code>++has:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#intin' title="Intersection (set)"><code>++int:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#putin' title="Put b in a (set)"><code>++put:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#repin' title="Accumulate elements (set)"><code>++rep:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#runin' title="Apply gate to set"><code>++run:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#tapin' title="Flatten set into list"><code>++tap:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#uniin' title="Union (sets)"><code>++uni:in</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#wytin' title="Produce number of elements in set"><code>++wyt:in</code></a>
 
 ### 2i: map logic
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#by' title="Map operations"><code>++by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#all-by' title="Logical AND (map and wet gate)"><code>++all:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#any-by' title="Logical OR (map and wet gate)"><code>++any:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#apt-by' title="Check correctness (map)"><code>++apt:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#bif-by' title="Bifurcate map"><code>++bif:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#del-by' title="Delete (map)"><code>++del:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#dig-by' title="Address of key (map)"><code>++dig:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#gas-by' title="Concatenate (map)"><code>++gas:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#get-by' title="Grab unit value"><code>++get:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#got-by' title="Assert for value (map)"><code>++got:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#gut-by' title="Grab value with default"><code>++gut:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#has-by' title="Key existence check (map)"><code>++has:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#int-by' title="Intersection (map)"><code>++int:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#mar-by' title="Assert and add (map)"><code>++mar:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#put-by' title="Add key-value pair (map)"><code>++put:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#rep-by' title="Replace by product (map)"><code>++rep:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#rib-by' title="Replace values with accumulator (map)"><code>++rib:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#run-by' title="Transform values (map)"><code>++run:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#rut-by' title="Transform nodes (map)"><code>++rut:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#tap-by' title="Listify pairs"><code>++tap:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#uni-by' title="Union (map between keys of two lists)"><code>++uni:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#urn-by' title="Turn (with key) (map)"><code>++urn:by</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#wyt-by' title="Produce depth of tree map"><code>++wyt:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#allby' title="Logical AND (map and wet gate)"><code>++all:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#anyby' title="Logical OR (map and wet gate)"><code>++any:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#aptby' title="Check correctness (map)"><code>++apt:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#bifby' title="Bifurcate map"><code>++bif:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#delby' title="Delete (map)"><code>++del:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#difby' title="Difference between maps"><code>++dif:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#digby' title="Address of key (map)"><code>++dig:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#gasby' title="Concatenate (map)"><code>++gas:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#getby' title="Grab unit value"><code>++get:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#gotby' title="Assert for value (map)"><code>++got:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#hasby' title="Key existence check (map)"><code>++has:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#intby' title="Intersection (map)"><code>++int:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#jabby' title="Transform value (map)"><code>++jab:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#keyby' title="Set of keys"><code>++key:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#marby' title="Add with validation (map)"><code>++mar:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#putby' title="Add keyvalue pair (map)"><code>++put:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#repby' title="Reduce to product (map)"><code>++rep:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#ribby' title="Transform + product (map)"><code>++rib:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#runby' title="Transform values (map)"><code>++run:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#rutby' title="Transform nodes (map)"><code>++rut:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#tapby' title="Listify pairs"><code>++tap:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#uniby' title="Union, merge (map)"><code>++uni:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#unoby' title="General union (map)"><code>++uno:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#urnby' title="Turn (with key) (map)"><code>++urn:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#wytby' title="Produce depth of tree map"><code>++wyt:by</code></a>
 
 ### 2j: jar and jug logic
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#ja' title="Jar engine"><code>++ja</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#add-ja' title="Prepend to list"><code>++add:ja</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#get-ja' title="Grab value by key"><code>++get:ja</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#addja' title="Prepend to list"><code>++add:ja</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#getja' title="Grab value by key"><code>++get:ja</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#ju' title="Jug operations"><code>++ju</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#del-ju' title="Delete (jug)"><code>++del:ju</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#get-ju' title="Retrieve set"><code>++get:ju</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#has-ju' title="Check contents (jug)"><code>++has:ju</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#put-ju' title="Add key-set pair (jar)"><code>++put:ju</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#delju' title="Delete (jug)"><code>++del:ju</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#gasju' title="Concatenate (jug)"><code>++gas:ju</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#getju' title="Retrieve set"><code>++get:ju</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#hasju' title="Check contents (jug)"><code>++has:ju</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#putju' title="Add keyset pair (jar)"><code>++put:ju</code></a>
 
 ### 2k: queue logic
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#to' title="Queue operations"><code>++to</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#bal-to' title="Balance queue"><code>++bal:to</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#dep-to' title="Maximum depth (queue)"><code>++dep:to</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#gas-to' title="Push list into queue"><code>++gas:to</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#get-to' title="Head-tail pair"><code>++get:to</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#nap-to' title="Remove head of queue"><code>++nap:to</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#nip-to' title="Remove root of queue"><code>++nip:to</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#put-to' title="Insert into queue"><code>++put:to</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#tap-to' title="Queue to list"><code>++tap:to</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#top-to' title="Produce head of queue"><code>++top:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#aptto' title="Check correctness of queue"><code>++apt:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#balto' title="Balance queue"><code>++bal:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#depto' title="Maximum depth (queue)"><code>++dep:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#gasto' title="Push list into queue"><code>++gas:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#getto' title="Headtail pair"><code>++get:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#napto' title="Remove head of queue"><code>++nap:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#nipto' title="Remove root of queue"><code>++nip:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#putto' title="Insert into queue"><code>++put:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#tapto' title="Queue to list"><code>++tap:to</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#topto' title="Produce head of queue"><code>++top:to</code></a>
 
 ### 2l: container from container
 
@@ -1031,30 +1216,31 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 2m: container from noun
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#nl' title="Noun to container operations"><code>++nl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#le-nl' title="Construct list from null-terminated noun"><code>++le:nl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#my-nl' title="Construct map from null-terminated noun"><code>++my:nl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#si-nl' title="Construct set from null-terminated noun"><code>++si:nl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#snag-nl' title="Produce element from list at specific null-terminated noun"><code>++snag:nl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#weld-nl' title="Concatenate null-terminated nouns"><code>++weld:nl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#lenl' title="Construct list from nullterminated noun"><code>++le:nl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#mynl' title="Construct map from nullterminated noun"><code>++my:nl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#sinl' title="Construct set from nullterminated noun"><code>++si:nl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#snagnl' title="Produce element from list at specific nullterminated noun"><code>++snag:nl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#weldnl' title="Concatenate nullterminated nouns"><code>++weld:nl</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#ly' title="List from raw noun"><code>++ly</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#my' title="Map from raw noun"><code>++my</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#sy' title="Produce set from null-terminated noun"><code>++sy</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#sy' title="Produce set from nullterminated noun"><code>++sy</code></a>
 
 ### 2n: functional hacks
 
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#aftr' title="Pair after"><code>++aftr</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#cork' title="Compose forward"><code>++cork</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#corl' title="Compose backward"><code>++corl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#curr' title="Right-curry a gate"><code>++curr</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#curr' title="Rightcurry a gate"><code>++curr</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#cury' title="Curry left a gate"><code>++cury</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#hard' title="Force remold"><code>++hard</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#fore' title="Pair before"><code>++fore</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#head' title="Get head of cell"><code>++head</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#mean' title="Crash and printf"><code>++mean</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#same' title="Identity (produces same value)"><code>++same</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#slog' title="Deify printf"><code>++slog</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#soft' title="Maybe remold"><code>++soft</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#succ' title="Successor"><code>++succ</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#tail' title="Get tail of cell"><code>++tail</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#test' title="Test for equality"><code>++test</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#lead' title="Put head"><code>++lead</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#late' title="Put tail"><code>++late</code></a>
 
 ### 2o: normalizing containers
 
@@ -1068,47 +1254,55 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#cue' title="Unpack atom to noun"><code>++cue</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#jam' title="Pack noun to atom"><code>++jam</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#mat' title="Length-encode"><code>++mat</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#rub' title="Length-decode"><code>++rub</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#mat' title="Lengthencode"><code>++mat</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2p/#rub' title="Lengthdecode"><code>++rub</code></a>
 
 ### 2q: molds and mold builders
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#char' title="Character"><code>++char</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#cord' title="UTF-8 text"><code>++cord</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#date' title="Point in time"><code>++date</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#knot' title="Atom type of ASCII characters"><code>++knot</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tang' title="Generic print structure"><code>++tang</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tank' title="Pretty-printing structure"><code>++tank</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tape' title="List of characters"><code>++tape</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tarp' title="Parsed time"><code>++tarp</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#term' title="Hoon constant"><code>++term</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#wain' title="List of cords"><code>++wain</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#wall' title="List of list of characters"><code>++wall</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#axis' title="Tree address"><code>+$axis</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#bean' title="Boolean"><code>+$bean</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#char' title="Character"><code>+$char</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#cord' title="UTF8 text"><code>+$cord</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#byts' title="bytes, LSB first"><code>+$byts</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#date' title="Parsed date"><code>+$date</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#flag' title="Boolean (flag)"><code>+$flag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#knot' title="Atom type of ASCII characters"><code>+$knot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#noun' title="Any noun"><code>+$noun</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#path' title="Like unix path"><code>+$path</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#stud' title="Standard name"><code>+$stud</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tang' title="Bottom-first error"><code>+$tang</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tank' title="Formatted print tree"><code>+$tank</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tape' title="List of characters"><code>+$tape</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tour' title="UTF-32 clusters"><code>+$tour</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#tarp' title="Parsed time"><code>+$tarp</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#term' title="Hoon constant"><code>+$term</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#wain' title="List of cords"><code>+$wain</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#wall' title="List of list of characters"><code>+$wall</code></a>
 
 ### 3a: modular and signed ints
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#fo' title="Modulo prime"><code>++fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#dif-fo' title='Subtraction (modular base)'><code>++dif:fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#exp-fo' title="Exponent (modular base)"><code>++exp:fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#fra-fo' title="Divide (modular base)"><code>++fra:fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#inv-fo' title="Inverse (signed modulus)"><code>++inv:fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#pro-fo' title="Multiplies b and c modulo a"><code>++pro:fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sit-fo' title="Produce remainder of b modulo a"><code>++sit:fo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sum-fo' title="Modular sum"><code>++sum:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#diffo' title='Subtraction (modular base)'><code>++dif:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#expfo' title="Exponent (modular base)"><code>++exp:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#frafo' title="Divide (modular base)"><code>++fra:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#invfo' title="Inverse (signed modulus)"><code>++inv:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#profo' title="Multiplies b and c modulo a"><code>++pro:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sitfo' title="Produce remainder of b modulo a"><code>++sit:fo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sumfo' title="Modular sum"><code>++sum:fo</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#si' title="Signed integer"><code>++si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#abs-si' title="Absolute value (signed integer)"><code>++abs:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#cmp-si' title="Compare (signed integer)"><code>++cmp:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#dif-si' title="Subtraction (signed integer)"><code>++dif:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#dul-si' title="Modulus (signed integer)"><code>++dul:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#fra-si' title="Divide (signed integer)"><code>++fra:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#new-si' title="Atom to @s"><code>++new:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#old-si' title="Sign and absolute value"><code>++old:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#pro-si' title="Multiply to signed integer"><code>++pro:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#rem-si' title="Remainder (signed integer)"><code>++rem:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sum-si' title="Addition (signed integer)"><code>++sum:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sun-si' title="@u to @s"><code>++sun:si</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#syn-si' title="Sign test"><code>++syn:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#abssi' title="Absolute value (signed integer)"><code>++abs:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#cmpsi' title="Compare (signed integer)"><code>++cmp:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#difsi' title="Subtraction (signed integer)"><code>++dif:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#dulsi' title="Modulus (signed integer)"><code>++dul:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#frasi' title="Divide (signed integer)"><code>++fra:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#newsi' title="Atom to @s"><code>++new:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#oldsi' title="Sign and absolute value"><code>++old:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#prosi' title="Multiply to signed integer"><code>++pro:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#remsi' title="Remainder (signed integer)"><code>++rem:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sumsi' title="Addition (signed integer)"><code>++sum:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sunsi' title="@u to @s"><code>++sun:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#synsi' title="Sign test"><code>++syn:si</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#egcd' title="Extended Euclidean algorithm"><code>++egcd</code></a>
 
@@ -1119,167 +1313,167 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#rn'><code>++rn</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ff'><code>++ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#add-ff' title="Add (floating point)"><code>++add:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bif-ff' title="Converts from fn to @r"><code>++bif:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bit-ff' title="fn to @r with rounding"><code>++bit:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#div-ff' title="Divide (IEEE float)"><code>++div:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drg-ff' title="@r to decimal float"><code>++drg:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equ-ff' title="Equals (IEEE float)"><code>++equ:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exp-ff' title="Get exponent (IEEE float)"><code>++exp:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fma-ff' title="Fused multiply-add (IEEE float)"><code>++fma:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grd-ff' title="Decimal float to @r"><code>++grd:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gte-ff' title="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gth-ff' title="Greater than (IEEE float)"><code>++gth:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lte-ff' title="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lth-ff' title="Less than (IEEE float)"><code>++lth:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#me-ff' title="Minimum exponent of ff"><code>++me:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mul-ff' title="Multiply (IEEE float)"><code>++mul:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#pa-ff' title="Initialize fl from ff core"><code>++pa:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#san-ff' title="Signed integer to @r"><code>++san:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sb-ff' title="Sign bit"><code>++sb:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sea-ff' title="Convert from IEEE float to fn"><code>++sea:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sig-ff' title="Produce sign of IEEE float"><code>++sig:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqt-ff' title="Produce square root from IEEE float"><code>++sqt:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sub-ff' title="Subtract from IEEE float"><code>++sub:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sun-ff' title="Unsigned integer to IEEE float"><code>++sun:ff</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toi-ff' title="Round IEEE float to nearest signed integer"><code>++toi:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addff' title="Add (floating point)"><code>++add:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bifff' title="Converts from fn to @r"><code>++bif:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bitff' title="fn to @r with rounding"><code>++bit:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#divff' title="Divide (IEEE float)"><code>++div:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgff' title="@r to decimal float"><code>++drg:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equff' title="Equals (IEEE float)"><code>++equ:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#expff' title="Get exponent (IEEE float)"><code>++exp:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmaff' title="Fused multiplyadd (IEEE float)"><code>++fma:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grdff' title="Decimal float to @r"><code>++grd:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gteff' title="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gthff' title="Greater than (IEEE float)"><code>++gth:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lteff' title="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lthff' title="Less than (IEEE float)"><code>++lth:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#meff' title="Minimum exponent of ff"><code>++me:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulff' title="Multiply (IEEE float)"><code>++mul:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#paff' title="Initialize fl from ff core"><code>++pa:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sanff' title="Signed integer to @r"><code>++san:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sbff' title="Sign bit"><code>++sb:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#seaff' title="Convert from IEEE float to fn"><code>++sea:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sigff' title="Produce sign of IEEE float"><code>++sig:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtff' title="Produce square root from IEEE float"><code>++sqt:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#subff' title="Subtract from IEEE float"><code>++sub:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sunff' title="Unsigned integer to IEEE float"><code>++sun:ff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toiff' title="Round IEEE float to nearest signed integer"><code>++toi:ff</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fl'><code>++fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#abs-fl' title="Absolute value"><code>++abs:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#add-fl' title="Add (with exact/rounded flag)"><code>++add:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#den-fl' title="Denormalizes (floating point)"><code>++den:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#div-fl' title="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drg-fl' title="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ead-fl' title="Exact add"><code>++ead:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emn-fl' title="Minimum exponent"><code>++emn:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emu-fl' title="Exact multiply"><code>++emu:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emx-fl' title="Maximum exponent"><code>++emx:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equ-fl' title="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fli-fl' title="Flip sign"><code>++fli:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fma-fl' title="Fused multiply-add"><code>++fma:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grd-fl' title="Decimal to float"><code>++grd:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gte-fl' title="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gth-fl' title="Greater than (producing flag)"><code>++gth:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ibl-fl' title="Integer binary logarithm"><code>++ibl:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#inv-fl' title="Inverse"><code>++inv:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lfe-fl' title="Maximum"><code>++lfe:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lfn-fl' title="Largest normal float"><code>++lfn:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lte-fl' title="Less than / equal (producing flag)"><code>++lte:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lth-fl' title="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lug-fl' title="Central rounding mechanism"><code>++lug:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mul-fl' title="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ned-fl' title="Require float"><code>++ned:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#prc-fl' title="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#rau-fl' title="Various roundings (floating point)"><code>++rau:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#rou-fl' title="Round to nearest float with 113-bit significand"><code>++rou:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#san-fl' title="Signed integer to float"><code>++san:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#shf-fl' title="Shift power"><code>++shf:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#spd-fl' title="Produce smallest denormalized float"><code>++spd:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#spn-fl' title="Produce smallest normal float"><code>++spn:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqt-fl' title="Produce square root from signed and unsigned integer cell"><code>++sqt:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sub-fl' title="Subtract from signed and unsigned integer cells"><code>++sub:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sun-fl' title="Unsigned integer to float"><code>++sun:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#swr-fl' title="Switch rounding mode of floating point"><code>++swr:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#syn-fl' title="Get sign"><code>++syn:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toi-fl' title="Round float to nearest signed integer"><code>++toi:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toj-fl' title="Round unsigned and signed integer to float"><code>++toj:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#uni-fl' title="Change representation to odd"><code>++uni:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#xpd-fl' title="Expand signed and unsigned integer cell"><code>++xpd:fl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#zer-fl' title="Produce zero as float"><code>++zer:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#absfl' title="Absolute value"><code>++abs:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addfl' title="Add (with exact/rounded flag)"><code>++add:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#denfl' title="Denormalizes (floating point)"><code>++den:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#divfl' title="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgfl' title="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#eadfl' title="Exact add"><code>++ead:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emnfl' title="Minimum exponent"><code>++emn:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emufl' title="Exact multiply"><code>++emu:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#emxfl' title="Maximum exponent"><code>++emx:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equfl' title="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#flifl' title="Flip sign"><code>++fli:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmafl' title="Fused multiplyadd"><code>++fma:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grdfl' title="Decimal to float"><code>++grd:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gtefl' title="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gthfl' title="Greater than (producing flag)"><code>++gth:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#iblfl' title="Integer binary logarithm"><code>++ibl:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#invfl' title="Inverse"><code>++inv:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lfefl' title="Maximum"><code>++lfe:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lfnfl' title="Largest normal float"><code>++lfn:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ltefl' title="Less than / equal (producing flag)"><code>++lte:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lthfl' title="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lugfl' title="Central rounding mechanism"><code>++lug:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulfl' title="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#nedfl' title="Require float"><code>++ned:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#prcfl' title="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#raufl' title="Various roundings (floating point)"><code>++rau:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#roufl' title="Round to nearest float with 113bit significand"><code>++rou:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sanfl' title="Signed integer to float"><code>++san:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#shffl' title="Shift power"><code>++shf:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#spdfl' title="Produce smallest denormalized float"><code>++spd:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#spnfl' title="Produce smallest normal float"><code>++spn:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtfl' title="Produce square root from signed and unsigned integer cell"><code>++sqt:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#subfl' title="Subtract from signed and unsigned integer cells"><code>++sub:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sunfl' title="Unsigned integer to float"><code>++sun:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#swrfl' title="Switch rounding mode of floating point"><code>++swr:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#synfl' title="Get sign"><code>++syn:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toifl' title="Round float to nearest signed integer"><code>++toi:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#tojfl' title="Round unsigned and signed integer to float"><code>++toj:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#unifl' title="Change representation to odd"><code>++uni:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#xpdfl' title="Expand signed and unsigned integer cell"><code>++xpd:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#zerfl' title="Produce zero as float"><code>++zer:fl</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#rd'><code>++rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#add-rd' title="Add (double-precision float)"><code>++add:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bit-rd' title="fn to double-precision binary float"><code>++bit:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#div-rd' title="Double precision float"><code>++div:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drg-rd' title="@rd to decimal float"><code>++drg:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equ-rd' title="Equals (double-precision float)"><code>++equ:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exp-rd' title="Exponent (@rd)"><code>++exp:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fma-rd' title="Fused multiply-add (@rd)"><code>++fma:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grd-rd' title="Decimal float to @rd"><code>++grd:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gte-rd' title="Greater than / equal (double-precision float)"><code>++gte:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gth-rd' title="Greater than (double-precision float)"><code>++gth:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lte-rd' title="Less than / equal (double-precision float)"><code>++lte:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lth-rd' title="Less than (double-precision float)"><code>++lth:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ma-rd' title="Initialize ff (rd core)"><code>++ma:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mul-rd' title="Multiply (double-precision float)"><code>++mul:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#san-rd' title="Unsigned integer to @rd"><code>++san:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sea-rd' title="Convert from double-precision binary float to fn"><code>++sea:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sig-rd' title="Produce sign of @rd"><code>++sig:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqt-rd' title="Produce square root of double-precision float"><code>++sqt:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sub-rd' title="Subtract from double-precision float"><code>++sub:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sun-rd' title="Unsigned integer to double-precision float"><code>++sun:rd</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toi-rd' title="Round double-precision float to nearest signed integer"><code>++toi:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addrd' title="Add (doubleprecision float)"><code>++add:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bitrd' title="fn to doubleprecision binary float"><code>++bit:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#divrd' title="Double precision float"><code>++div:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgrd' title="@rd to decimal float"><code>++drg:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equrd' title="Equals (doubleprecision float)"><code>++equ:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exprd' title="Exponent (@rd)"><code>++exp:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmard' title="Fused multiplyadd (@rd)"><code>++fma:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grdrd' title="Decimal float to @rd"><code>++grd:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gterd' title="Greater than / equal (doubleprecision float)"><code>++gte:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gthrd' title="Greater than (doubleprecision float)"><code>++gth:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lterd' title="Less than / equal (doubleprecision float)"><code>++lte:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lthrd' title="Less than (doubleprecision float)"><code>++lth:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mard' title="Initialize ff (rd core)"><code>++ma:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulrd' title="Multiply (doubleprecision float)"><code>++mul:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sanrd' title="Unsigned integer to @rd"><code>++san:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#seard' title="Convert from doubleprecision binary float to fn"><code>++sea:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sigrd' title="Produce sign of @rd"><code>++sig:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtrd' title="Produce square root of doubleprecision float"><code>++sqt:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#subrd' title="Subtract from doubleprecision float"><code>++sub:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sunrd' title="Unsigned integer to doubleprecision float"><code>++sun:rd</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toird' title="Round doubleprecision float to nearest signed integer"><code>++toi:rd</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#rh'><code>++rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#add-rh' title="Add (half-precision float)"><code>++add:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bit-rh' title="fn to half-precision float"><code>++bit:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#div-rh' title="Divide (half-precision float)"><code>++div:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drg-rh' title="@rh to decimal float"><code>++drg:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equ-rh' title="Equals (half-precision float)"><code>++equ:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exp-rh' title="Exponent (half-precision float)"><code>++exp:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fma-rh' title="Fused multiply-add (half-precision float)"><code>++fma:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fos-rh' title="@rs to @rh"><code>++fos:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grd-rh' title="Decimal float to @rh"><code>++grd:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gte-rh' title="Greater than / equal (half-precision float)"><code>++gte:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gth-rh' title="Greater than (half-precision float)"><code>++gth:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lte-rh' title="Less than / equal (half-precision float)"><code>++lte:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lth-rh' title="Less than (half-precision float)"><code>++lth:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ma-rh' title="Initialize ff (rh core)"><code>++ma:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mul-rh' title="Multiply (quad-precision float)"><code>++mul:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#san-rh' title="Signed integer to @rh"><code>++san:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sea-rh' title="Convert from half-precision float to fn"><code>++sea:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sig-rh' title="Produce sign of half-precision float"><code>++sig:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqt-rh' title="Produce square root of half-precision float"><code>++sqt:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sub-rh' title="Subtract from half-precision float"><code>++sub:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sun-rh' title="Unsigned integer to half-precision float"><code>++sun:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toi-rh' title="Round half-precision float to nearest signed integer"><code>++toi:rh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#tos-rh' title="Convert half-precision float to single-precision float"><code>++tos:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addrh' title="Add (halfprecision float)"><code>++add:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bitrh' title="fn to halfprecision float"><code>++bit:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#divrh' title="Divide (halfprecision float)"><code>++div:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgrh' title="@rh to decimal float"><code>++drg:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equrh' title="Equals (halfprecision float)"><code>++equ:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exprh' title="Exponent (halfprecision float)"><code>++exp:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmarh' title="Fused multiplyadd (halfprecision float)"><code>++fma:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fosrh' title="@rs to @rh"><code>++fos:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grdrh' title="Decimal float to @rh"><code>++grd:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gterh' title="Greater than / equal (halfprecision float)"><code>++gte:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gthrh' title="Greater than (halfprecision float)"><code>++gth:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lterh' title="Less than / equal (halfprecision float)"><code>++lte:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lthrh' title="Less than (halfprecision float)"><code>++lth:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#marh' title="Initialize ff (rh core)"><code>++ma:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulrh' title="Multiply (quadprecision float)"><code>++mul:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sanrh' title="Signed integer to @rh"><code>++san:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#searh' title="Convert from halfprecision float to fn"><code>++sea:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sigrh' title="Produce sign of halfprecision float"><code>++sig:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtrh' title="Produce square root of halfprecision float"><code>++sqt:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#subrh' title="Subtract from halfprecision float"><code>++sub:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sunrh' title="Unsigned integer to halfprecision float"><code>++sun:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toirh' title="Round halfprecision float to nearest signed integer"><code>++toi:rh</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#tosrh' title="Convert halfprecision float to singleprecision float"><code>++tos:rh</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#rs'><code>++rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#add-rs' title="Add (single-precision float)"><code>++add:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bit-rs' title="fn to single-precision float"><code>++bit:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#div-rs' title="Divide (single-precision float)"><code>++div:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drg-rs' title="@rs to decimal float"><code>++drg:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equ-rs' title="Equals (single-precision float)"><code>++equ:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exp-rs' title="Exponent (@rs)"><code>++exp:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fma-rs' title="Fused multiply-add (single-precision float)"><code>++fma:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grd-rs' title="Decimal float to @rs"><code>++grd:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gte-rs' title="Greater than / equal (single-precision float)"><code>++gte:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gth-rs' title="Greater than (single-precision float)"><code>++gth:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lte-rs' title="Less than / equal (single-precision float)"><code>++lte:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lth-rs' title="Less than (single-precision float)"><code>++lth:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ma-rs' title="Initialize ff (rs core)"><code>++ma:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mul-rs' title="Multiply (single-precision float)"><code>++mul:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#san-rs' title="Signed integer to @rs"><code>++san:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sea-rs' title="Convert from single-precision float to fn"><code>++sea:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sig-rs' title="Produce sign of @rs"><code>++sig:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqt-rs' title="Produce square root of single-precision float"><code>++sqt:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sub-rs' title="Subtract from single-precision float"><code>++sub:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sun-rs' title="Unsigned integer to single-precision float"><code>++sun:rs</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toi-rs' title="Round single-precision float to nearest signed integer"><code>++toi:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addrs' title="Add (singleprecision float)"><code>++add:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bitrs' title="fn to singleprecision float"><code>++bit:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#divrs' title="Divide (singleprecision float)"><code>++div:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgrs' title="@rs to decimal float"><code>++drg:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equrs' title="Equals (singleprecision float)"><code>++equ:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exprs' title="Exponent (@rs)"><code>++exp:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmars' title="Fused multiplyadd (singleprecision float)"><code>++fma:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grdrs' title="Decimal float to @rs"><code>++grd:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gters' title="Greater than / equal (singleprecision float)"><code>++gte:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gthrs' title="Greater than (singleprecision float)"><code>++gth:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lters' title="Less than / equal (singleprecision float)"><code>++lte:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lthrs' title="Less than (singleprecision float)"><code>++lth:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mars' title="Initialize ff (rs core)"><code>++ma:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulrs' title="Multiply (singleprecision float)"><code>++mul:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sanrs' title="Signed integer to @rs"><code>++san:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sears' title="Convert from singleprecision float to fn"><code>++sea:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sigrs' title="Produce sign of @rs"><code>++sig:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtrs' title="Produce square root of singleprecision float"><code>++sqt:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#subrs' title="Subtract from singleprecision float"><code>++sub:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sunrs' title="Unsigned integer to singleprecision float"><code>++sun:rs</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toirs' title="Round singleprecision float to nearest signed integer"><code>++toi:rs</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#rq'><code>++rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#add-rq' title="Add (quad-precision float)"><code>++add:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bit-rq' title="fn to quad-precision float"><code>++bit:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#div-rq' title="Divide (quad-precision float)"><code>++div:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drg-rq' title="@rq to decimal float"><code>++drg:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equ-rq' title="Equals (quad-precision float)"><code>++equ:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exp-rq' title="Exponent (quad-precision float)"><code>++exp:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fma-rq' title="Fused multiply-add (quad-precision float)"><code>++fma:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grd-rq' title="Decimal float to @rq"><code>++grd:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gte-rq' title="Greater than / equal (quad-precision float)"><code>++gte:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gth-rq' title="Greater than (quad-precision float)"><code>++gth:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lte-rq' title="Less than / equal (quad-precision float)"><code>++lte:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lth-rq' title="Less than (quad-precision float)"><code>++lth:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#ma-rq' title="Initialize ff (rq core)"><code>++ma:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mul-rq' title="Multiply (quad-precision float)"><code>++mul:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#san-rq' title="Signed integer to @rq"><code>++san:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sea-rq' title="Convert from quad-precision float to fn"><code>++sea:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sig-rq' title="Produce sign of quad-precision float"><code>++sig:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqt-rq' title="Produce square root of quad-precision float"><code>++sqt:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sub-rq' title="Subtract from quad-precision float"><code>++sub:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sun-rq' title="Unsigned integer to quad-precision float"><code>++sun:rq</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toi-rq' title="Round quad-precision float to nearest signed integer"><code>++toi:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addrq' title="Add (quadprecision float)"><code>++add:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#bitrq' title="fn to quadprecision float"><code>++bit:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#divrq' title="Divide (quadprecision float)"><code>++div:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#drgrq' title="@rq to decimal float"><code>++drg:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#equrq' title="Equals (quadprecision float)"><code>++equ:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#exprq' title="Exponent (quadprecision float)"><code>++exp:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmarq' title="Fused multiplyadd (quadprecision float)"><code>++fma:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#grdrq' title="Decimal float to @rq"><code>++grd:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gterq' title="Greater than / equal (quadprecision float)"><code>++gte:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#gthrq' title="Greater than (quadprecision float)"><code>++gth:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lterq' title="Less than / equal (quadprecision float)"><code>++lte:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lthrq' title="Less than (quadprecision float)"><code>++lth:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#marq' title="Initialize ff (rq core)"><code>++ma:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulrq' title="Multiply (quadprecision float)"><code>++mul:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sanrq' title="Signed integer to @rq"><code>++san:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#searq' title="Convert from quadprecision float to fn"><code>++sea:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sigrq' title="Produce sign of quadprecision float"><code>++sig:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtrq' title="Produce square root of quadprecision float"><code>++sqt:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#subrq' title="Subtract from quadprecision float"><code>++sub:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sunrq' title="Unsigned integer to quadprecision float"><code>++sun:rq</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#toirq' title="Round quadprecision float to nearest signed integer"><code>++toi:rq</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#rlyd'><code>++rlyd</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#rlyh'><code>++rlyh</code></a>
@@ -1293,43 +1487,43 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 3c: urbit time
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yo' title="Time constants core"><code>++yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#cet-yo' title="Days in a century"><code>++cet:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#day-yo' title="Seconds in day"><code>++day:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#era-yo' title="Leap-year period"><code>++era:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#hor-yo' title="Seconds in hour"><code>++hor:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#jes-yo' title="Maximum 64-bit timestamp"><code>++jes:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#mit-yo' title="Seconds in minute"><code>++mit:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#moh-yo' title="Days in month"><code>++moh:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#moy-yo' title="Days in months of leap-year"><code>++moy:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#qad-yo' title="Seconds in 4 years"><code>++qad:yo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yer-yo' title="Seconds in year"><code>++yer:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#cetyo' title="Days in a century"><code>++cet:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#dayyo' title="Seconds in day"><code>++day:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#erayo' title="Leapyear period"><code>++era:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#horyo' title="Seconds in hour"><code>++hor:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#jesyo' title="Maximum 64bit timestamp"><code>++jes:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#mityo' title="Seconds in minute"><code>++mit:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#mohyo' title="Days in month"><code>++moh:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#moyyo' title="Days in months of leapyear"><code>++moy:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#qadyo' title="Seconds in 4 years"><code>++qad:yo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yeryo' title="Seconds in year"><code>++yer:yo</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yall' title="Time since beginning of time"><code>++yall</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yawn' title="Days since beginning of time"><code>++yawn</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#year' title="Date to @d"><code>++year</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yell' title="Tarp from atomic date"><code>++yell</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yelp' title="Determine if leap-week"><code>++yelp</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yelp' title="Determine if leapweek"><code>++yelp</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yore' title="Date from atomic date"><code>++yore</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#yule' title="Daily time to time atom"><code>++yule</code></a>
 
 ### 3d: SHA hash family
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#og' title="Container arm for SHA-256 powered RNG"><code>++og</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#rad-og' title="Random in range"><code>++rad:og</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#rads-og' title="Random continuation"><code>++rads:og</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#raw-og' title="Random bits"><code>++raw:og</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#raws-og' title="Random bits continuation"><code>++raws:og</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#og' title="Container arm for SHA256 powered RNG"><code>++og</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#radog' title="Random in range"><code>++rad:og</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#radsog' title="Random continuation"><code>++rads:og</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#rawog' title="Random bits"><code>++raw:og</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#rawsog' title="Random bits continuation"><code>++raws:og</code></a>
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shad' title="Double SHA-256"><code>++shad</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shaf' title="Half SHA-256"><code>++shaf</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shal' title="SHA-512 with length"><code>++shal</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#sham' title="128-bit noun hash"><code>++sham</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shan' title="SHA-1"><code>++shan</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shad' title="Double SHA256"><code>++shad</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shaf' title="Half SHA256"><code>++shaf</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shal' title="SHA512 with length"><code>++shal</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#sham' title="128bit noun hash"><code>++sham</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shan' title="SHA1"><code>++shan</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shas' title="Salted hash"><code>++shas</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shaw' title="Hash to nbits"><code>++shaw</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shax' title="SHA-256"><code>++shax</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shay' title="SHA-256 with length"><code>++shay</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shaz' title="SHA-512"><code>++shaz</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shax' title="SHA256"><code>++shax</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shay' title="SHA256 with length"><code>++shay</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shaz' title="SHA512"><code>++shaz</code></a>
 
 ### 3e: AES encryption
 
@@ -1338,96 +1532,97 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 3f: scrambling
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#ob' title="Reversible scrambling v2"><code>++ob</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#feen-ob' title="Conceal structure v2"><code>++feen:ob</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#fend-ob' title="Restore structure v2"><code>++fend:ob</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#fice-ob' title="Feistel-like cipher"><code>++fice:ob</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#raku-ob' title="Key list"><code>++raku:ob</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#rund-ob' title="Reverse single Feistel-like"><code>++rund:ob</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#rynd-ob' title="Reverse Feistel-like cipher"><code>++rynd:ob</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#teil-ob' title="Reverse Feistel-like cipher"><code>++teil:ob</code></a>
-
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#feinob' title="Conceal structure v3"><code>++fein:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#fyndob' title="Restore structure v3"><code>++fynd:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#feisob' title="Four-round generalised Feistel cipher over the domain [0, 2^32 - 2^16 - 1]"><code>++feis:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#rakuob' title="Key list"><code>++raku:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#tailob' title="Reverse +feis"><code>++tail:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#feeob' title="Feistel cipher Fe in B&R (2002)"><code>++fee:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#feenob' title="Reverse +fee"><code>++feen:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#feob' title="Internal function to +fee"><code>++fe:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#fenob' title="Reverse +fe"><code>++fen:ob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#effob' title="murmur3-based pseudorandom function"><code>++eff:ob</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#un' title="Reversible scrambling"><code>++un</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#wred-un' title="Restore structure"><code>++wred:un</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#wren-un' title="Conceal structure"><code>++wren:un</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#xafo-un'><code>++xafo:un</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#xaro-un'><code>++xaro:un</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zaft-un' title="Look up in 255 sub box"><code>++zaft:un</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zart-un' title="Reverse look up in 255 sub box"><code>++zart:un</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zyft-un' title="Lookup byte in 256 sub box"><code>++zyft:un</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zyrt-un' title="Reverse lookup byte in 256 sub box"><code>++zyrt:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#wredun' title="Restore structure"><code>++wred:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#wrenun' title="Conceal structure"><code>++wren:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#xafoun'><code>++xafo:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#xaroun'><code>++xaro:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zaftun' title="Look up in 255 sub box"><code>++zaft:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zartun' title="Reverse look up in 255 sub box"><code>++zart:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zyftun' title="Lookup byte in 256 sub box"><code>++zyft:un</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#zyrtun' title="Reverse lookup byte in 256 sub box"><code>++zyrt:un</code></a>
 
 ### 3g: molds and mold builders
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#coin' title="Noun-literal syntax cases"><code>++coin</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#dime' title="Aura-atom pair"><code>++dime</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#edge' title="Parsing location metadata"><code>++edge</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#hair' title="Parsing line and column"><code>++hair</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#coin' title="Nounliteral syntax cases"><code>+$coin</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#dime' title="Auraatom pair"><code>+$dime</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#edge' title="Parsing location metadata"><code>+$edge</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#hair' title="Parsing line and column"><code>+$hair</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#like' title="Generic edge"><code>++like</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#nail' title="Location, remainder of parsed text"><code>++nail</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#path' title="Filesystem path"><code>++path</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#pint' title="Parsing range"><code>++pint</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#rule' title="Parsing rule (match this with _)"><code>++rule</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#spot' title="Stack trace line"><code>++spot</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#tone' title="Nock result (error report)"><code>++tone</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#toon' title="Nock result (stack trace)"><code>++toon</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#nail' title="Location, remainder of parsed text"><code>+$nail</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#pint' title="Parsing range"><code>+$pint</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#rule' title="Parsing rule (match this with _)"><code>+$rule</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#spot' title="Stack trace line"><code>+$spot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#tone' title="Nock result (error report)"><code>+$tone</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#toon' title="Nock result (stack trace)"><code>+$toon</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#wonk' title="Product from edge"><code>++wonk</code></a>
 
 ### 4a: exotic bases
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#po' title="Phonetic base"><code>++po</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#ind-po' title="Parse suffix"><code>++ind:po</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#ins-po' title="Parse prefix"><code>++ins:po</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#tod-po' title="Fetch suffix"><code>++tod:po</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#tos-po' title="Fetch prefix"><code>++tos:po</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#indpo' title="Parse suffix"><code>++ind:po</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#inspo' title="Parse prefix"><code>++ins:po</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#todpo' title="Fetch suffix"><code>++tod:po</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#tospo' title="Fetch prefix"><code>++tos:po</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#fa' title="base58check"><code>++fa</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#chafa' title="Decode base58check character"><code>++cha:fa</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#tokfa' title="Compute base58check checksum"><code>++tok:fa</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#padfa' title="base58check padding bytes"><code>++pad:fa</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#encfa' title="Encode base58check"><code>++enc:fa</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#denfa' title="Decode base58check"><code>++den:fa</code></a>
 
 ### 4b: text processing
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#at' title="(Undocumented)"><code>++at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#r-at' title="(Undocumented)"><code>++r:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rf-at' title="(Undocumented)"><code>++rf:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rn-at' title="(Undocumented)"><code>++rn:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rt-at' title="(Undocumented)"><code>++rt:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rta-at' title="(Undocumented)"><code>++rta:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rtam-at' title="(Undocumented)"><code>++rtam:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rub-at' title="(Undocumented)"><code>++rub:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rud-at' title="(Undocumented)"><code>++rud:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rum-at' title="(Undocumented)"><code>++rum:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rup-at' title="(Undocumented)"><code>++rup:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#ruv-at' title="(Undocumented)"><code>++ruv:at</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rux-at' title="(Undocumented)"><code>++rux:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#at' title="Basic printing"><code>++at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rat' title="Print term, number or hex"><code>++r:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rfat' title="Print loobean"><code>++rf:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rnat' title="Print null"><code>++rn:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rtat' title="Print cord, including escape characters"><code>++rt:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rtaat' title="Print cord, including escape characters"><code>++rta:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rtamat' title="Print cord with @tas syntax"><code>++rtam:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rubat' title="Print binary"><code>++rub:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rudat' title="Print atom as integer"><code>++rud:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rumat' title="Print base-n"><code>++rum:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rupat' title="Print @p (outdated)"><code>++rup:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#ruvat' title="Print base-64"><code>++ruv:at</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#ruxat' title="Print hexadecimal"><code>++rux:at</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#cass' title="To lowercase"><code>++cass</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#crip' title="Tape to cord"><code>++crip</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#cuss' title="To uppercase"><code>++cuss</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#mesc' title="Escape special characters"><code>++mesc</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#runt' title="Prepend n times"><code>++runt</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#sand' title="Soft-cast by aura"><code>++sand</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#sand' title="Softcast by aura"><code>++sand</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#sane' title="Check aura validity"><code>++sane</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#teff' title="UTF-8 length"><code>++teff</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#teff' title="UTF8 length"><code>++teff</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#trim' title="Tape split"><code>++trim</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#trip' title="Cord to tape"><code>++trip</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tuba' title="UTF-8 to UTF-32 tape"><code>++tuba</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tufa' title="UTF-32 to UTF-8 tape"><code>++tufa</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tuft' title="UTF-32 to UTF-8 text"><code>++tuft</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#turf' title="UTF-8 to UTF-32 cord"><code>++turf</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#wack' title="Coin format encode"><code>++wack</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#wick' title="Coin format decode"><code>++wick</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tuba' title="UTF8 to UTF32 tape"><code>++tuba</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tufa' title="UTF32 to UTF8 tape"><code>++tufa</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#tuft' title="UTF32 to UTF8 text"><code>++tuft</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#taft' title="UTF8 to UTF32 cord"><code>++taft</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#wack' title="Knot escape"><code>++wack</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#wick' title="Knot unescape"><code>++wick</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#woad' title="Unescape cord"><code>++woad</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#wood' title="Escape cord"><code>++wood</code></a>
 
 ### 4c: tank printer
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#re' title="Pretty-printing engine (tank)"><code>++re</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#din-re' title="(Undocumented)"><code>++din:re</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#fit-re' title="Fit on one line test"><code>++fit:re</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#ram-re' title="Flatten tank to tape"><code>++ram:re</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#rig-re' title="Wrap tape in / (tank)"><code>++rig:re</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#wig-re' title="++win - render tape"><code>++wig:re</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#win-re' title="Render at indent"><code>++win:re</code></a>
-
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#shep' title="(Undocumented)"><code>++shep</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#shop' title="(Undocumented)"><code>++shop</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#show' title="(Undocumented)"><code>++show</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#wash' title="Render tank at width"><code>++wash</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#re' title="Prettyprinting engine (tank)"><code>++re</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#ramre' title="Flatten tank to tape"><code>++ram:re</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#winre' title="Render at indent"><code>++win:re</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#show' title="Pretty-printer (deprecated)"><code>++show</code></a>
 
 ### 4d: parsing (tracing)
 
@@ -1449,15 +1644,17 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4f: parsing (rule builders)
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#bass' title="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#bass' title="Parser modifier (LSBordered ++list as atom of ++base)"><code>++bass</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#boss' title="Parser modifier: LSB"><code>++boss</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#cold' title="Replace with constant"><code>++cold</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#cook' title="Apply gate"><code>++cook</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#easy' title="Always parse"><code>++easy</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#full' title="Parse to end"><code>++full</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#funk' title="Add to tape"><code>++funk</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#here' title="Place-based apply"><code>++here</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#fuss' title="Has A or B?"><code>++fuss</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#here' title="Placebased apply"><code>++here</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#ifix' title="Infix"><code>++ifix</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#inde' title="Indentation block"><code>++inde</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#jest' title="Match a cord"><code>++jest</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#just' title="Match a single character"><code>++just</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#knee' title="Recursive parsers"><code>++knee</code></a>
@@ -1465,13 +1662,15 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#more' title="Parse list with delimiter"><code>++more</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#most' title="Parse list of at least one match"><code>++most</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#next' title="Consume character"><code>++next</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#perk' title="Parse cube fork"><code>++perk</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#plus' title="List of at least one match"><code>++plus</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#punt' title="Unitized parse"><code>++punt</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#sear' title="Conditional ++cook"><code>++sear</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#shim' title="Match character within range"><code>++shim</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#slug' title="Use gate to parse delimited list"><code>++slug</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stag' title="Add label"><code>++stag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#star' title="Produce list of matches"><code>++star</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stet' title="Add faces to range-parser pairs in list"><code>++stet</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stet' title="Add faces to rangeparser pairs in list"><code>++stet</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stew' title="Switch by first"><code>++stew</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stir' title="Parse repeatedly"><code>++stir</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#stun' title="Parse several times"><code>++stun</code></a>
@@ -1479,6 +1678,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 4g: parsing (outside caller)
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4g/#rash' title="Parse or crash"><code>++rash</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4g/#rose' title="Parse to each"><code>++rose</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4g/#rush' title="Parse or null"><code>++rush</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4g/#rust' title="Parse tape or null"><code>++rust</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4g/#scan' title="Parse tape or crash"><code>++scan</code></a>
@@ -1499,22 +1699,22 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#gal' title="Parse < (gal)"><code>++gal</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#gar' title="Parse > (gar)"><code>++gar</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#hax' title="Parse # (hax)"><code>++hax</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#hep' title="Parse - (hep)"><code>++hep</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#hep' title="Parse  (hep)"><code>++hep</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#kel' title="Parse { (kel)"><code>++kel</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#ker' title="Parse } (ker)"><code>++ker</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#ket' title="Parse ^ (ket)"><code>++ket</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#lus' title="Parse + (lus)"><code>++lus</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#pam' title="Parse & (pam)"><code>++pam</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#pat' title="Parse @ (pat)"><code>++pat</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#pel' title="Parse ( (pel)"><code>++pel</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#per' title="Parse ) (per)"><code>++per</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#pal' title="Parse ( (pal)"><code>++pal</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#par' title="Parse ) (par)"><code>++par</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#sel' title="Parse [ (sel)"><code>++sel</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#sem' title="Parse ; (sem)"><code>++sem</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#mic' title="Parse ; (mic)"><code>++mic</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#ser' title="Parse ] (ser)"><code>++ser</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#sig' title="Parse ~ (sig)"><code>++sig</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#soq' title="Parse ' (soq)"><code>++soq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#tar' title="Parse * (tar)"><code>++tar</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#tec' title="Parse ` (tec)"><code>++tec</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#tic' title="Parse ` (tic)"><code>++tic</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#tis' title="Parse = (tis)"><code>++tis</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#wut' title="Parse ? (wut)"><code>++wut</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#zap' title="Parse ! (zap)"><code>++zap</code></a>
@@ -1523,16 +1723,17 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#alf' title="Parse alphabetic characters"><code>++alf</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#aln' title="Parse alphanumeric characters"><code>++aln</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#alp' title="Parse alphanumeric characters and -"><code>++alp</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#alp' title="Parse alphanumeric characters and "><code>++alp</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#bet' title="Parse hep and lus axis syntax"><code>++bet</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#bin' title="Binary to atom"><code>++bin</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#but' title="Parse binary digit"><code>++but</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#cit' title="Octal digit"><code>++cit</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#dem' title="Decimal to atom"><code>++dem</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#dit' title="Decimal digit"><code>++dit</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#dof' title="Hep & optional gap"><code>++dof</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#dog' title="Optional gap"><code>++dog</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#doh' title="@p separator"><code>++doh</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#dun' title="-- to ~"><code>++dun</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#dun' title=" to ~"><code>++dun</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#duz' title="== to ~"><code>++duz</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#gah' title="New line or ''"><code>++gah</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#gap' title="Plural whitespace"><code>++gap</code></a>
@@ -1547,13 +1748,15 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#iny' title="Indentation block"><code>++iny</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#low' title="Parse lowercase letter"><code>++low</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#mes' title="Parse hexabyte"><code>++mes</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#nix' title="Parse letters and -"><code>++nix</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#nix' title="Parse letters and underscore"><code>++nix</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#nud' title="Parse numeric character"><code>++nud</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#prn' title="Parse any printable character"><code>++prn</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#qat' title="Parse chars in blockcord"><code>++qat</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#qit' title="Parse character to cord atom"><code>++qit</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#qut' title="Parse cord"><code>++qut</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#soz' title="Parse triple single-quote"><code>++soz</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#soz' title="Parse triple singlequote"><code>++soz</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#sym' title="Term"><code>++sym</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#mixed-case-symbol' title="Mixed-case term"><code>++mixed-case-symbol</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#ven' title="Axis syntax parser"><code>++ven</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#vit' title="Parse base 64 digit"><code>++vit</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#vul' title="Comments to null"><code>++vul</code></a>
@@ -1561,85 +1764,114 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 4j: parsing (bases and base digits)
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ab' title="Primitive parser engine"><code>++ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bix-ab' title="Parse hex pair"><code>++bix:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hif-ab' title="Parse phonetic pair"><code>++hif:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#huf-ab' title="Parse two phonetic pairs"><code>++huf:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hyf-ab' title="Parse 8 phonetic bytes"><code>++hyf:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pev-ab' title="Parse <=5 in base 32"><code>++pev:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pew-ab' title="Parse <= 5 in base 64"><code>++pew:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#piv-ab' title="Parse 5 digits in base 32"><code>++piv:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#piw-ab' title="Parse 5 digits in base 64"><code>++piw:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qeb-ab' title="Parse <=4 binary digits"><code>++qeb:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qex-ab' title="Parse <=4 hexadecimal digits"><code>++qex:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qib-ab' title="Parse 4 binary digits"><code>++qib:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qix-ab' title="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#seb-ab' title="Parse 1"><code>++seb:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sed-ab' title="Parse non-zero decimal digit"><code>++sed:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sev-ab' title="Parse non-zero base 32 digit"><code>++sev:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sew-ab' title="Parse non-zero base 64 digit"><code>++sew:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sex-ab' title="Parse nonzero hexadecimal digit"><code>++sex:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sib-ab' title="Parse binary digit"><code>++sib:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sid-ab' title="Parse decimal digit"><code>++sid:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#siv-ab' title="Parse a base 32 digit"><code>++siv:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#siw-ab' title="Parse a base 64 digit"><code>++siw:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#six-ab' title="Parse a hexadecimal digit"><code>++six:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sov-ab' title="Parse base 32 letter"><code>++sov:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sow-ab' title="Parse base 64 letter/symbol"><code>++sow:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sox-ab' title="Parse hexadecimal letter"><code>++sox:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ted-ab' title="Parse decimal number with <= 3 digits"><code>++ted:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tid-ab' title="Parse 3 decimal digits"><code>++tid:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#til-ab' title="Parse 3 lowercase letters"><code>++til:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tip-ab' title="Leading phonetic byte"><code>++tip:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tiq-ab' title="Trailing phonetic syllable"><code>++tiq:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#urs-ab' title="Parse span characters"><code>++urs:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#urt-ab' title="Parse non-_ span"><code>++urt:ab</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#voy-ab' title="Parse bas, soq, or bix"><code>++voy:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bixab' title="Parse hex pair"><code>++bix:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#femab' title="Parse base58check char"><code>++fem:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hafab' title="Parse non-doz phonetic pair"><code>++haf:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hefab' title="Parse non-dozzod phonetic pair"><code>++hef:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hifab' title="Parse phonetic pair"><code>++hif:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hofab' title="Parse 2-4 @q phonetic pair"><code>++hof:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hufab' title="Parse 1-4 @q phonetic pairs"><code>++huf:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hyfab' title="Parse four @q phonetic pairs"><code>++hyf:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pevab' title="Parse 1-5 @uv base-32 chars"><code>++pev:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pewab' title="Parse <= 5 in base 64"><code>++pew:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pivab' title="Parse 5 @uv base-32 chars"><code>++piv:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#piwab' title="Parse 5 @uw base-64 chars"><code>++piw:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qebab' title="Parse 1-4 binary digits"><code>++qeb:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qexab' title="Parse 1-4 hex digits"><code>++qex:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qibab' title="Parse 4 binary digits"><code>++qib:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#qixab' title="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sebab' title="Parse 1"><code>++seb:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sedab' title="Parse nonzero decimal digit"><code>++sed:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sevab' title="Parse nonzero base 32 digit"><code>++sev:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sewab' title="Parse nonzero base 64 digit"><code>++sew:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sexab' title="Parse nonzero hexadecimal digit"><code>++sex:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sibab' title="Parse binary digit"><code>++sib:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sidab' title="Parse decimal digit"><code>++sid:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sivab' title="Parse a base 32 digit"><code>++siv:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#siwab' title="Parse a base 64 digit"><code>++siw:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sixab' title="Parse a hexadecimal digit"><code>++six:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sovab' title="Parse @uv base-32 letter"><code>++sov:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sowab' title="Parse @uw base-64 letter/symbol"><code>++sow:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#soxab' title="Parse hexadecimal letter"><code>++sox:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tedab' title="Parse 1-999 decimal"><code>++ted:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tepab' title="Parse non-doz leading phonetic byte"><code>++tep:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tidab' title="Parse 3 decimal digits"><code>++tid:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tilab' title="Parse 3 lowercase letters"><code>++til:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tipab' title="Leading phonetic byte"><code>++tip:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tiqab' title="Trailing phonetic syllable"><code>++tiq:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ursab' title="Parse knot characters"><code>++urs:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#urtab' title="Parse knot without underscores"><code>++urt:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#voyab' title="Parse bas, soq, or bix"><code>++voy:ab</code></a>
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ag' title="Top-level atom parser engine"><code>++ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ape-ag' title="Parse 0 or rule"><code>++ape:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bay-ag' title="Parses binary number"><code>++bay:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bip-ag' title="Parse IPv6"><code>++bip:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#dem-ag' title="Parse decmal with dots"><code>++dem:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#dim-ag' title="Parse decimal number"><code>++dim:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#dum-ag' title="Parse decimal with leading zero"><code>++dum:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#fed-ag' title="Parse @p"><code>++fed:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hex-ag' title="Parse hexadecimal number"><code>++hex:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#lip-ag' title="Parse IPv4 address"><code>++lip:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#viz-ag' title="Parse base 32 digit with dot separators"><code>++viz:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#vum-ag' title="Parse base 32 string"><code>++vum:ag</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#wiz-ag' title="Parse base 64 number"><code>++wiz:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ag' title="Toplevel atom parser engine"><code>++ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#apeag' title="Parse 0 or rule"><code>++ape:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bayag' title="Parses binary number"><code>++bay:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#bipag' title="Parse IPv6"><code>++bip:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#demag' title="Parse decmal with dots"><code>++dem:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#dimag' title="Parse decimal number"><code>++dim:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#dumag' title="Parse decimal with leading zero"><code>++dum:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#fedag' title="Parse @p"><code>++fed:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#feqag' title="Parse @q phonetic base"><code>++feq:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#fimag' title="Parse base58check"><code>++fim:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hexag' title="Parse hexadecimal number"><code>++hex:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#lipag' title="Parse IPv4 address"><code>++lip:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#motag' title="Parse numerical month"><code>++mot:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#vizag' title="Parse base 32 digit with dot separators"><code>++viz:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#vumag' title="Parse base 32 string"><code>++vum:ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#wizag' title="Parse base 64 number"><code>++wiz:ag</code></a>
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#mu' title="Core used to scramble 16-bit atoms"><code>++mu</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zag-mu' title="Add bottom into top"><code>++zag:mu</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zig-mu' title="Subtract bottom from top"><code>++zig:mu</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zug-mu' title="Concatenate into atom"><code>++zug:mu</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#mu' title="Core used to scramble 16bit atoms"><code>++mu</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zagmu' title="Add bottom into top"><code>++zag:mu</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zigmu' title="Subtract bottom from top"><code>++zig:mu</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#zugmu' title="Concatenate into atom"><code>++zug:mu</code></a>
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ne' title="Digit rendering engine"><code>++ne</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#d-ne' title="Render decimal"><code>++d:ne</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#v-ne' title="Render base 32"><code>++v:ne</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#w-ne' title="Render base 64 digit"><code>++w:ne</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#x-ne' title="Render hexadecimal digit as atom of ASCII byte value"><code>++x:ne</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#cne' title="Render base58check"><code>++c:ne</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#dne' title="Render decimal"><code>++d:ne</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#vne' title="Render base 32"><code>++v:ne</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#wne' title="Render base 64 digit"><code>++w:ne</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#xne' title="Render hexadecimal digit as atom of ASCII byte value"><code>++x:ne</code></a>
 
 ### 4k: parsing (atom printing)
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#co' title="Literal rendering engine"><code>++co</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rear-co' title="Prepend and render atom as tape"><code>++rear:co</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rend-co' title="Render coin lot as tape"><code>++rend:co</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rent-co' title="Render coin lot as span"><code>++rent:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rearco' title="Prepend and render atom as tape"><code>++rear:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rendco' title="Render coin lot as tape"><code>++rend:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rentco' title="Render coin as knot"><code>++rent:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#a-coco' title="Render decimal"><code>++a-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#c-coco' title="Render base58check"><code>++c-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#d-coco' title="Render decimal with min length"><code>++d-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#r-coco' title="Render floating point"><code>++r-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#s-coco' title="Render hex list"><code>++s-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#v-coco' title="Render base-32 with minimum length"><code>++v-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#w-coco' title="Render base-64 with minimum length"><code>++w-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#x-coco' title="Render hex with minimum length"><code>++x-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#y-coco' title="Render decimal with at least two digits"><code>++y-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#z-coco' title="Render '0x'-prefixed hex"><code>++z-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#em-coco' title="Render in numeric base"><code>++em-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ed-coco' title="Format with decimal place"><code>++ed-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ox-coco' title="Format dot-separated digits in numeric base"><code>++ox-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ro-coco' title="Format dot-prefixed bloqs in numeric base"><code>++ro-co:co</code></a>
 
 ### 4l: parsing (atom parsing)
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#so' title="Coin parser engine"><code>++so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#bisk-so' title="Parse aura-atom pair"><code>++bisk:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#crub-so' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#nuck-so' title="Top-level coin parser"><code>++nuck:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#nusk-so' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#perd-so' title="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-so' title="Parse dime float"><code>++royl:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-cell-so' title="(Undocumented)"><code>++royl-cell:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#tash-so' title="Parse signed dime"><code>++tash:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#twid-so' title="Parse coins without ~ prefix"><code>++twid:so</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#zust-so' title="Parse prefixed dimes from IP, loobean, or floating point"><code>++zust:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#biskso' title="Parse auraatom pair"><code>++bisk:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#crubso' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#nuckso' title="Toplevel coin parser"><code>++nuck:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#nuskso' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#perdso' title="Parsing coin literal without prefixes"><code>++perd:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#roylso' title="Parse dime float"><code>++royl:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-cellso' title="Convert rn to dn"><code>++royl-cell:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rhso' title="Parse half-precision float"><code>++royl-rh:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rqso' title="Parse quad-precision float"><code>++royl-rq:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rdso' title="Parse double-precision float"><code>++royl-rd:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rsso' title="Parse single-precision float"><code>++royl-rs:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#royl-rnso' title="Parse real number"><code>++royl-rn:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#tashso' title="Parse signed dime"><code>++tash:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#twidso' title="Parse coins without ~ prefix"><code>++twid:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#whenso' title="Parse date"><code>++when:so</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#zustso' title="Parse dimes from @i, @f, @r or @q"><code>++zust:so</code></a>
 
 ### 4m: parsing (formatting functions)
 
@@ -1653,81 +1885,181 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#spat' title="Render path as cord"><code>++spat</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#spud' title="Render path as tape"><code>++spud</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#stab' title="Parse cord to path"><code>++stab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#stap' title="Path parser"><code>++stap</code></a>
 
 ### 4n: parsing (virtualization)
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mack' title="Nock subject to unit"><code>++mack</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mink' title="Mock (virtual Nock) interpreter"><code>++mink</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mock' title="Compute formula on subject with hint"><code>++mock</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mong' title="Slam gate with sample"><code>++mong</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mook' title="Intelligently render crash annotation"><code>++mook</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mole' title="Typed unitary virtual"><code>++mole</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mong' title="Slam gate with sample"><code>++mong</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mule' title="Typed virtual"><code>++mule</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mure' title="Untyped unitary virtual"><code>++mure</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mute' title="Untyped virtual"><code>++mute</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#slum' title="Slam a gate on a sample using raw nock, untyped"><code>++slum</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#soft' title="Virtual clam"><code>++soft</code></a>
 
 ### 4o: parsing (molds)
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#abel' title="Compiler alias"><code>++abel</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#aura' title="'Type' of atom"><code>++aura</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#axis' title="Nock axis"><code>++axis</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#base' title="Base type"><code>++base</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#bean' title="Boolean"><code>++bean</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#beer' title="Tape builder"><code>++beer</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#beet' title="XML interpolation cases"><code>++beet</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#chum' title="Jet hint information"><code>++chum</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#coil' title="Tuple of core information"><code>++coil</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#foot' title="Cases of arms by variance model"><code>++foot</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#limb' title="Reference into subject by name/axis"><code>++limb</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#line' title="(Undocumented)"><code>++line</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#metl' title="(Undocumented)"><code>++metl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#nock' title="Virtual machine (see Nock)"><code>++nock</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#noun' title="(Undocumented)"><code>++noun</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#null' title="(Undocumented)"><code>++null</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#port' title="(Undocumented)"><code>++port</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#span' title="ASCII atom"><code>++span</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tiki' title="(Undocumented)"><code>++tiki</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#toga' title="Tree of faces"><code>++toga</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tone'><code>++tone</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tuna' title="XML template tree"><code>++tuna</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tusk' title="List of expressions"><code>++tusk</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyke' title="List of 'maybe' hoons"><code>++tyke</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#typo' title="Pointer for ++type"><code>++typo</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyre' title="List, term hoon"><code>++tyre</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vase' title="Typed data"><code>++vase</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vise' title="Convert during reboot"><code>++vise</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#wing' title="Address in subject"><code>++wing</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#abel' title="Original sin: type"><code>+$abel</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#alas' title="Alias list"><code>+$alas</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#atom' title="Just an atom"><code>+$atom</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#aura' title="'Type' of atom"><code>+$aura</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#base' title="Base type"><code>+$base</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#woof' title="Simple embed"><code>+$woof</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#chum' title="Jet hint information"><code>+$chum</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#coil' title="Tuple of core information"><code>+$coil</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#garb' title="Core metadata"><code>+$garb</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#poly' title="Polarity"><code>+$poly</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#foot' title="Cases of arms by variance model"><code>+$foot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#link' title="Lexical segment"><code>+$link</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#crib' title="Summary and details"><code>+$crib</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#help' title="Documentation"><code>+$help</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#limb' title="Reference into subject by name/axis"><code>+$limb</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#null' title="Null, nil, etc"><code>+$null</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#onyx' title="Arm activation"><code>+$onyx</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#opal' title="Wing match"><code>+$opal</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#pica' title="Prose or code"><code>+$pica</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#palo' title="Wing trace, match"><code>+$palo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#plat' title="%hoon, %type, %nock or %tank"><code>+$plat</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#pock' title="Changes"><code>+$pock</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#port' title="Successful wing match"><code>+$port</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#spec' title="Structure definition AST"><code>+$spec</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tent' title="Model builder"><code>+$tent</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tiki' title="Test case"><code>+$tiki</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#skin' title="Texture"><code>+$skin</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tome' title="Core chapter"><code>+$tome</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tope' title="Topographic type"><code>+$tope</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#hoot' title="Hoon tools"><code>++hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#beerhoot' title="Simple embed"><code>+$beer:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#manehoot' title="XML name+space"><code>+$mane:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#manxhoot' title="Dynamic XML node"><code>+$manx:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marlhoot' title="Dynamic XML nodes"><code>+$marl:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marthoot' title="Dynamic XML attributes"><code>+$mart:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marxhoot' title="Dynamic XML tag"><code>+$marx:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marehoot' title="Node or nodes"><code>+$mare:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#maruhoot' title="Interpolation or nodes"><code>+$maru:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tunahoot' title="Maybe interpolation"><code>+$tuna:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#hoon' title="Hoon AST"><code>+$hoon</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyre' title="List, term hoon"><code>+$tyre</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tyke' title="List of 'maybe' hoons"><code>+$tyke</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#nock' title="Virtual nock"><code>+$nock</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#note' title="Type annotation"><code>+$note</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#type' title="Hoon type type"><code>+$type</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tony' title="$tone done right"><code>+$tony</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tine' title="Partial noun"><code>+$tine</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tool' title="Type decoration"><code>+$tool</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tune' title="Complex"><code>+$tune</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#typo' title="Old type"><code>+$typo</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vase' title="Type-value pair"><code>+$vase</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vise' title="Old vase"><code>+$vise</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vial' title="co/contra/in/bi"><code>+$vial</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vair' title="Core variance"><code>+$vair</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vein' title="Search trace"><code>+$vein</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#sect' title="Paragraph"><code>+$sect</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#whit' title="Documentation"><code>+$whit</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#what' title="Help slogan/section"><code>+$what</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#wing' title="Search path"><code>+$wing</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#block' title="Abstract identity of resource awaited"><code>+$block</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#result' title="Internal interpreter result"><code>+$result</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#thunk' title="Fragment constructor"><code>+$thunk</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#doss' title="Profiling"><code>+$doss</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#moan' title="Profiling: sample metric"><code>+$moan</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#hump' title="Profiling"><code>+$hump</code></a>
 
 ### 5a: compiler utilities
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#musk' title="Nock with block set (compiler utility)"><code>++musk</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#bool' title="Make loobean (compiler utility)"><code>++bool</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cell' title="Make %cell type (compiler utility)"><code>++cell</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#core' title="Make %core type (compiler utility)"><code>++core</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#hint' title="Make %hint type (compiler utility)"><code>++hint</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#face' title="Make %face type (compiler utility)"><code>++face</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#fork' title="Make %fork type (compiler utility)"><code>++fork</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cove' title="Extract [0 *] axis (compiler utility)"><code>++cove</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#comb' title="Combine two formulas (compiler utility)"><code>++comb</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cond' title="?: compile (compiler utility)"><code>++cond</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cons' title="Make formula cell (compiler utility)"><code>++cons</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#fitz' title="Odor compatibility (compiler utility)"><code>++fitz</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#flan' title="Loobean & (compiler utility)"><code>++flan</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#flip' title="Loobean negation (compiler utility)"><code>++flip</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#flor' title="Loobean | (compiler utility)"><code>++flor</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#hike' title="Compiler utility"><code>++hike</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#jock' title="Compiler utility"><code>++jock</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#look' title="Compiler utility"><code>++look</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#loot' title="Compiler utility"><code>++loot</code></a>
 
 ### 5b: macro expansion
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/#ah' title="Tiki engine"><code>++ah</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/#ax' title="Spec engine"><code>++ax</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/#ap' title="Hoon engine"><code>++ap</code></a>
 
 ### 5c: compiler backend and prettyprinter
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#ut' title="Hoon compiler backend"><code>++ut</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#us' title="Pretty-printer backend"><code>++us</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#cain' title="Tank pretty-print"><code>++cain</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#noah' title="Tape pretty-print"><code>++noah</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#onan' title="Vise to vase"><code>++onan</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#levi' title="Type nests or crash"><code>++levi</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#text' title="Tape pretty-print"><code>++text</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#seem' title="Promote typo"><code>++seem</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#seer' title="Promote vise"><code>++seer</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#sell' title="Pretty-print vase to a tank"><code>++sell</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#skol' title="Pretty-print type to tank"><code>++skol</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slam' title="Slam a gate"><code>++slam</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slab' title="Test if contains"><code>++slab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slap' title="Untyped vase .*"><code>++slap</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slog' title="Deify printf"><code>++slog</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#mean' title="Crash and printf"><code>++mean</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#road' title="Evaluate trap"><code>++road</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slew' title="Get axis in vase"><code>++slew</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slim' title="Identical to ++seer"><code>++slim</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slit' title="Type of slam"><code>++slit</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slob' title="Superficial arm"><code>++slob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#sloe' title="Get arms in core"><code>++sloe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slop' title="Cons two vases"><code>++slop</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slot' title="Got axis in vase"><code>++slot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slym' title="Slam without sample-type"><code>++slym</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#sped' title="Reconstruct type"><code>++sped</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#swat' title="Deferred ++slap"><code>++swat</code></a>
 
 ### 5d: parser
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vang' title="Set ++vast parameters"><code>++vang</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vast' title="Main parsing core"><code>++vast</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vest' title="Parse hoon"><code>++vest</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vice' title="Parse wide-form hoon"><code>++vice</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#make' title="Compile cord to nock"><code>++make</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#rain' title="Parse with % path"><code>++rain</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#ream' title="Parse cord to hoon"><code>++ream</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#reck' title="Parse hoon file"><code>++reck</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#ride' title="End-to-end compiler"><code>++ride</code></a>
 
-### 5e: caching compiler
+### 5e: Molds and mold builders
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mane' title="XML name+space"><code>++mane</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#manx' title="Dynamic XML node"><code>++manx</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#marl' title="XML node list"><code>++marl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mars' title="XML cdata"><code>++mars</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mart' title="XML attributes"><code>++mart</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#marx' title="Dynamic XML tag"><code>++marx</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mite' title="MIME type"><code>++mite</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#pass' title="Public key"><code>++pass</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#ring' title="Private key"><code>++ring</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#ship' title="Network identity"><code>++ship</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#shop' title="Urbit/DNS identity"><code>++shop</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#spur' title="ship desk case spur"><code>++spur</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#time' title="Galactic time"><code>++time</code></a>
 
-### 5f: molds and mold builders
+### 5f: Profiling support
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#mane'><code>++mane</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#manx'><code>++manx</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#marl'><code>++marl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#mars'><code>++mars</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#mart'><code>++mart</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#marx'><code>++marx</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pass'><code>++pass</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#ring'><code>++ring</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#time'><code>++time</code></a>
-
-### 5g: profiling support
-
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5g/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-heck' title="Profiling utility"><code>++pi-heck</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-noon' title="Sample trace"><code>++pi-noon</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-mope' title="Add sample"><code>++pi-mope</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-moth' title="Count sample"><code>++pi-moth</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-mumm' title="Print sample"><code>++pi-mumm</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-tell' title="Produce dump"><code>++pi-tell</code></a>

--- a/content/docs/hoon/reference/stdlib/table-of-contents.md
+++ b/content/docs/hoon/reference/stdlib/table-of-contents.md
@@ -29,6 +29,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#addrq' title="Add (quadprecision float)"><code>++add:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#aftr' title="Pair after"><code>++aftr</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ag' title="Toplevel atom parser engine"><code>++ag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/#ah' title="Tiki engine"><code>++ah</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#alas' title="Alias list"><code>+$alas</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#alf' title="Parse alphabetic characters"><code>++alf</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#allby' title="Logical AND (map and wet gate)"><code>++all:by</code></a>
@@ -38,6 +39,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#anyby' title="Logical OR (map and wet gate)"><code>++any:by</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#anyin' title="Logical OR (set and gate)"><code>++any:in</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2f/#aor' title="Alphabetical order"><code>++aor</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/#ap' title="Hoon engine"><code>++ap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#apeag' title="Parse 0 or rule"><code>++ape:ag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#aptby' title="Check correctness (map)"><code>++apt:by</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2h/#aptin' title="Check correctness (set)"><code>++apt:in</code></a>
@@ -45,6 +47,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#at' title="Basic printing"><code>++at</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#atom' title="Just an atom"><code>+$atom</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#aura' title="'Type' of atom"><code>+$aura</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/#ax' title="Spec engine"><code>++ax</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#axis' title="Tree address"><code>+$axis</code></a>
 
 ### b
@@ -79,6 +82,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#block' title="Abstract identity of resource awaited"><code>+$block</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#bloq' title="Blocksize"><code>$bloq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#bond' title="Replace null"><code>++bond</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#bool' title="Make loobean (compiler utility)"><code>++bool</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#boss' title="Parser modifier: LSB"><code>++boss</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#both' title="Group unit values into pair"><code>++both</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#buc' title="Parse $ (buc)"><code>++buc</code></a>
@@ -89,11 +93,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#cne' title="Render base58check"><code>++c:ne</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#cab' title="Parse _ (cab)"><code>++cab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#cain' title="Tank pretty-print"><code>++cain</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#can' title="Assemble"><code>++can</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1b/#cap' title="Tree head"><code>++cap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#cass' title="To lowercase"><code>++cass</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#cat' title="Concatenate"><code>++cat</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#c-coco' title="Render base58check"><code>++c-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cell' title="Make %cell type (compiler utility)"><code>++cell</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#cen' title="Parse % (cen)"><code>++cen</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#cetyo' title="Days in a century"><code>++cet:yo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#chafa' title="Decode base58check character"><code>++cha:fa</code></a>
@@ -109,12 +115,17 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#col' title="Parse : (col)"><code>++col</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#cold' title="Replace with constant"><code>++cold</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#com' title="Parse , (com)"><code>++com</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#comb' title="Combine two formulas (compiler utility)"><code>++comb</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#comp' title="Arbitrary compose"><code>++comp</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2d/#con' title="Binary OR"><code>++con</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cond' title="?: compile (compiler utility)"><code>++cond</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cons' title="Make formula cell (compiler utility)"><code>++cons</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#cook' title="Apply gate"><code>++cook</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#cord' title="UTF8 text"><code>+$cord</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#core' title="Make %core type (compiler utility)"><code>++core</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#cork' title="Compose forward"><code>++cork</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#corl' title="Compose backward"><code>++corl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cove' title="Extract [0 *] axis (compiler utility)"><code>++cove</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#crib' title="Summary and details"><code>+$crib</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#crip' title="Tape to cord"><code>++crip</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#crubso' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
@@ -209,6 +220,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### f
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4a/#fa' title="base58check"><code>++fa</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#face' title="Make %face type (compiler utility)"><code>++face</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#fail' title="Never parse"><code>++fail</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#fall' title="Give unit a default value"><code>++fall</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#fand' title="All indices in list"><code>++fand</code></a>
@@ -226,10 +238,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#fil' title="Fill bloqstream"><code>++fil</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#fimag' title="Parse base58check"><code>++fim:ag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#find' title="First index in list"><code>++find</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#fitz' title="Odor compatibility (compiler utility)"><code>++fitz</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#flag' title="Boolean (flag)"><code>+$flag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#flan' title="Loobean & (compiler utility)"><code>++flan</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#flifl' title="Flip sign"><code>++fli:fl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#flip' title="Loobean negation (compiler utility)"><code>++flip</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2a/#flit' title="Make filter"><code>++flit</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#flop' title="Reverse list"><code>++flop</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#flor' title="Loobean | (compiler utility)"><code>++flor</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmaff' title="Fused multiplyadd (IEEE float)"><code>++fma:ff</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmafl' title="Fused multiplyadd"><code>++fma:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fmard' title="Fused multiplyadd (@rd)"><code>++fma:rd</code></a>
@@ -239,6 +255,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#fo' title="Modulo prime"><code>++fo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#foot' title="Cases of arms by variance model"><code>+$foot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#fore' title="Pair before"><code>++fore</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#fork' title="Make %fork type (compiler utility)"><code>++fork</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#fosrh' title="@rs to @rh"><code>++fos:rh</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#frafo' title="Divide (modular base)"><code>++fra:fo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#frasi' title="Divide (signed integer)"><code>++fra:si</code></a>
@@ -310,6 +327,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hexag' title="Parse hexadecimal number"><code>++hex:ag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hifab' title="Parse phonetic pair"><code>++hif:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#hig' title="Parse single uppercase letter"><code>++hig</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#hike' title="Compiler utility"><code>++hike</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#hint' title="Make %hint type (compiler utility)"><code>++hint</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#hit' title="Parse single hexadecimal digit"><code>++hit</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#hofab' title="Parse 2-4 @q phonetic pair"><code>++hof:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#homo' title="Homogenize list"><code>++homo</code></a>
@@ -343,6 +362,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2o/#jar' title="Mold generator (jar)"><code>++jar</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#jesyo' title="Maximum 64bit timestamp"><code>++jes:yo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#jest' title="Match a cord"><code>++jest</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#jock' title="Compiler utility"><code>++jock</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#join' title="Add separator between list elements"><code>++join</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2j/#ju' title="Jug operations"><code>++ju</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2o/#jug' title="Mold generator (jug)"><code>++jug</code></a>
@@ -364,6 +384,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#lead' title="Put head"><code>++lead</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#lenl' title="Construct list from nullterminated noun"><code>++le:nl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#lent' title="List length"><code>++lent</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#levi' title="Type nests or crash"><code>++levi</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#levy' title="Logical AND on list"><code>++levy</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lfefl' title="Maximum"><code>++lfe:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#lfnfl' title="Largest normal float"><code>++lfn:fl</code></a>
@@ -376,6 +397,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#lipag' title="Parse IPv4 address"><code>++lip:ag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#list' title="Mold constructor (list)"><code>++list</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1c/#lone' title="Mold generator (face on mold)"><code>++lone</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#look' title="Compiler utility"><code>++look</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#loot' title="Compiler utility"><code>++loot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#low' title="Parse lowercase letter"><code>++low</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#lsh' title="Leftshift"><code>++lsh</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#lte' title="Less than / equal (atom)"><code>++lte</code></a>
@@ -400,20 +423,27 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### m
 
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mane' title="XML name+space"><code>++mane</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#manx' title="Dynamic XML node"><code>++manx</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#manxhoot' title="Dynamic XML node"><code>+$manx:hoot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mard' title="Initialize ff (rd core)"><code>++ma:rd</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#marh' title="Initialize ff (rh core)"><code>++ma:rh</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mars' title="Initialize ff (rs core)"><code>++ma:rs</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#marq' title="Initialize ff (rq core)"><code>++ma:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mack' title="Nock subject to unit"><code>++mack</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#make' title="Compile cord to nock"><code>++make</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2l/#malt' title="Map from list"><code>++malt</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#manehoot' title="XML name+space"><code>+$mane:hoot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2o/#map' title="Mold generator (map)"><code>++map</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#marby' title="Add with validation (map)"><code>++mar:by</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marehoot' title="Node or nodes"><code>+$mare:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#marl' title="XML node list"><code>++marl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marlhoot' title="Dynamic XML nodes"><code>+$marl:hoot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marthoot' title="Dynamic XML attributes"><code>+$mart:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mars' title="XML cdata"><code>++mars</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mart' title="XML attributes"><code>++mart</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#maruhoot' title="Interpolation or nodes"><code>+$maru:hoot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#marx' title="Dynamic XML tag"><code>++marx</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#marxhoot' title="Dynamic XML tag"><code>+$marx:hoot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1b/#mas' title="Address within head/tail"><code>++mas</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#mask' title="Match character"><code>++mask</code></a>
@@ -427,6 +457,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#met' title="Measure"><code>++met</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/1a/#min' title="Minimum (atom)"><code>++min</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mink' title="Mock (virtual Nock) interpreter"><code>++mink</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mite' title="MIME type"><code>++mite</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3c/#mityo' title="Seconds in minute"><code>++mit:yo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2d/#mix' title="Binary XOR (atom)"><code>++mix</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#mixed-case-symbol' title="Mixed-case term"><code>++mixed-case-symbol</code></a>
@@ -455,6 +486,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#mulrq' title="Multiply (quadprecision float)"><code>++mul:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mule' title="Typed virtual"><code>++mule</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mure' title="Untyped unitary virtual"><code>++mure</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#musk' title="Nock with block set (compiler utility)"><code>++musk</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#mute' title="Untyped virtual"><code>++mute</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#murn' title="Maybe transform"><code>++murn</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#my' title="Map from raw noun"><code>++my</code></a>
@@ -473,6 +505,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2k/#nipto' title="Remove root of queue"><code>++nip:to</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#nix' title="Parse letters and underscore"><code>++nix</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#nl' title="Noun to container operations"><code>++nl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#noah' title="Tape pretty-print"><code>++noah</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#nock' title="Virtual nock"><code>+$nock</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2d/#not' title="Binary NOT (atom)"><code>++not</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#note' title="Type annotation"><code>+$note</code></a>
@@ -487,6 +520,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#ob' title="Reversible scrambling v2"><code>++ob</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#og' title="Container arm for SHA256 powered RNG"><code>++og</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#oldsi' title="Sign and absolute value"><code>++old:si</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#onan' title="Vise to vase"><code>++onan</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#onyx' title="Arm activation"><code>+$onyx</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#opal' title="Wing match"><code>+$opal</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#oust' title="Remove from list"><code>++oust</code></a>
@@ -505,11 +539,18 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#pal' title="Parse ( (pal)"><code>++pal</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#palo' title="Wing trace, match"><code>+$palo</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#par' title="Parse ) (par)"><code>++par</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#pass' title="Public key"><code>++pass</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4l/#perdso' title="Parsing coin literal without prefixes"><code>++perd:so</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#perk' title="Parse cube fork"><code>++perk</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pevab' title="Parse 1-5 @uv base-32 chars"><code>++pev:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pewab' title="Parse <= 5 in base 64"><code>++pew:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4e/#pfix' title="Discard first rule"><code>++pfix</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-heck' title="Profiling utility"><code>++pi-heck</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-noon' title="Sample trace"><code>++pi-noon</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-mope' title="Add sample"><code>++pi-mope</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-moth' title="Count sample"><code>++pi-moth</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-mumm' title="Print sample"><code>++pi-mumm</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-tell' title="Produce dump"><code>++pi-tell</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#pica' title="Prose or code"><code>+$pica</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#pint' title="Parsing range"><code>+$pint</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#pivab' title="Parse 5 @uv base-32 chars"><code>++piv:ab</code></a>
@@ -552,6 +593,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rat' title="Print term, number or hex"><code>++r:at</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#radog' title="Random in range"><code>++rad:og</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#radsog' title="Random continuation"><code>++rads:og</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#rain' title="Parse with % path"><code>++rain</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3f/#rakuob' title="Key list"><code>++raku:ob</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#ramre' title="Flatten tank to tape"><code>++ram:re</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rap' title="Assemble nonzero"><code>++rap</code></a>
@@ -561,9 +603,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#rawsog' title="Random bits continuation"><code>++raws:og</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#r-coco' title="Render floating point"><code>++r-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#re' title="Prettyprinting engine (tank)"><code>++re</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#ream' title="Parse cord to hoon"><code>++ream</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#rear' title="Last item in list"><code>++rear</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rearco' title="Prepend and render atom as tape"><code>++rear:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#reap' title="Replicate (list)"><code>++reap</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#reck' title="Parse hoon file"><code>++reck</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#reel' title="Right fold (list)"><code>++reel</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#remsi' title="Remainder (signed integer)"><code>++rem:si</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#rendco' title="Render coin lot as tape"><code>++rend:co</code></a>
@@ -575,9 +619,12 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rev' title="Reverse"><code>++rev</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rfat' title="Print loobean"><code>++rf:at</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#ribby' title="Transform + product (map)"><code>++rib:by</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#ride' title="End-to-end compiler"><code>++ride</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#ring' title="Private key"><code>++ring</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rip' title="Disassemble"><code>++rip</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4b/#rnat' title="Print null"><code>++rn:at</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#ro-coco' title="Format dot-prefixed bloqs in numeric base"><code>++ro-co:co</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#road' title="Evaluate trap"><code>++road</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#rolfe' title="Roll left"><code>++rol:fe</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#roll' title="Left fold (list)"><code>++roll</code></a>
 <code>++rood</code>
@@ -636,7 +683,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sebab' title="Parse 1"><code>++seb:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#sect' title="Paragraph"><code>+$sect</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#sedab' title="Parse nonzero decimal digit"><code>++sed:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#seem' title="Promote typo"><code>++seem</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#seer' title="Promote vise"><code>++seer</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#sel' title="Parse [ (sel)"><code>++sel</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#sell' title="Pretty-print vase to a tank"><code>++sell</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#mic' title="Parse ; (mic)"><code>++mic</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4h/#ser' title="Parse ] (ser)"><code>++ser</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2o/#set' title="Mold generator (set)"><code>++set</code></a>
@@ -657,6 +707,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3d/#shaz' title="SHA512"><code>++shaz</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#shffl' title="Shift power"><code>++shf:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#shim' title="Match character within range"><code>++shim</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#ship' title="Network identity"><code>++ship</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#shop' title="Urbit/DNS identity"><code>++shop</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4c/#show' title="Pretty-printer (deprecated)"><code>++show</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#si' title="Signed integer"><code>++si</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#sinl' title="Construct set from nullterminated noun"><code>++si:nl</code></a>
@@ -679,14 +731,26 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#skim' title="Produce list of elements from boolean gate"><code>++skim</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#skin' title="Texture"><code>+$skin</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#skip' title="Produce list of elements failing boolean gate"><code>++skip</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#skol' title="Pretty-print type to tank"><code>++skol</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slab' title="Test if contains"><code>++slab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#slag' title="Produce all elements from index in list"><code>++slag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slam' title="Slam a gate"><code>++slam</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slap' title="Untyped vase .*"><code>++slap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#slat' title="Curried slaw"><code>++slat</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#slav' title="Demand: parse cord with input aura"><code>++slav</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#slaw' title="Parse cord to input aura"><code>++slaw</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#slay' title="Parse cord to coin"><code>++slay</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slew' title="Get axis in vase"><code>++slew</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slim' title="Identical to ++seer"><code>++slim</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slit' title="Type of slam"><code>++slit</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slob' title="Superficial arm"><code>++slob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#sloe' title="Get arms in core"><code>++sloe</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slog' title="Deify printf"><code>++slog</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slop' title="Cons two vases"><code>++slop</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slot' title="Got axis in vase"><code>++slot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4f/#slug' title="Use gate to parse delimited list"><code>++slug</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4n/#slum' title="Slam a gate on a sample using raw nock, untyped"><code>++slum</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slym' title="Slam without sample-type"><code>++slym</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#smyt' title="Render path as tank"><code>++smyt</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#snag' title="Produce element at specific index (list)"><code>++snag</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#snagnl' title="Produce element from list at specific nullterminated noun"><code>++snag:nl</code></a>
@@ -704,11 +768,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#spat' title="Render path as cord"><code>++spat</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#spdfl' title="Produce smallest denormalized float"><code>++spd:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#spec' title="Structure definition AST"><code>+$spec</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#sped' title="Reconstruct type"><code>++sped</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#spin' title="Gate to list (with state)"><code>++spin</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#spnfl' title="Produce smallest normal float"><code>++spn:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3g/#spot' title="Stack trace line"><code>+$spot</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4m/#spud' title="Render path as tape"><code>++spud</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#spun' title="Gate to list (with state)"><code>++spun</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#spur' title="ship desk case spur"><code>++spur</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2g/#sqt' title="Compute square root with remainder"><code>++sqt</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtff' title="Produce square root of IEEE float"><code>++sqt:ff</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sqtfl' title="Produce square root from signed and unsigned integer cell"><code>++sqt:fl</code></a>
@@ -745,6 +811,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#sunrq' title="Unsigned integer to quadprecision float"><code>++sun:rq</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3a/#sunsi' title="@u to @s"><code>++sun:si</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2b/#swag' title="Infix (list)"><code>++swag</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#swat' title="Deferred ++slap"><code>++swat</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2c/#swp' title="Reverse block order"><code>++swp</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/3b/#swrfl' title="Switch rounding mode of floating point"><code>++swr:fl</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2m/#sy' title="Produce set from nullterminated noun"><code>++sy</code></a>
@@ -773,10 +840,12 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tepab' title="Parse non-doz leading phonetic byte"><code>++tep:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2q/#term' title="Hoon constant"><code>+$term</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2n/#test' title="Test for equality"><code>++test</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#text' title="Tape pretty-print"><code>++text</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#thunk' title="Fragment constructor"><code>+$thunk</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tidab' title="Parse 3 decimal digits"><code>++tid:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tiki' title="Test case"><code>+$tiki</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tilab' title="Parse 3 lowercase letters"><code>++til:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#time' title="Galactic time"><code>++time</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#tine' title="Partial noun"><code>+$tine</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tipab' title="Leading phonetic byte"><code>++tip:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#tiqab' title="Trailing phonetic syllable"><code>++tiq:ab</code></a>
@@ -829,18 +898,22 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/hoon/reference/stdlib/2i/#urnby' title="Turn (with key) (map)"><code>++urn:by</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#ursab' title="Parse knot characters"><code>++urs:ab</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#urtab' title="Parse knot without underscores"><code>++urt:ab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#us' title="Pretty-printer backend"><code>++us</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#ut' title="Hoon compiler backend"><code>++ut</code></a>
 
 ### v
 
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#vne' title="Render base 32"><code>++v:ne</code></a>
-<code>++vang</code>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vair' title="Core variance"><code>+$vair</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vang' title="Set ++vast parameters"><code>++vang</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vase' title="Type-value pair"><code>+$vase</code></a>
-<code>++vast</code>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vast' title="Main parsing core"><code>++vast</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4k/#v-coco' title="Render base-32 with minimum length"><code>++v-co:co</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vein' title="Search trace"><code>+$vein</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#ven' title="Axis syntax parser"><code>++ven</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vest' title="Parse hoon"><code>++vest</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vial' title="co/contra/in/bi"><code>+$vial</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vice' title="Parse wide-form hoon"><code>++vice</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4o/#vise' title="Old vase"><code>+$vise</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4i/#vit' title="Parse base 64 digit"><code>++vit</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/4j/#vizag' title="Parse base 32 digit with dot separators"><code>++viz:ag</code></a>
@@ -1897,38 +1970,95 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 5a: compiler utilities
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#musk' title="Nock with block set (compiler utility)"><code>++musk</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#bool' title="Make loobean (compiler utility)"><code>++bool</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cell' title="Make %cell type (compiler utility)"><code>++cell</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#core' title="Make %core type (compiler utility)"><code>++core</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#hint' title="Make %hint type (compiler utility)"><code>++hint</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#face' title="Make %face type (compiler utility)"><code>++face</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#fork' title="Make %fork type (compiler utility)"><code>++fork</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cove' title="Extract [0 *] axis (compiler utility)"><code>++cove</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#comb' title="Combine two formulas (compiler utility)"><code>++comb</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cond' title="?: compile (compiler utility)"><code>++cond</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#cons' title="Make formula cell (compiler utility)"><code>++cons</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#fitz' title="Odor compatibility (compiler utility)"><code>++fitz</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#flan' title="Loobean & (compiler utility)"><code>++flan</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#flip' title="Loobean negation (compiler utility)"><code>++flip</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#flor' title="Loobean | (compiler utility)"><code>++flor</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#hike' title="Compiler utility"><code>++hike</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#jock' title="Compiler utility"><code>++jock</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#look' title="Compiler utility"><code>++look</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5a/#loot' title="Compiler utility"><code>++loot</code></a>
 
 ### 5b: macro expansion
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/#ah' title="Tiki engine"><code>++ah</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/#ax' title="Spec engine"><code>++ax</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5b/#ap' title="Hoon engine"><code>++ap</code></a>
 
 ### 5c: compiler backend and prettyprinter
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/'>_(To be fully documented)_</a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#ut' title="Hoon compiler backend"><code>++ut</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#us' title="Pretty-printer backend"><code>++us</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#cain' title="Tank pretty-print"><code>++cain</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#noah' title="Tape pretty-print"><code>++noah</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#onan' title="Vise to vase"><code>++onan</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#levi' title="Type nests or crash"><code>++levi</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#text' title="Tape pretty-print"><code>++text</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#seem' title="Promote typo"><code>++seem</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#seer' title="Promote vise"><code>++seer</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#sell' title="Pretty-print vase to a tank"><code>++sell</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#skol' title="Pretty-print type to tank"><code>++skol</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slam' title="Slam a gate"><code>++slam</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slab' title="Test if contains"><code>++slab</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slap' title="Untyped vase .*"><code>++slap</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slog' title="Deify printf"><code>++slog</code></a>
 <a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#mean' title="Crash and printf"><code>++mean</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#road' title="Evaluate trap"><code>++road</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slew' title="Get axis in vase"><code>++slew</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slim' title="Identical to ++seer"><code>++slim</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slit' title="Type of slam"><code>++slit</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slob' title="Superficial arm"><code>++slob</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#sloe' title="Get arms in core"><code>++sloe</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slop' title="Cons two vases"><code>++slop</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slot' title="Got axis in vase"><code>++slot</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#slym' title="Slam without sample-type"><code>++slym</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#sped' title="Reconstruct type"><code>++sped</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5c/#swat' title="Deferred ++slap"><code>++swat</code></a>
 
 ### 5d: parser
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vang' title="Set ++vast parameters"><code>++vang</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vast' title="Main parsing core"><code>++vast</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vest' title="Parse hoon"><code>++vest</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#vice' title="Parse wide-form hoon"><code>++vice</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#make' title="Compile cord to nock"><code>++make</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#rain' title="Parse with % path"><code>++rain</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#ream' title="Parse cord to hoon"><code>++ream</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#reck' title="Parse hoon file"><code>++reck</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5d/#ride' title="End-to-end compiler"><code>++ride</code></a>
 
-### 5e: caching compiler
+### 5e: Molds and mold builders
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mane' title="XML name+space"><code>++mane</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#manx' title="Dynamic XML node"><code>++manx</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#marl' title="XML node list"><code>++marl</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mars' title="XML cdata"><code>++mars</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mart' title="XML attributes"><code>++mart</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#marx' title="Dynamic XML tag"><code>++marx</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#mite' title="MIME type"><code>++mite</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#pass' title="Public key"><code>++pass</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#ring' title="Private key"><code>++ring</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#ship' title="Network identity"><code>++ship</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#shop' title="Urbit/DNS identity"><code>++shop</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#spur' title="ship desk case spur"><code>++spur</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5e/#time' title="Galactic time"><code>++time</code></a>
 
-### 5f: molds and mold builders
+### 5f: Profiling support
 
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#mane'><code>++mane</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#manx'><code>++manx</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#marl'><code>++marl</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#mars'><code>++mars</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#mart'><code>++mart</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#marx'><code>++marx</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pass'><code>++pass</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#ring'><code>++ring</code></a>
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#time'><code>++time</code></a>
-
-### 5g: profiling support
-
-<a class="tooltip" href='/docs/hoon/reference/stdlib/5g/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-heck' title="Profiling utility"><code>++pi-heck</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-noon' title="Sample trace"><code>++pi-noon</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-mope' title="Add sample"><code>++pi-mope</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-moth' title="Count sample"><code>++pi-moth</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-mumm' title="Print sample"><code>++pi-mumm</code></a>
+<a class="tooltip" href='/docs/hoon/reference/stdlib/5f/#pi-tell' title="Produce dump"><code>++pi-tell</code></a>

--- a/lib/glossary.js
+++ b/lib/glossary.js
@@ -1494,6 +1494,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Tiki engine",
+    symbol: "ah",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5b/#ah",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Alias list",
     symbol: "alas",
     usage: "stdlib",
@@ -1557,6 +1564,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Hoon engine",
+    symbol: "ap",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5b/#ap",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Parse 0 or rule",
     symbol: "ape:ag",
     usage: "stdlib",
@@ -1603,6 +1617,13 @@ export const glossary = [
     symbol: "aura",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#aura",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Spec engine",
+    symbol: "ax",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5b/#ax",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -1816,6 +1837,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Make loobean (compiler utility)",
+    symbol: "bool",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#bool",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Parser modifier: LSB",
     symbol: "boss",
     usage: "stdlib",
@@ -1872,6 +1900,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Tank pretty-print",
+    symbol: "cain",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#cain",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Assemble",
     symbol: "can",
     usage: "stdlib",
@@ -1904,6 +1939,13 @@ export const glossary = [
     symbol: "c-co:co",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4k/#c-coco",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Make %cell type (compiler utility)",
+    symbol: "cell",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#cell",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -2012,6 +2054,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Combine two formulas (compiler utility)",
+    symbol: "comb",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#comb",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Arbitrary compose",
     symbol: "comp",
     usage: "stdlib",
@@ -2023,6 +2072,20 @@ export const glossary = [
     symbol: "con",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2d/#con",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "?: compile (compiler utility)",
+    symbol: "cond",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#cond",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Make formula cell (compiler utility)",
+    symbol: "cons",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#cons",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -2040,6 +2103,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Make %core type (compiler utility)",
+    symbol: "core",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#core",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Compose forward",
     symbol: "cork",
     usage: "stdlib",
@@ -2051,6 +2121,13 @@ export const glossary = [
     symbol: "corl",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2n/#corl",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Extract [0 *] axis (compiler utility)",
+    symbol: "cove",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#cove",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -2656,6 +2733,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Make %face type (compiler utility)",
+    symbol: "face",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#face",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Never parse",
     symbol: "fail",
     usage: "stdlib",
@@ -2782,6 +2866,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Odor compatibility (compiler utility)",
+    symbol: "fitz",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#fitz",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Boolean (flag)",
     symbol: "flag",
     usage: "stdlib",
@@ -2789,10 +2880,24 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Loobean & (compiler utility)",
+    symbol: "flan",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#flan",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Flip sign",
     symbol: "fli:fl",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/3b/#flifl",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Loobean negation (compiler utility)",
+    symbol: "flip",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#flip",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -2807,6 +2912,13 @@ export const glossary = [
     symbol: "flop",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2b/#flop",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Loobean | (compiler utility)",
+    symbol: "flor",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#flor",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -2870,6 +2982,13 @@ export const glossary = [
     symbol: "fore",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2n/#aftr",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Make %fork type (compiler utility)",
+    symbol: "fork",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#fork",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -3321,6 +3440,20 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Compiler utility",
+    symbol: "hike",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#hike",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Make %hint type (compiler utility)",
+    symbol: "hint",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#hint",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Parse single hexadecimal digit",
     symbol: "hit",
     usage: "stdlib",
@@ -3517,6 +3650,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Compiler utility",
+    symbol: "jock",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#jock",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Add separator between list elements",
     symbol: "join",
     usage: "stdlib",
@@ -3622,6 +3762,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Type nests or crash",
+    symbol: "levi",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#levi",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Logical AND on list",
     symbol: "levy",
     usage: "stdlib",
@@ -3703,6 +3850,20 @@ export const glossary = [
     symbol: "lone",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/1c/#lone",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Compiler utility",
+    symbol: "look",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#look",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Compiler utility",
+    symbol: "loot",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#loot",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -3888,6 +4049,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Compile cord to nock",
+    symbol: "make",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5d/#make",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Map from list",
     symbol: "malt",
     usage: "stdlib",
@@ -3902,10 +4070,24 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "XML name+space",
+    symbol: "mane",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5e/#mane",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Dynamic XML node",
     symbol: "manx:hoot",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#manxhoot",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Dynamic XML node",
+    symbol: "manx",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5e/#manx",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -3937,10 +4119,31 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "XML node list",
+    symbol: "marl",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5e/#marl",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "XML cdata",
+    symbol: "mars",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5e/#mars",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Dynamic XML attributes",
     symbol: "mart:hoot",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#marthoot",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "XML attributes",
+    symbol: "mart",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5e/#mart",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -3955,6 +4158,13 @@ export const glossary = [
     symbol: "marx:hoot",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#marxhoot",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Dynamic XML tag",
+    symbol: "marx",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5e/#marx",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -4046,6 +4256,13 @@ export const glossary = [
     symbol: "mit:yo",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/3c/#mityo",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "MIME type",
+    symbol: "mite",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5e/#mite",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -4252,6 +4469,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Nock with block set (compiler utility)",
+    symbol: "musk",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5a/#musk",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Map from raw noun",
     symbol: "my",
     usage: "stdlib",
@@ -4343,6 +4567,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Tape pretty-print",
+    symbol: "noah",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#noah",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Virtual Nock",
     symbol: "nock",
     usage: "stdlib",
@@ -4420,6 +4651,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Vise to vase",
+    symbol: "onan",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#onan",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Arm activation",
     symbol: "onyx",
     usage: "stdlib",
@@ -4480,6 +4718,13 @@ export const glossary = [
     symbol: "pam",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4h/#pam",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Public key",
+    symbol: "pass",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5e/#pass",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -4550,6 +4795,48 @@ export const glossary = [
     symbol: "pfix",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4e/#pfix",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Profiling utility",
+    symbol: "pi-heck",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5f/#pi-heck",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Sample trace",
+    symbol: "pi-noon",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5f/#pi-noon",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Add sample",
+    symbol: "pi-mope",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5f/#pi-mope",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Count sample",
+    symbol: "pi-moth",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5f/#pi-moth",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Print sample",
+    symbol: "pi-mumm",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5f/#pi-mumm",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Produce dump",
+    symbol: "pi-tell",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5f/#pi-tell",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -4805,6 +5092,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Parse with % path",
+    symbol: "rain",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5d/#rain",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Key list",
     symbol: "raku:ob",
     usage: "stdlib",
@@ -4868,6 +5162,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Parse cord to hoon",
+    symbol: "ream",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5d/#ream",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Last item in list",
     symbol: "rear",
     usage: "stdlib",
@@ -4886,6 +5187,13 @@ export const glossary = [
     symbol: "reap",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2b/#reap",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Parse hoon file",
+    symbol: "reck",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5d/#reck",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -4959,6 +5267,20 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "End-to-end compiler",
+    symbol: "ride",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5d/#ride",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Private key",
+    symbol: "ring",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5e/#ring",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Disassemble",
     symbol: "rip",
     usage: "stdlib",
@@ -4977,6 +5299,13 @@ export const glossary = [
     symbol: "ro-co:co",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4k/#ro-coco",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Evaluate trap",
+    symbol: "road",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#road",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -5358,10 +5687,31 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Promote typo",
+    symbol: "seem",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#seem",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Promote vise",
+    symbol: "seer",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#seer",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Parse [ (sel)",
     symbol: "sel",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4h/#sel",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Pretty-print vase to a tank",
+    symbol: "sell",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#sell",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -5502,6 +5852,20 @@ export const glossary = [
     symbol: "shim",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4f/#shim",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Network identity",
+    symbol: "ship",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5e/#ship",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Urbit/DNS identity",
+    symbol: "shop",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5e/#shop",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -5659,10 +6023,38 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Pretty-print type to tank",
+    symbol: "skol",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#skol",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Test if contains",
+    symbol: "slab",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#slab",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Produce all elements from index in list",
     symbol: "slag",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2b/#slag",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Slam a gate",
+    symbol: "slam",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#slam",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Untyped vase .*",
+    symbol: "slap",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#slap",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -5694,10 +6086,59 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Get axis in vase",
+    symbol: "slew",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#slew",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Identical to ++seer",
+    symbol: "slim",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#slim",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Type of slam",
+    symbol: "slit",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#slit",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Superficial arm",
+    symbol: "slob",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#slob",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Get arms in core",
+    symbol: "sloe",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#sloe",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Deify printf",
     symbol: "slog",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/5c/#slog",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Cons two vases",
+    symbol: "slop",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#slop",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Got axis in vase",
+    symbol: "slot",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#slot",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -5712,6 +6153,13 @@ export const glossary = [
     symbol: "slum",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4n/#slum",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Slam without sample-type",
+    symbol: "slym",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#slym",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -5820,6 +6268,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Reconstruct type",
+    symbol: "sped",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#sped",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Produce smallest denormalized float",
     symbol: "spd:fl",
     usage: "stdlib",
@@ -5866,6 +6321,13 @@ export const glossary = [
     symbol: "spun",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2b/#spun",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "ship desk case spur",
+    symbol: "spur",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5e/#spur",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -6121,6 +6583,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Deferred ++slap",
+    symbol: "swat",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#swat",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Reverse block order",
     symbol: "swp",
     usage: "stdlib",
@@ -6254,6 +6723,13 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Galactic time",
+    symbol: "time",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5e/#time",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Partial noun",
     symbol: "tine",
     usage: "stdlib",
@@ -6307,6 +6783,13 @@ export const glossary = [
     symbol: "test",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/2n/#test",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Tape pretty-print",
+    symbol: "text",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#text",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -6667,6 +7150,20 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Pretty-printer backend",
+    symbol: "us",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#us",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Hoon compiler backend",
+    symbol: "ut",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#ut",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Render base 32",
     symbol: "v:ne",
     usage: "stdlib",
@@ -6681,10 +7178,24 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Set ++vast parameters",
+    symbol: "vang",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5d/#vang",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "Type-value pair",
     symbol: "vase",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#vase",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Main parsing core",
+    symbol: "vast",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5d/#vast",
     desc: "Used in the Hoon standard library.",
   },
   {
@@ -6709,10 +7220,24 @@ export const glossary = [
     desc: "Used in the Hoon standard library.",
   },
   {
+    name: "Parse hoon",
+    symbol: "vest",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#vest",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
     name: "co/contra/in/bi",
     symbol: "vial",
     usage: "stdlib",
     slug: "https://urbit.org/docs/reference/library/4o/#vial",
+    desc: "Used in the Hoon standard library.",
+  },
+  {
+    name: "Parse wide-form hoon",
+    symbol: "vice",
+    usage: "stdlib",
+    slug: "https://urbit.org/docs/reference/library/5c/#vice",
     desc: "Used in the Hoon standard library.",
   },
   {


### PR DESCRIPTION
- 5a
  - add +musk, +bool, +cell, +core, +hint, +face, +fork, +cove,
    +comb, +cond, +cons, +fitz, +flan, +flip, +flor, +hike, +jock,
    +look, +loot
  - update ToC and glossary.js as appropriate
- 5b
  - add +ah, +ax, +ap
  - update ToC and glossary.js as appropriate

- 5c
  - add +ut +us +cain +noah +onan +levi +text +seem +seer
    +sell +skol +slam +slab +slap +road +slew +slim +slit
    +slob +sloe +slop +slot +slym +sped +swat
  - update ToC and glossary.js as appropriate

- 5d
  - add vang vast make rain ream reck ride
  - update ToC and glossary.js as appropriate

- 5e
  - add mane manx marl mars mart marx mite pass ring ship
    shop spur time
  - update ToC and glossary.js as appropriate
  - rename molds and mold builders

- 5f
  - add pi-heck pi-noon pi-mope pi-moth pi-mumm pi-tell
  - update ToC and glossary.js as appropriate
  - rename profiling support

- 5g
  - removed entirely as there is no longer a 5g section in
    hoon.hoon

_index.md also updated with a copy of the ToC because it was
reproduced there and outdated.

Note some functions are included but not explained as they're
internal compiler things or otherwise obscure and not something
people would use directly.

resolves #1137

@sigilante 