### PR TITLE
add sail guide

### DIFF
--- a/content/docs/glossary/sailudon.md
+++ b/content/docs/glossary/sailudon.md
@@ -8,6 +8,7 @@ category = "arvo"
 
 **Sail** and **Udon** are domain specific languages for Hoon.
 
-Sail is used to express XML data structures, which are used for rendering webpages, such as when browsing [collections](/docs/glossary/collection) in [Landscape](/docs/glossary/landscape).
+Sail is used to express XML data structures, which are used for rendering
+webpages. See the [Sail Guide](/docs/hoon/guides/sail) for more details.
 
 Udon is similar to Markdown, a simple language for writing documents. Udon is stored in [Clay](/docs/glossary/clay) and rendered using [Ford](/docs/glossary/ford).

--- a/content/docs/glossary/sailudon.md
+++ b/content/docs/glossary/sailudon.md
@@ -8,7 +8,7 @@ category = "arvo"
 
 **Sail** and **Udon** are domain specific languages for Hoon.
 
-Sail is used to express XML data structures, which are used for rendering
+Sail is used to express XML data structures, which are commonly used for rendering HTML
 webpages. See the [Sail Guide](/docs/hoon/guides/sail) for more details.
 
 Udon is similar to Markdown, a simple language for writing documents.

--- a/content/docs/glossary/sailudon.md
+++ b/content/docs/glossary/sailudon.md
@@ -11,4 +11,4 @@ category = "arvo"
 Sail is used to express XML data structures, which are used for rendering
 webpages. See the [Sail Guide](/docs/hoon/guides/sail) for more details.
 
-Udon is similar to Markdown, a simple language for writing documents. Udon is stored in [Clay](/docs/glossary/clay) and rendered using [Ford](/docs/glossary/ford).
+Udon is similar to Markdown, a simple language for writing documents.

--- a/content/docs/hoon/guides/_index.md
+++ b/content/docs/hoon/guides/_index.md
@@ -15,3 +15,5 @@ insert_anchor_links = "right"
 ## [Strings](/docs/hoon/guides/strings)
 
 ## [JSON](/docs/hoon/guides/json-guide)
+
+## [Sail](/docs/hoon/guides/sail)

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -59,8 +59,8 @@ It’s easy to see how Sail can directly translate to HTML:
 
 In Sail, tag heads are written with the tag name prepended by `;`. Unlike in
 HTML, there are different ways of closing tags, depending on the needs of the
-tag. One of the nice things about Hoon is that you don’t have to be constantly
-closing expressions; Sail inherits this convenience.
+tag. One of the nice things about Hoon is that you don’t have to constantly
+close expressions; Sail inherits this convenience.
 
 ### Empty
 

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -315,16 +315,47 @@ elements, converting characters such as `>` to HTML entities. For example:
 
 ### Marks
 
-The mark for a raw `$manx` is a `%hymn`. This mark is included in the `%base`
-desk. The mark for a rendered HTML cord is `%html`. The `%hymn` mark includes
-conversion methods to both `%html` and `%mime`. The `%html` mark includes
-conversion methods to `%mime` and `%hymn`.
+There are a few different HTML and XML related marks, so it can be a bit
+confusing. We'll look at the ones you're most likely to use.
 
-If you want to produce an HTML document through Eyre's scry interface, for
-example, you can either produce a `$manx` with a `%hymn` mark and let Eyre
-convert it to `%html`, or else you can call `++en-xml:html` and then `++crip` on
-the product of your Sail expressions and produce a cord with an `%html` mark
-directly.
+#### `%html`
+
+- Type: `@t`
+
+This mark is used for HTML that has been printed as text in a cord. You may wish
+to return this mark when serving pages to the web. To do so, you must run the
+`$manx` produced by your Sail expressions through `++en-xml:html`, and then run
+the resulting `tape` through `++crip`.
+
+#### `%hymn`
+
+- Type: `$manx`
+
+The `%hymn` mark is intended to be used for complete HTML documents - having an
+`&lt;html>` root element, `&lt;head>`, `&lt;body>`, etc. This isn't enforced on
+the type level but it is assumed in certain mark conversion pathways. Rather
+than calling `++en-xml:html` on the `$manx` produced by your Sail expressions
+and returning an `%html` mark, you may wish to return the `$manx` directly as a
+`%hymn` and let Eyre handle converting it to `%html` before giving it to web
+clients.
+
+#### `%elem`
+
+- Type: `$manx`
+
+The type of the `%elem` mark is a `$manx`, just like a `%hymn`. While `%hymn`s
+are intended for complete HTML documents, `%elem`s are intended for more general
+XML structures. You may wish to use an `%elem` mark if you're producing smaller
+fragments of XML or HTML rather than whole documents. Like a `%hymn`, Eyre can
+automatically convert it to `%html` and provide it to web clients.
+
+#### Summary
+
+In general, if you're going to be composing web pages and serving them to web
+clients, running the result of your Sail through `++en-xml:html`, `++crip`ping
+it and producing `%html` is the most straight-forward approach. If you might
+want to pass around a `$manx` to other agents or ships which may wish to
+manipulate it futher, a `%hymn` or `%elem` is better.
 
 ## Sail Runes
 

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -307,9 +307,6 @@ A `$manx` can be rendered as HTML in a tape with the `++en-xml:html` function in
 '<p>foobar</p>'
 ```
 
-You may wish to do this in your agent directly, but you can also leave mark
-conversion to Eyre.
-
 ### Sanitization
 
 The `++en-xml:html` function will sanitize the contents of both attributes and
@@ -342,11 +339,9 @@ the resulting `tape` through `++crip`.
 
 The `%hymn` mark is intended to be used for complete HTML documents - having an
 `&lt;html>` root element, `&lt;head>`, `&lt;body>`, etc. This isn't enforced on
-the type level but it is assumed in certain mark conversion pathways. Rather
-than calling `++en-xml:html` on the `$manx` produced by your Sail expressions
-and returning an `%html` mark, you may wish to return the `$manx` directly as a
-`%hymn` and let Eyre handle converting it to `%html` before giving it to web
-clients.
+the type level but it is assumed in certain mark conversion pathways. Eyre can
+automatically convert a `%hymn` to printed `%html` if it was requested through
+Eyre's scry interface.
 
 #### `%elem`
 
@@ -356,7 +351,7 @@ The type of the `%elem` mark is a `$manx`, just like a `%hymn`. While `%hymn`s
 are intended for complete HTML documents, `%elem`s are intended for more general
 XML structures. You may wish to use an `%elem` mark if you're producing smaller
 fragments of XML or HTML rather than whole documents. Like a `%hymn`, Eyre can
-automatically convert it to `%html` and provide it to web clients.
+automatically convert it to `%html` if requested through its scry interface.
 
 #### Summary
 

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -408,12 +408,11 @@ In order to nest it inside another Sail element, it must be preceeded with a
 
 ```hoon
 ;p
-  ;+  ;/  "foobar"
+  ;+  ;/  ?:  =(0 (mod eny 2))
+            "even"
+          "odd"
 ==
 ```
-
-The argument for Micfas needn't directly be a tape, it may also be a hoon
-expression that produces a tape.
 
 ### `;*` Mictar
 

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -78,8 +78,11 @@ tag name, then insert your plain text following a space. Example:
 ### Nested
 
 To nest tags, simply create a new line. Nested tags need to be closed with `==`,
-because they expect a list of sub-tags. If we nest lines of plain text with no
-tag, the text will be wrapped in a `&lt;p>` tag.
+because they expect a list of sub-tags.
+
+If we nest lines of plain text with no tag, the text will be wrapped in a
+`&lt;p>` tag. Additionally, any text with atom auras or `++arm:syntax` in such
+plain text lines will be wrapped in `&lt;code>` tags.
 
 Example:
 

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -1,0 +1,472 @@
++++
+title = "Sail (HTML)"
+weight = 6
+template = "doc.html"
++++
+
+Sail is a domain-specific language for composing HTML structures in Hoon.
+Front-ends for Urbit apps are often created and uploaded separately to the rest
+of the code in the desk. Sail provides an alternative approach, where front-ends
+can be composed directly inside agents.
+
+This document will walk through the basics of Sail and its syntax.
+
+## Basic example
+
+It’s easy to see how Sail can directly translate to HTML:
+
+#### Sail code
+
+```hoon
+;html
+  ;head
+    ;title: My page
+    ;meta(charset "utf-8");
+  ==
+  ;body
+    ;h1: Welcome!
+    ;p
+      ; Hello, world!
+      ; Welcome to my page.
+      ; Here is an image:
+      ;br;
+      ;img@"https://media.urbit.org/docs/userspace/dist/wut.svg";
+    ==
+  ==
+==
+```
+
+#### HTML code
+
+```html
+&lt;html> &lt;head> &lt;title>My page&lt;/title> &lt;meta charset="utf-8" />
+&lt;/head> &lt;body> &lt;h1>Welcome!&lt;/h1> &lt;p> Hello, world! Welcome to my
+page. Here is an image: &lt;br /> &lt;img
+src="https://media.urbit.org/docs/userspace/dist/wut.svg" /> &lt;/p> &lt;/body>
+&lt;/html>
+```
+
+## Tags and Closing
+
+In Sail, tag heads are written with the tag name prepended by `;`. Unlike in
+HTML, there are different ways of closing tags, depending on the needs of the
+tag. One of the nice things about Hoon is that you don’t have to be constantly
+closing expressions; Sail inherits this convenience.
+
+### Empty
+
+Empty tags are closed with a `;` following the tag. For example, `;div;` will be
+rendered as `&lt;div>&lt;/div>`. Non-container tags `;br;` and `;img@"some-url";` in
+particular will be rendered as a single tag like `&lt;br />` and `&lt;img src="some-url" />`.
+
+### Filled
+
+Filled tags are closed via line-break. To fill text inside, add `:` after the
+tag name, then insert your plain text following a space. Example:
+
+```hoon
+;h1: The title
+```
+
+Produces:
+
+```html
+&lt;h1>The title&lt;/h1>
+```
+
+### Nested
+
+To nest tags, simply create a new line. Nested tags need to be closed with `==`,
+because they expect a list of sub-tags. If we nest lines of plain text with no
+tag, the text will be wrapped in a `&lt;p>` tag.
+
+Example:
+
+```hoon
+;body
+  ;h1: Blog title
+  This is some good content.
+==
+```
+
+Produces:
+
+```html
+&lt;body> &lt;h1>Blog title&lt;/h1> &lt;p>This is some good content.&lt;/p>
+&lt;/body>
+```
+
+If we want to write a string with no tag at all, then we can prepend
+those untagged lines with `;` and then a space:
+
+```hoon
+;body
+  ;h1: Welcome!
+  ; Hello, world!
+  ; We’re on the web.
+==
+```
+
+Produces:
+
+```html
+&lt;body> &lt;h1>Welcome!&lt;/h1> Hello, world. We’re on the web. &lt;/body>
+```
+
+## Attributes
+
+Adding attributes is simple: just add the desired attribute between parentheses,
+right after the tag name without a space. We separate different attributes of
+the same node by using `,`.
+
+Attributes can also be specified in tall form, with each key prefixed by `=`,
+followed by two spaces, and then a tape with its value. These two styles are
+shown below.
+
+### Generic
+
+Wide-form attributes:
+
+```hoon
+;div(title "a tooltip", style "color:red")
+  ;h1: Foo
+  foo bar baz
+==
+```
+
+Tall-form attributes:
+
+```hoon
+;div
+  =title  "a tooltip"
+  =style  "color:red"
+  ;h1: Foo
+  foo bar baz
+==
+```
+
+Produces:
+
+```html
+&lt;div title="a tooltip" style="color:red"> &lt;h1>Foo&lt;/h1> &lt;p>foo bar
+baz &lt;/p> &lt;/div>
+```
+
+### IDs
+
+Add `#` after tag name to add an ID:
+
+```hoon
+;nav#header: Menu
+```
+
+Produces:
+
+```html
+&lt;nav id="header">Menu&lt;/nav>
+```
+
+### Classes
+
+Add `.` after tag name to add a class:
+
+```hoon
+;h1.text-blue: Title
+```
+
+Produces:
+
+```html
+&lt;h1 class="text-blue">Title&lt;/h1>
+```
+
+If you want a class name that contains a space, you will need to use use the
+syntax of a generic attribute:
+
+```hoon
+;div(class "logo inverse");
+```
+
+Produces:
+
+```html
+&lt;div class="logo inverse">&lt;/div>
+```
+
+### Images
+
+Add `@` after the tag name to link your source:
+
+```hoon
+;img@"example.png";
+```
+
+Produces:
+
+```html
+&lt;img src="example.png"/>
+```
+
+To add attributes to the image, like size specifications, add the desired
+attribute after the `"` of the image name and before the final `;` of the `img`
+tag:
+
+```hoon
+;img@"example.png"(width "100%");
+```
+
+### Links
+
+Add `/` after tag name to start an `href`.
+
+```hoon
+;a/"urbit.org": A link to Urbit.org
+```
+
+Produces:
+
+```html
+&lt;a href="urbit.org">A link to Urbit.org&lt;/a>
+```
+
+## Interpolation
+
+The textual content of tags, despite not being enclosed in double-quotes, are
+actually tapes. This means they support interpolated Hoon expressions in the
+usual manner. For example:
+
+```hoon
+=|  =time
+;p: foo {<time>} bar
+```
+
+Produces:
+
+```html
+&lt;p>foo ~2000.1.1 baz&lt;/p>
+```
+
+Likewise:
+
+```hoon
+=/  txt=tape  " bananas"
+;article
+  ;b: {(a-co:co (mul 42 789))}
+  ; {txt}
+  {<our>} {<now>} {<`@ux`(end 6 eny)>}
+==
+```
+
+Produces:
+
+```html
+&lt;article> &lt;b>33138&lt;/b> bananas &lt;p>~zod ~2022.2.21..09.54.21..5b63
+0x9827.99c7.06f4.8ef9 &lt;/p> &lt;/article>
+```
+
+## A note on CSS
+
+The CSS for a page is usually quite large. The typical approach is to include a
+separate arm in your agent (`++style` or the like) and write out the CSS in a
+fenced cord block. You can then call `++trip` on it and include it in a style
+tag. For example:
+
+```hoon
+++  style
+  ^~
+  %-  trip
+  '''
+  main {
+    width: 100%;
+    color: red;
+  }
+  header {
+    color: blue;
+    font-family: monospace;
+  }
+  '''
+```
+
+And then your style tag might look like:
+
+```hoon
+;style: {style}
+```
+
+A cord is used rather than a tape so you don't need to escape double-quotes. The
+[ketsig](/docs/hoon/reference/rune/ket#-ketsig) (`^~`) rune means `++trip` will
+be run at compile time rather than call time.
+
+## Types and marks
+
+So far we've shown rendered HTML for demonstrative purposes, but Sail syntax
+doesn't directly produce HTML text. Instead, it produces a
+[$manx](/docs/hoon/reference/stdlib/5e#manx). This is a Hoon type used to
+represent an XML hierarchical structure with a single root node. There are six
+XML-related types defined in the standard library:
+
+```hoon
++$  mane  $@(@tas [@tas @tas])                    ::  XML name+space
++$  manx  $~([[%$ ~] ~] [g=marx c=marl])          ::  dynamic XML node
++$  marl  (list manx)                             ::  XML node list
++$  mars  [t=[n=%$ a=[i=[n=%$ v=tape] t=~]] c=~]  ::  XML cdata
++$  mart  (list [n=mane v=tape])                  ::  XML attributes
++$  marx  $~([%$ ~] [n=mane a=mart])              ::  dynamic XML tag
+```
+
+More information about these can be found in [section 5e of the standard library
+reference](/docs/hoon/reference/stdlib/5e).
+
+You don't need to understand these types in order to write Sail. The main thing
+to note is that a `$manx` is a node (a single tag) and its contents is a
+[$marl](/docs/hoon/reference/stdlib/5e#marl), which is just a `(list manx)`.
+
+### Rendering
+
+A `$manx` can be rendered as HTML in a tape with the `++en-xml:html` function in
+`zuse.hoon`. For example:
+
+```
+> ;p: foobar
+[[%p ~] [[%$ [%$ "foobar"] ~] ~] ~]
+
+> =x ;p: foobar
+
+> (en-xml:html x)
+"<p>foobar</p>"
+
+> (crip (en-xml:html x))
+'<p>foobar</p>'
+```
+
+You may wish to do this in your agent directly, but you can also leave mark
+conversion to Eyre.
+
+### Sanitization
+
+The `++en-xml:html` function will sanitize the contents of both attributes and
+elements, converting characters such as `>` to HTML entities. For example:
+
+```
+> =z ;p(class "\"><script src=\"example.com/xxx.js"): <h1>FOO</h1>
+
+> (crip (en-xml:html z))
+'<p class="&quot;&gt;&lt;script src=&quot;example.com/xxx.js">&lt;h1&gt;FOO&lt;/h1&gt;</p>'
+```
+
+### Marks
+
+The mark for a raw `$manx` is a `%hymn`. This mark is included in the `%base`
+desk. The mark for a rendered HTML cord is `%html`. The `%hymn` mark includes
+conversion methods to both `%html` and `%mime`. The `%html` mark includes
+conversion methods to `%mime` and `%hymn`.
+
+If you want to produce an HTML document through Eyre's scry interface, for
+example, you can either produce a `$manx` with a `%hymn` mark and let Eyre
+convert it to `%html`, or else you can call `++en-xml:html` and then `++crip` on
+the product of your Sail expressions and produce a cord with an `%html` mark
+directly.
+
+## Sail Runes
+
+In addition to the syntax so far described, there are also a few Sail-specific
+runes:
+
+### `;+` Miclus
+
+The [miclus rune](/docs/hoon/reference/rune/mic#-miclus) makes a `$marl` from a
+complex hoon expression that produces a single `$manx`. Its main use is nesting
+tall-form hoon logic in another Sail element. For example:
+
+```hoon
+;p
+  ;b: {(a-co:co number)}
+  ; is an
+  ;+  ?:  =(0 (mod number 2))
+        ;b: even
+      ;b: odd
+  ; number.
+==
+```
+
+Produces one of these depending on the value of `number`:
+
+```html
+&lt;p> &lt;b>2 &lt;/b>is an &lt;b>even &lt;/b>number. &lt;/p>
+```
+
+```html
+&lt;p> &lt;b>12345 &lt;/b>is an &lt;b>odd &lt;/b>number. &lt;/p>
+```
+
+### `;/` Micfas
+
+The [micfas rune](/docs/hoon/reference/rune/mic#-micfas) turns an ordinary tape
+into a `$manx`. For example:
+
+```
+> %-  en-xml:html  ;/  "foobar"
+"foobar"
+```
+
+In order to nest it inside another Sail element, it must be preceeded with a
+`;+` rune or similar, it cannot be used directly. For example:
+
+```hoon
+;p
+  ;+  ;/  "foobar"
+==
+```
+
+The argument for Micfas needn't directly be a tape, it may also be a hoon
+expression that produces a tape.
+
+### `;*` Mictar
+
+The [mictar rune](/docs/hoon/reference/rune/mic#-mictar) makes a `$marl` (a list
+of XML nodes) from a complex hoon expression. This rune lets you add many
+elements inside another Sail element. For example:
+
+```hoon
+=/  nums=(list @ud)  (gulf 1 9)
+;p
+  ;*  %+  turn  nums
+      |=  n=@ud
+      ?:  =(0 (mod n 2))
+        ;sup: {(a-co:co n)}
+      ;sub: {(a-co:co n)}
+==
+```
+
+Produces:
+
+```html
+&lt;p> &lt;sub>1&lt;/sub>&lt;sup>2&lt;/sup>&lt;sub>3&lt;/sub>
+&lt;sup>4&lt;/sup>&lt;sub>5&lt;/sub>&lt;sup>6&lt;/sup>
+&lt;sub>7&lt;/sub>&lt;sup>8&lt;/sup>&lt;sub>9&lt;/sub> &lt;/p>
+```
+
+### `;=` Mictis
+
+The [mictis rune](/docs/hoon/reference/rune/mic#-mictis) makes a `$marl` (a list
+of XML nodes) from a series of `$manx`es. This is mostly useful if you want to
+make the list outside of an element and then be able to insert it afterwards.
+For example:
+
+```hoon
+=/  paras=marl
+  ;=  ;p: This is the first node.
+      ;p: This is the second.
+      ;p: Here is the last one.
+  ==
+;main
+  ;*  paras
+==
+```
+
+Produces:
+
+```html
+&lt;main> &lt;p>This is the first node.&lt;/p> &lt;p>This is the second.&lt;/p>
+&lt;p>Here is the last one.&lt;/p> &lt;/main>
+```

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -38,12 +38,21 @@ It’s easy to see how Sail can directly translate to HTML:
 
 #### HTML code
 
-```html
-&lt;html> &lt;head> &lt;title>My page&lt;/title> &lt;meta charset="utf-8" />
-&lt;/head> &lt;body> &lt;h1>Welcome!&lt;/h1> &lt;p> Hello, world! Welcome to my
-page. Here is an image: &lt;br /> &lt;img
-src="https://media.urbit.org/docs/userspace/dist/wut.svg" /> &lt;/p> &lt;/body>
-&lt;/html>
+```
+<html>
+  <head>
+    <title>My page</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <h1>Welcome!</h1>
+    <p>Hello, world! Welcome to my
+      page. Here is an image:
+      <br />
+      <img src="https://media.urbit.org/docs/userspace/dist/wut.svg" />
+    </p>
+  </body>
+</html>
 ```
 
 ## Tags and Closing
@@ -70,8 +79,8 @@ tag name, then insert your plain text following a space. Example:
 
 Produces:
 
-```html
-&lt;h1>The title&lt;/h1>
+```
+<h1>The title</h1>
 ```
 
 ### Nested
@@ -91,9 +100,11 @@ Example:
 
 Produces:
 
-```html
-&lt;body> &lt;h1>Blog title&lt;/h1> &lt;p>This is some good content.&lt;/p>
-&lt;/body>
+```
+<body>
+  <h1>Blog title</h1>
+  <p>This is some good content.</p>
+</body>
 ```
 
 If we want to write a string with no tag at all, then we can prepend
@@ -109,8 +120,11 @@ those untagged lines with `;` and then a space:
 
 Produces:
 
-```html
-&lt;body> &lt;h1>Welcome!&lt;/h1> Hello, world. We’re on the web. &lt;/body>
+```
+<body>
+  <h1>Welcome!</h1>
+  Hello, world. We’re on the web.
+</body>
 ```
 
 ## Attributes
@@ -147,9 +161,11 @@ Tall-form attributes:
 
 Produces:
 
-```html
-&lt;div title="a tooltip" style="color:red"> &lt;h1>Foo&lt;/h1> &lt;p>foo bar
-baz &lt;/p> &lt;/div>
+```
+<div title="a tooltip" style="color:red">
+  <h1>Foo</h1>
+  <p>foo bar baz </p>
+</div>
 ```
 
 ### IDs
@@ -162,8 +178,8 @@ Add `#` after tag name to add an ID:
 
 Produces:
 
-```html
-&lt;nav id="header">Menu&lt;/nav>
+```
+<nav id="header">Menu</nav>
 ```
 
 ### Classes
@@ -176,8 +192,8 @@ Add `.` after tag name to add a class:
 
 Produces:
 
-```html
-&lt;h1 class="text-blue">Title&lt;/h1>
+```
+<h1 class="text-blue">Title</h1>
 ```
 
 If you want a class name that contains a space, you will need to use use the
@@ -189,8 +205,8 @@ syntax of a generic attribute:
 
 Produces:
 
-```html
-&lt;div class="logo inverse">&lt;/div>
+```
+<div class="logo inverse"></div>
 ```
 
 ### Images
@@ -203,8 +219,8 @@ Add `@` after the tag name to link your source:
 
 Produces:
 
-```html
-&lt;img src="example.png"/>
+```
+<img src="example.png"/>
 ```
 
 To add attributes to the image, like size specifications, add the desired
@@ -225,8 +241,8 @@ Add `/` after tag name to start an `href`.
 
 Produces:
 
-```html
-&lt;a href="urbit.org">A link to Urbit.org&lt;/a>
+```
+<a href="urbit.org">A link to Urbit.org</a>
 ```
 
 ## Interpolation
@@ -242,8 +258,8 @@ usual manner. For example:
 
 Produces:
 
-```html
-&lt;p>foo ~2000.1.1 baz&lt;/p>
+```
+<p>foo ~2000.1.1 baz</p>
 ```
 
 Likewise:
@@ -259,9 +275,11 @@ Likewise:
 
 Produces:
 
-```html
-&lt;article> &lt;b>33138&lt;/b> bananas &lt;p>~zod ~2022.2.21..09.54.21..5b63
-0x9827.99c7.06f4.8ef9 &lt;/p> &lt;/article>
+```
+<article>
+  <b>33138</b> bananas
+  <p>~zod ~2022.2.21..09.54.21..5b63 0x9827.99c7.06f4.8ef9</p>
+</article>
 ```
 
 ## A note on CSS
@@ -391,12 +409,12 @@ tall-form hoon logic in another Sail element. For example:
 
 Produces one of these depending on the value of `number`:
 
-```html
-&lt;p>&lt;b>2 &lt;/b>is an &lt;b>even &lt;/b>number.&lt;/p>
+```
+<p><b>2 </b>is an <b>even </b>number.</p>
 ```
 
-```html
-&lt;p>&lt;b>12345 &lt;/b>is an &lt;b>odd &lt;/b>number.&lt;/p>
+```
+<p><b>12345 </b>is an <b>odd </b>number.</p>
 ```
 
 ### `;/` Micfas
@@ -440,10 +458,12 @@ elements inside another Sail element. For example:
 
 Produces:
 
-```html
-&lt;p> &lt;sub>1&lt;/sub>&lt;sup>2&lt;/sup>&lt;sub>3&lt;/sub>
-&lt;sup>4&lt;/sup>&lt;sub>5&lt;/sub>&lt;sup>6&lt;/sup>
-&lt;sub>7&lt;/sub>&lt;sup>8&lt;/sup>&lt;sub>9&lt;/sub> &lt;/p>
+```
+<p>
+  <sub>1</sub><sup>2</sup><sub>3</sub>
+  <sup>4</sup><sub>5</sub><sup>6</sup>
+  <sub>7</sub><sup>8</sup><sub>9</sub>
+</p>
 ```
 
 ### `;=` Mictis
@@ -466,7 +486,10 @@ For example:
 
 Produces:
 
-```html
-&lt;main> &lt;p>This is the first node.&lt;/p> &lt;p>This is the second.&lt;/p>
-&lt;p>Here is the last one.&lt;/p> &lt;/main>
+```
+<main>
+  <p>This is the first node.</p>
+  <p>This is the second.</p>
+  <p>Here is the last one.</p>
+</main>
 ```

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -4,10 +4,10 @@ weight = 6
 template = "doc.html"
 +++
 
-Sail is a domain-specific language for composing HTML structures in Hoon.
-Front-ends for Urbit apps are often created and uploaded separately to the rest
-of the code in the desk. Sail provides an alternative approach, where front-ends
-can be composed directly inside agents.
+Sail is a domain-specific language for composing HTML (and XML) structures in
+Hoon. Front-ends for Urbit apps are often created and uploaded separately to the
+rest of the code in the desk. Sail provides an alternative approach, where
+front-ends can be composed directly inside agents.
 
 This document will walk through the basics of Sail and its syntax.
 

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -261,7 +261,7 @@ And then your style tag might look like:
 ;style: {style}
 ```
 
-A cord is used rather than a tape so you don't need to escape double-quotes. The
+A cord is used rather than a tape so you don't need to escape braces. The
 [ketsig](/docs/hoon/reference/rune/ket#-ketsig) (`^~`) rune means `++trip` will
 be run at compile time rather than call time.
 

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -392,11 +392,11 @@ tall-form hoon logic in another Sail element. For example:
 Produces one of these depending on the value of `number`:
 
 ```html
-&lt;p> &lt;b>2 &lt;/b>is an &lt;b>even &lt;/b>number. &lt;/p>
+&lt;p>&lt;b>2 &lt;/b>is an &lt;b>even &lt;/b>number.&lt;/p>
 ```
 
 ```html
-&lt;p> &lt;b>12345 &lt;/b>is an &lt;b>odd &lt;/b>number. &lt;/p>
+&lt;p>&lt;b>12345 &lt;/b>is an &lt;b>odd &lt;/b>number.&lt;/p>
 ```
 
 ### `;/` Micfas

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -393,27 +393,6 @@ Produces one of these depending on the value of `number`:
 <p><b>12345 </b>is an <b>odd </b>number.</p>
 ```
 
-### `;/` Micfas
-
-The [micfas rune](/docs/hoon/reference/rune/mic#-micfas) turns an ordinary tape
-into a `$manx`. For example:
-
-```
-> %-  en-xml:html  ;/  "foobar"
-"foobar"
-```
-
-In order to nest it inside another Sail element, it must be preceeded with a
-`;+` rune or similar, it cannot be used directly. For example:
-
-```hoon
-;p
-  ;+  ;/  ?:  =(0 (mod eny 2))
-            "even"
-          "odd"
-==
-```
-
 ### `;*` Mictar
 
 The [mictar rune](/docs/hoon/reference/rune/mic#-mictar) makes a `$marl` (a list
@@ -464,6 +443,27 @@ For example:
   &#x26;&#x6C;&#x74;&#x3B;p>Third node.&#x26;&#x6C;&#x74;&#x3B;/p>
 &#x26;&#x6C;&#x74;&#x3B;/main>
 </pre></td></tr></tbody></table>
+
+### `;/` Micfas
+
+The [micfas rune](/docs/hoon/reference/rune/mic#-micfas) turns an ordinary tape
+into a `$manx`. For example:
+
+```
+> %-  en-xml:html  ;/  "foobar"
+"foobar"
+```
+
+In order to nest it inside another Sail element, it must be preceeded with a
+`;+` rune or similar, it cannot be used directly. For example:
+
+```hoon
+;p
+  ;+  ;/  ?:  =(0 (mod eny 2))
+            "even"
+          "odd"
+==
+```
 
 ## Good examples
 

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -430,3 +430,14 @@ For example:
   &#x26;&#x6C;&#x74;&#x3B;p>Third node.&#x26;&#x6C;&#x74;&#x3B;/p>
 &#x26;&#x6C;&#x74;&#x3B;/main>
 </pre></td></tr></tbody></table>
+
+## Good examples
+
+Here's a couple of agents that make use of Sail, which you can use as a
+reference:
+
+- [Pals by ~palfun-foslup][pals]
+- [Gora by ~rabsef-bicrym][gora]
+
+[pals]: https://github.com/Fang-/suite/blob/master/app/pals/webui/index.hoon
+[gora]: https://github.com/dalten-collective/gora/blob/master/sail/app/gora/goraui/index.hoon

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -167,12 +167,18 @@ Add `.` after tag name to add a class:
 | ---------------------- | ---------------------------------------- |
 | `;h1.text-blue: Title` | `&lt;h1 class="text-blue">Title&lt;/h1>` |
 
-If you want a class name that contains a space, you will need to use use the
-syntax of a generic attribute:
+For class values containing spaces, you can add additional `.`s like so:
 
-| Sail                          | HTML                                     |
-| ----------------------------- | ---------------------------------------- |
-| `;div(class "logo inverse");` | `&lt;div class="logo inverse">&lt;/div>` |
+| Sail                | HTML                                    |
+| ------------------- | --------------------------------------- |
+| `;div.foo.bar.baz;` | `&lt;div class="foo bar baz">&lt;/div>` |
+
+Otherwise, if your class value does not conform to the allowed `@tas`
+characters, you must use the generic attribute syntax:
+
+| Sail                     | HTML                                |
+| ------------------------ | ----------------------------------- |
+| `;div(class "!!! !!!");` | `&lt;div class="!!! !!!">&lt;/div>` |
 
 ### Images
 

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -15,9 +15,8 @@ This document will walk through the basics of Sail and its syntax.
 
 It’s easy to see how Sail can directly translate to HTML:
 
-#### Sail code
-
-```hoon
+<table><thead><tr><th>Sail</th><th>HTML</th></tr></thead>
+<tbody><tr><td><pre class="language-hoon">
 ;html
   ;head
     ;title: My page
@@ -30,30 +29,26 @@ It’s easy to see how Sail can directly translate to HTML:
       ; Welcome to my page.
       ; Here is an image:
       ;br;
-      ;img@"https://media.urbit.org/docs/userspace/dist/wut.svg";
+      ;img@"/foo.png";
     ==
   ==
 ==
-```
-
-#### HTML code
-
-```
-<html>
-  <head>
-    <title>My page</title>
-    <meta charset="utf-8" />
-  </head>
-  <body>
-    <h1>Welcome!</h1>
-    <p>Hello, world! Welcome to my
+</pre></td><td><pre>
+&#x26;&#x6C;&#x74;&#x3B;html>
+  &#x26;&#x6C;&#x74;&#x3B;head>
+    &#x26;&#x6C;&#x74;&#x3B;title>My page&#x26;&#x6C;&#x74;&#x3B;/title>
+    &#x26;&#x6C;&#x74;&#x3B;meta charset="utf-8" />
+  &#x26;&#x6C;&#x74;&#x3B;/head>
+  &#x26;&#x6C;&#x74;&#x3B;body>
+    &#x26;&#x6C;&#x74;&#x3B;h1>Welcome!&#x26;&#x6C;&#x74;&#x3B;/h1>
+    &#x26;&#x6C;&#x74;&#x3B;p>Hello, world! Welcome to my
       page. Here is an image:
-      <br />
-      <img src="https://media.urbit.org/docs/userspace/dist/wut.svg" />
-    </p>
-  </body>
-</html>
-```
+      &#x26;&#x6C;&#x74;&#x3B;br />
+      &#x26;&#x6C;&#x74;&#x3B;img src="/foo.png" />
+    &#x26;&#x6C;&#x74;&#x3B;/p>
+  &#x26;&#x6C;&#x74;&#x3B;/body>
+&#x26;&#x6C;&#x74;&#x3B;/html>
+</pre></td></tr></tbody></table>
 
 ## Tags and Closing
 
@@ -73,15 +68,9 @@ particular will be rendered as a single tag like `&lt;br />` and `&lt;img src="s
 Filled tags are closed via line-break. To fill text inside, add `:` after the
 tag name, then insert your plain text following a space. Example:
 
-```hoon
-;h1: The title
-```
-
-Produces:
-
-```
-<h1>The title</h1>
-```
+| Sail             | HTML                       |
+| ---------------- | -------------------------- |
+| `;h1: The title` | `&lt;h1>The title&lt;/h1>` |
 
 ### Nested
 
@@ -91,41 +80,36 @@ tag, the text will be wrapped in a `&lt;p>` tag.
 
 Example:
 
-```hoon
+<table><thead><tr><th>Sail</th><th>HTML</th></tr></thead><tbody><tr><td>
+<pre class="language-hoon">
 ;body
   ;h1: Blog title
   This is some good content.
 ==
-```
-
-Produces:
-
-```
-<body>
-  <h1>Blog title</h1>
-  <p>This is some good content.</p>
-</body>
-```
+</pre></td><td><pre>
+&#x26;&#x6C;&#x74;&#x3B;body>
+  &#x26;&#x6C;&#x74;&#x3B;h1>Blog title&#x26;&#x6C;&#x74;&#x3B;/h1>
+  &#x26;&#x6C;&#x74;&#x3B;p>This is some good content.&#x26;&#x6C;&#x74;&#x3B;/p>
+&#x26;&#x6C;&#x74;&#x3B;/body>
+</pre></td></tr></tbody></table>
 
 If we want to write a string with no tag at all, then we can prepend
 those untagged lines with `;` and then a space:
 
-```hoon
+<table><thead><tr><th>Sail</th><th>HTML</th></tr></thead><tbody><tr><td>
+<pre class="language-hoon">
 ;body
   ;h1: Welcome!
   ; Hello, world!
   ; We’re on the web.
 ==
-```
-
-Produces:
-
-```
-<body>
-  <h1>Welcome!</h1>
-  Hello, world. We’re on the web.
-</body>
-```
+</pre></td><td><pre>
+&#x26;&#x6C;&#x74;&#x3B;body>
+  &#x26;&#x6C;&#x74;&#x3B;h1>Welcome!&#x26;&#x6C;&#x74;&#x3B;/h1>
+  Hello, world!
+  We’re on the web.
+&#x26;&#x6C;&#x74;&#x3B;/body>
+</pre></td></tr></tbody></table>
 
 ## Attributes
 
@@ -139,111 +123,72 @@ shown below.
 
 ### Generic
 
-Wide-form attributes:
-
-```hoon
+<table><thead><tr><th>Form</th><th>Example</th></tr></thead><tbody>
+<tr><td>Wide</td><td><pre class="language-hoon">
 ;div(title "a tooltip", style "color:red")
   ;h1: Foo
   foo bar baz
 ==
-```
-
-Tall-form attributes:
-
-```hoon
+</pre></td></tr>
+<tr><td>Tall</td><td><pre class="language-hoon">
 ;div
   =title  "a tooltip"
   =style  "color:red"
   ;h1: Foo
   foo bar baz
 ==
-```
-
-Produces:
-
-```
-<div title="a tooltip" style="color:red">
-  <h1>Foo</h1>
-  <p>foo bar baz </p>
-</div>
-```
+</pre></td></tr>
+<tr><td>HTML</td><td><pre>
+&#x26;&#x6C;&#x74;&#x3B;div title="a tooltip" style="color:red">
+  &#x26;&#x6C;&#x74;&#x3B;h1>Foo&#x26;&#x6C;&#x74;&#x3B;/h1>
+  &#x26;&#x6C;&#x74;&#x3B;p>foo bar baz &#x26;&#x6C;&#x74;&#x3B;/p>
+&#x26;&#x6C;&#x74;&#x3B;/div>
+</pre></td></tr></tbody></table>
 
 ### IDs
 
 Add `#` after tag name to add an ID:
 
-```hoon
-;nav#header: Menu
-```
-
-Produces:
-
-```
-<nav id="header">Menu</nav>
-```
+| Sail                | HTML                                |
+| ------------------- | ----------------------------------- |
+| `;nav#header: Menu` | `&lt;nav id="header">Menu&lt;/nav>` |
 
 ### Classes
 
 Add `.` after tag name to add a class:
 
-```hoon
-;h1.text-blue: Title
-```
-
-Produces:
-
-```
-<h1 class="text-blue">Title</h1>
-```
+| Sail                   | HTML                                     |
+| ---------------------- | ---------------------------------------- |
+| `;h1.text-blue: Title` | `&lt;h1 class="text-blue">Title&lt;/h1>` |
 
 If you want a class name that contains a space, you will need to use use the
 syntax of a generic attribute:
 
-```hoon
-;div(class "logo inverse");
-```
-
-Produces:
-
-```
-<div class="logo inverse"></div>
-```
+| Sail                          | HTML                                     |
+| ----------------------------- | ---------------------------------------- |
+| `;div(class "logo inverse");` | `&lt;div class="logo inverse">&lt;/div>` |
 
 ### Images
 
 Add `@` after the tag name to link your source:
 
-```hoon
-;img@"example.png";
-```
-
-Produces:
-
-```
-<img src="example.png"/>
-```
+| Sail                  | HTML                          |
+| --------------------- | ----------------------------- |
+| `;img@"example.png";` | `&lt;img src="example.png"/>` |
 
 To add attributes to the image, like size specifications, add the desired
 attribute after the `"` of the image name and before the final `;` of the `img`
-tag:
-
-```hoon
-;img@"example.png"(width "100%");
-```
+tag like ;img@"example.png"(width "100%");`.
 
 ### Links
 
 Add `/` after tag name to start an `href`.
 
-```hoon
+<table><tr><th>Sail</th></tr><tr><td><pre class="language-hoon">
 ;a/"urbit.org": A link to Urbit.org
-```
-
-Produces:
-
-```
-<a href="urbit.org">A link to Urbit.org</a>
-```
+</pre></td></tr><tr><th>HTML</th></tr><tr><td><pre>
+&#x26;&#x6C;&#x74;&#x3B;a href="urbit.org">A link to Urbit.org&#x26;&#x6C;&#x74;&#x3B;/a>
+</pre></td></tr></table>
 
 ## Interpolation
 
@@ -251,36 +196,29 @@ The textual content of tags, despite not being enclosed in double-quotes, are
 actually tapes. This means they support interpolated Hoon expressions in the
 usual manner. For example:
 
-```hoon
+<table><thead><tr><th>Sail</th><th>HTML</th></tr></thead><tbody><tr><td>
+<pre class="language-hoon">
 =|  =time
-;p: foo {<time>} bar
-```
-
-Produces:
-
-```
-<p>foo ~2000.1.1 baz</p>
-```
+;p: foo {&#x26;&#x6C;&#x74;&#x3B;time>} bar
+</pre></td><td><pre>
+&#x26;&#x6C;&#x74;&#x3B;p>foo ~2000.1.1 baz&#x26;&#x6C;&#x74;&#x3B;/p>
+</pre></td></tr></tbody></table>
 
 Likewise:
 
-```hoon
+<table><tr><th>Sail</th></tr><tr><td><pre class="language-hoon">
 =/  txt=tape  " bananas"
 ;article
   ;b: {(a-co:co (mul 42 789))}
   ; {txt}
-  {<our>} {<now>} {<`@ux`(end 6 eny)>}
+  {&#x26;&#x6C;&#x74;&#x3B;our>} {&#x26;&#x6C;&#x74;&#x3B;now>} {&#x26;&#x6C;&#x74;&#x3B;`@ux`(end 6 eny)>}
 ==
-```
-
-Produces:
-
-```
-<article>
-  <b>33138</b> bananas
-  <p>~zod ~2022.2.21..09.54.21..5b63 0x9827.99c7.06f4.8ef9</p>
-</article>
-```
+</pre></td></tr><tr><th>HTML</th></tr><tr><td><pre>
+&#x26;&#x6C;&#x74;&#x3B;article>
+  &#x26;&#x6C;&#x74;&#x3B;b>33138&#x26;&#x6C;&#x74;&#x3B;/b> bananas
+  &#x26;&#x6C;&#x74;&#x3B;p>~zod ~2022.2.21..09.54.21..5b63 0x9827.99c7.06f4.8ef9&#x26;&#x6C;&#x74;&#x3B;/p>
+&#x26;&#x6C;&#x74;&#x3B;/article>
+</pre></td></tr></table>
 
 ## A note on CSS
 
@@ -445,7 +383,8 @@ The [mictar rune](/docs/hoon/reference/rune/mic#-mictar) makes a `$marl` (a list
 of XML nodes) from a complex hoon expression. This rune lets you add many
 elements inside another Sail element. For example:
 
-```hoon
+<table><thead><tr><th>Sail</th><th>HTML</th></tr></thead><tbody><tr><td>
+<pre class="language-hoon">
 =/  nums=(list @ud)  (gulf 1 9)
 ;p
   ;*  %+  turn  nums
@@ -454,17 +393,15 @@ elements inside another Sail element. For example:
         ;sup: {(a-co:co n)}
       ;sub: {(a-co:co n)}
 ==
-```
-
-Produces:
-
-```
-<p>
-  <sub>1</sub><sup>2</sup><sub>3</sub>
-  <sup>4</sup><sub>5</sub><sup>6</sup>
-  <sub>7</sub><sup>8</sup><sub>9</sub>
-</p>
-```
+</pre></td><td><pre>
+&#x26;&#x6C;&#x74;&#x3B;p>
+  &#x26;&#x6C;&#x74;&#x3B;sub>1&#x26;&#x6C;&#x74;&#x3B;/sub>&#x26;&#x6C;&#x74;&#x3B;sup>2&#x26;&#x6C;&#x74;&#x3B;/sup>
+  &#x26;&#x6C;&#x74;&#x3B;sub>3&#x26;&#x6C;&#x74;&#x3B;/sub>&#x26;&#x6C;&#x74;&#x3B;sup>4&#x26;&#x6C;&#x74;&#x3B;/sup>
+  &#x26;&#x6C;&#x74;&#x3B;sub>5&#x26;&#x6C;&#x74;&#x3B;/sub>&#x26;&#x6C;&#x74;&#x3B;sup>6&#x26;&#x6C;&#x74;&#x3B;/sup>
+  &#x26;&#x6C;&#x74;&#x3B;sub>7&#x26;&#x6C;&#x74;&#x3B;/sub>&#x26;&#x6C;&#x74;&#x3B;sup>8&#x26;&#x6C;&#x74;&#x3B;/sup>
+  &#x26;&#x6C;&#x74;&#x3B;sub>9&#x26;&#x6C;&#x74;&#x3B;/sub>
+&#x26;&#x6C;&#x74;&#x3B;/p>
+</pre></td></tr></tbody></table>
 
 ### `;=` Mictis
 
@@ -473,23 +410,20 @@ of XML nodes) from a series of `$manx`es. This is mostly useful if you want to
 make the list outside of an element and then be able to insert it afterwards.
 For example:
 
-```hoon
+<table><thead><tr><th>Sail</th><th>HTML</th></tr></thead><tbody><tr><td>
+<pre class="language-hoon">
 =/  paras=marl
-  ;=  ;p: This is the first node.
-      ;p: This is the second.
-      ;p: Here is the last one.
+  ;=  ;p: First node.
+      ;p: Second node.
+      ;p: Third node.
   ==
 ;main
   ;*  paras
 ==
-```
-
-Produces:
-
-```
-<main>
-  <p>This is the first node.</p>
-  <p>This is the second.</p>
-  <p>Here is the last one.</p>
-</main>
-```
+</pre></td><td><pre>
+&#x26;&#x6C;&#x74;&#x3B;main>
+  &#x26;&#x6C;&#x74;&#x3B;p>First node.&#x26;&#x6C;&#x74;&#x3B;/p>
+  &#x26;&#x6C;&#x74;&#x3B;p>Second node.&#x26;&#x6C;&#x74;&#x3B;/p>
+  &#x26;&#x6C;&#x74;&#x3B;p>Third node.&#x26;&#x6C;&#x74;&#x3B;/p>
+&#x26;&#x6C;&#x74;&#x3B;/main>
+</pre></td></tr></tbody></table>

--- a/content/docs/hoon/guides/sail.md
+++ b/content/docs/hoon/guides/sail.md
@@ -5,7 +5,10 @@ template = "doc.html"
 +++
 
 Sail is a domain-specific language for composing HTML (and XML) structures in
-Hoon. Front-ends for Urbit apps are often created and uploaded separately to the
+Hoon. Like everything else in Hoon, a Sail document is a noun, just one produced
+by a specialized markup language within Hoon.
+
+Front-ends for Urbit apps are often created and uploaded separately to the
 rest of the code in the desk. Sail provides an alternative approach, where
 front-ends can be composed directly inside agents.
 


### PR DESCRIPTION
This is an update, edited, revised version of the old sail guide from 2019 (or whenever it was). The framing of writing whole documents in sail is replaced by a framing of using it in agents to render front-ends.