### PR TITLE
update list of planet vendors

### DIFF
--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -103,7 +103,7 @@ There are a few ways to get your own planet:
 
 - Getting an invitation from a friend (or stranger).
 - Purchasing a planet, including hosting, from a [hosting provider](#hosting-providers).
-- Manually setting up and hosting a planet purchased from a third party such as [azimuth.shop](https://azimuth.shop/), [urbit.live](https://urbit.live), [urbit.me](https://urbit.me), [Urbitex](https://urbitex.io), [Urbit Marketplace](https://urbitmarketplace.com/), or [planet.market](https://planet.market/).
+- Manually setting up and hosting a planet purchased from a third party such as [azimuth.shop](https://azimuth.shop/), [urbit.live](https://urbit.live), [urbit.me](https://urbit.me), [Urbitex](https://urbitex.io), [Urbit Marketplace](https://urbitmarketplace.com/), or [Wexpert Systems](https://wexpert.systems).
 
 ## Hosting Providers {#hosting-providers}
 

--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -103,7 +103,7 @@ There are a few ways to get your own planet:
 
 - Getting an invitation from a friend (or stranger).
 - Purchasing a planet, including hosting, from a [hosting provider](#hosting-providers).
-- Manually setting up and hosting a planet purchased from a third party such as [urbit.live](https://urbit.live), [OpenSea](https://opensea.io), [planet.market](https://planet.market/), [urbit.me](https://urbit.me), [urth systems](https://urth.systems/), [Urbitex](https://urbitex.io), or [Urbit Marketplace](https://urbitmarketplace.com/).
+- Manually setting up and hosting a planet purchased from a third party such as [azimuth.shop](https://azimuth.shop/), [urbit.live](https://urbit.live), [urbit.me](https://urbit.me), [Urbitex](https://urbitex.io), [Urbit Marketplace](https://urbitmarketplace.com/), or [planet.market](https://planet.market/).
 
 ## Hosting Providers {#hosting-providers}
 


### PR DESCRIPTION
OpenSea removed - incompatible with L2 and generally inferior to bespoke alternatives
urth.systems removed - page 404's
azimuth.shop added and placed first for being L2-optimized (re-ordering blessed by urbit.live's operator)
planet.market moved to end of line - page under construction