### PR TITLE
Correct return type of `murn`

### DIFF
--- a/content/docs/hoon/reference/stdlib/2b.md
+++ b/content/docs/hoon/reference/stdlib/2b.md
@@ -561,7 +561,7 @@ Passes each member of `list` `a` to gate `b`, which must produce a
 
 #### Produces
 
-A unit.
+A list.
 
 #### Source
 


### PR DESCRIPTION
Return type of `murn` is currently `unit` but should be `list`.