### PR TITLE
Fix typo in sigwut

### DIFF
--- a/content/docs/hoon/reference/rune/sig.md
+++ b/content/docs/hoon/reference/rune/sig.md
@@ -395,7 +395,7 @@ If `p` is true, prettyprints `q` on the console before computing `r`.
 
 ##### Syntax
 
-Regular: **4-fixed**.
+Regular: **3-fixed**.
 
 ##### Examples
 


### PR DESCRIPTION
sigwut takes 3 children not 4