### PR TITLE
threads: use correct start arguments

### DIFF
--- a/content/docs/userspace/threads/gall/poke-thread.md
+++ b/content/docs/userspace/threads/gall/poke-thread.md
@@ -29,7 +29,7 @@ Here's a modified agent that pokes our thread. I've replaced some off the previo
         (pair term term)
       =/  tid  `@ta`(cat 3 'thread_' (scot %uv (sham eny.bowl)))
       =/  ta-now  `@ta`(scot %da now.bowl)
-      =/  start-args  [~ `tid byk.bowl p.q.vase !>(q.q.vase)]
+      =/  start-args  [~ `tid byk.bowl(q da+now.bowl) p.q.vase !>(q.q.vase)]
       :_  this
       :~
         [%pass /thread/[ta-now] %agent [our.bowl %spider] %watch /thread-result/[tid]]

--- a/content/docs/userspace/threads/gall/start-thread.md
+++ b/content/docs/userspace/threads/gall/start-thread.md
@@ -29,7 +29,7 @@ Here's an example of a barebones gall agent that just starts a thread:
         (pair term term)
       =/  tid  `@ta`(cat 3 'thread_' (scot %uv (sham eny.bowl)))
       =/  ta-now  `@ta`(scot %da now.bowl)
-      =/  start-args  [~ `tid byk.bowl p.q.vase !>(q.q.vase)]
+      =/  start-args  [~ `tid byk.bowl(q da+now.bowl) p.q.vase !>(q.q.vase)]
       :_  this
       :~
         [%pass /thread/[ta-now] %agent [our.bowl %spider] %poke %spider-start !>(start-args)]
@@ -116,7 +116,7 @@ We can ignore the input logic, here's the important part:
 ```hoon
 =/  tid  `@ta`(cat 3 'thread_' (scot %uv (sham eny.bowl)))
 =/  ta-now  `@ta`(scot %da now.bowl)
-=/  start-args  [~ `tid byk.bowl p.q.vase !>(q.q.vase)]
+=/  start-args  [~ `tid byk.bowl(q da+now.bowl) p.q.vase !>(q.q.vase)]
 :_  this
 :~
   [%pass /thread/[ta-now] %agent [our.bowl %spider] %poke %spider-start !>(start-args)]

--- a/content/docs/userspace/threads/gall/stop-thread.md
+++ b/content/docs/userspace/threads/gall/stop-thread.md
@@ -29,7 +29,7 @@ Here we've added one last card to `on-poke` to stop the thread and a little extr
         (pair term term)
       =/  tid  `@ta`(cat 3 'thread_' (scot %uv (sham eny.bowl)))
       =/  ta-now  `@ta`(scot %da now.bowl)
-      =/  start-args  [~ `tid byk.bowl p.q.vase !>(q.q.vase)]
+      =/  start-args  [~ `tid byk.bowl(q da+now.bowl) p.q.vase !>(q.q.vase)]
       :_  this
       :~
         [%pass /thread/[ta-now] %agent [our.bowl %spider] %watch /thread-result/[tid]]

--- a/content/docs/userspace/threads/gall/take-facts.md
+++ b/content/docs/userspace/threads/gall/take-facts.md
@@ -31,7 +31,7 @@ Here we've added another card to subscribe for any facts sent by the thread and 
         (pair term term)
       =/  tid  `@ta`(cat 3 'thread_' (scot %uv (sham eny.bowl)))
       =/  ta-now  `@ta`(scot %da now.bowl)
-      =/  start-args  [~ `tid byk.bowl p.q.vase !>(q.q.vase)]
+      =/  start-args  [~ `tid byk.bowl(q da+now.bowl) p.q.vase !>(q.q.vase)]
       :_  this
       :~
         [%pass /thread/[ta-now] %agent [our.bowl %spider] %watch /thread-result/[tid]]

--- a/content/docs/userspace/threads/gall/take-result.md
+++ b/content/docs/userspace/threads/gall/take-result.md
@@ -29,7 +29,7 @@ Here we've added an extra card to subscribe for the result and a couple of lines
         (pair term term)
       =/  tid  `@ta`(cat 3 'thread_' (scot %uv (sham eny.bowl)))
       =/  ta-now  `@ta`(scot %da now.bowl)
-      =/  start-args  [~ `tid byk.bowl p.q.vase !>(q.q.vase)]
+      =/  start-args  [~ `tid byk.bowl(q da+now.bowl) p.q.vase !>(q.q.vase)]
       :_  this
       :~
         [%pass /thread/[ta-now] %agent [our.bowl %spider] %watch /thread-result/[tid]]


### PR DESCRIPTION
Generally, you want to use the latest case when starting threads.
The agent's build case may not be latest, and clay may not support building threads from there.

May or may not need similar changes elsewhere.

cc @yosoyubik, who ran into this.