### PR TITLE
api: less fuzzy search

### DIFF
--- a/pages/api/search.js
+++ b/pages/api/search.js
@@ -1,9 +1,11 @@
 import { index } from "../../cache/data";
-import FuzzySearch from "fuzzy-search";
 
 export default (req, res) => {
-  const searcher = new FuzzySearch(index, ["title"], { sort: true });
-  const results = searcher.search(req.query.q);
+  const results = index.filter(
+    (e) =>
+      e.title?.toLowerCase().includes(req.query.q) ||
+      e?.slug.includes(req.query.q)
+  );
   res.statusCode = 200;
   res.setHeader("Content-Type", "application/json");
   res.end(JSON.stringify({ results }));


### PR DESCRIPTION
Current search uses FuzzySearch and produces tons of results; with this PR basically we just filter down what you're searching and look for it in titles or slugs and leave it at that.

@tacryt-socryp I don't have a set of replication terms to assess this, could you peek at the Vercel preview here? If there's more to include in the index I can go hunting.