### PR TITLE
search: debounce input

### DIFF
--- a/components/Search.js
+++ b/components/Search.js
@@ -1,6 +1,7 @@
 import { Component, createRef } from "react";
 import { glossary } from "../lib/glossary";
 import { withRouter } from "next/router";
+import debounce from "lodash.debounce";
 import Downshift from "downshift";
 
 class Search extends Component {
@@ -38,7 +39,7 @@ class Search extends Component {
     this.props.closeSearch();
   }
 
-  onInputValueChange(query) {
+  onInputValueChange = debounce((query) => {
     if (query.length) {
       fetch(this.searchEndpoint(query))
         .then((res) => res.json())
@@ -61,7 +62,7 @@ class Search extends Component {
     } else {
       this.setState({ results: [] });
     }
-  }
+  }, 250);
 
   render() {
     const { state, props } = this;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "fuzzy-search": "^3.2.1",
         "gray-matter": "^4.0.3",
         "html-entities": "^2.3.2",
+        "lodash.debounce": "^4.0.8",
         "luxon": "^2.0.2",
         "next": "^12.1.5",
         "path-browserify": "^1.0.1",
@@ -1908,6 +1909,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "node_modules/longest-streak": {
       "version": "3.0.1",
@@ -6293,6 +6299,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "longest-streak": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "fuzzy-search": "^3.2.1",
     "gray-matter": "^4.0.3",
     "html-entities": "^2.3.2",
+    "lodash.debounce": "^4.0.8",
     "luxon": "^2.0.2",
     "next": "^12.1.5",
     "path-browserify": "^1.0.1",


### PR DESCRIPTION
We weren't debouncing search input, so we would send queries to the back-end each keystroke; sometimes partial keystroke requests would return after our complete one.

Fixes #1330

@tinnus-napbus can you run the deploy preview here and do your darndest to replicate your scenario again? I think we are good.