### PR TITLE
search: two fixes

### DIFF
--- a/components/Search.js
+++ b/components/Search.js
@@ -206,9 +206,10 @@ class Search extends Component {
                                   className={`font-normal text-base mt-1 ${
                                     selected ? "text-white" : "text-wall-600"
                                   }`}
-                                >
-                                  {item.content.desc}
-                                </p>
+                                  dangerouslySetInnerHTML={{
+                                    __html: item.content.desc,
+                                  }}
+                                ></p>
                               </div>
                             </li>
                           );

--- a/components/Search.js
+++ b/components/Search.js
@@ -84,7 +84,7 @@ class Search extends Component {
             content: item,
           }));
 
-          const list = [...patpResult, ...glossaryResults, ...results];
+          const list = [...glossaryResults, ...patpResult, ...results];
 
           this.setState({ results: list });
         });


### PR DESCRIPTION
- Injects `<code></code>` from glossary results so they actually show their styling.
- Rearranges glossary results above patps

Fixes #1432
Fixes #731

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/20846414/166156942-b482bd6c-83e6-4fe2-92ed-3a1b797ed04f.png">
