### PR TITLE
markdown.css: preserve whitespace in inline code blocks

### DIFF
--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -73,6 +73,10 @@
   @apply text-base leading-relaxed;
 }
 
+.markdown.technical p code {
+  white-space: pre-wrap;
+}
+
 .markdown.technical li {
   @apply py-2 ml-6 text-base;
 }


### PR DESCRIPTION
Going surgical with the CSS here — does appear to remedy the issue as described in original ticket.

<img width="892" alt="image" src="https://user-images.githubusercontent.com/20846414/166346145-217e4905-50c4-4d74-99d6-44004e2e3ea0.png">

Check the preview deployment and compare, reviewers!

Fixes #1332