### PR TITLE
TableOfContents: smaller fonts

### DIFF
--- a/components/TableOfContents.js
+++ b/components/TableOfContents.js
@@ -55,13 +55,13 @@ const Headings = ({ headings, activeId }) => (
     {headings.map((heading, index) => (
       <li key={heading.id}>
         <a
-          className={index === 0 ? "font-bold" : "font-medium"}
+          className={index === 0 ? "font-bold" : "font-medium text-sm"}
           href={`#${heading.id}`}
         >
           {heading.title}
         </a>
         {heading.items.length > 0 && (
-          <ul className="pl-2">
+          <ul className="pl-2 text-xs">
             {heading.items.map((child) => (
               <li
                 key={child.id}


### PR DESCRIPTION
Fixes #1135 

Title uses regular font size; headers use `text-sm`, subheaders use `text-xs`. Lets us fit more on a line but also gives a better sense of content hierarchy beyond just colours.

Compare (before / after):

<img width="217" alt="Screen Shot 2022-05-02 at 5 32 38 PM" src="https://user-images.githubusercontent.com/20846414/166353410-e541cc27-e267-4714-9814-ca43add97048.png">
<img width="262" alt="Screen Shot 2022-05-02 at 5 32 22 PM" src="https://user-images.githubusercontent.com/20846414/166353680-11685311-7ada-4845-915b-0b8ba773013f.png">

See `docs/arvo/tutorials/move-trace` on the deploy preview for example and the original issue has current links for comparison.