### PR TITLE
docs: add "edit page on github" link

### DIFF
--- a/components/ContentArea.js
+++ b/components/ContentArea.js
@@ -44,7 +44,7 @@ export default function ContentArea(props) {
     <div className="w-full min-w-0 flex flex-col items-center">
       <div
         ref={scrollBox}
-        className="px-4 md:px-12 lg:px-24 pb-24 pt-8 md:pt-10 lg:pt-16 flex flex-col w-full max-w-screen-xl max-h-screen h-screen overflow-y-scroll"
+        className="px-4 md:px-12 lg:px-24 pt-8 md:pt-10 lg:pt-16 flex flex-col w-full max-w-screen-xl max-h-screen h-screen overflow-y-scroll"
       >
         <div className="flex justify-between w-full items-center shrink-0">
           <div className="type-ui text-wall-500">{props.breadcrumbs}</div>
@@ -65,13 +65,13 @@ export default function ContentArea(props) {
             <Section narrow className={""}>
               <h2 className="mb-16 mt-24">{props.title}</h2>
               {props.children}
-              <div className="pb-32" />
+              <div className="pb-24" />
             </Section>
           ) : (
             <div className="min-w-0">
               <h2 className="mb-16 mt-24">{props.title}</h2>
               {props.children}
-              <div className="pb-32" />
+              <div className="pb-24" />
             </div>
           )}
           <TableOfContents

--- a/pages/docs/[[...slug]].js
+++ b/pages/docs/[[...slug]].js
@@ -121,6 +121,7 @@ export default function DocsLayout({
     "text-wall-600": !isSelected,
   });
   const rootClasses = "pl-0 text-base hover:text-green-400";
+
   return (
     <>
       <Head>
@@ -176,6 +177,15 @@ export default function DocsLayout({
               />
             )}
           </div>
+          <a
+            className="font-semibold rounded-xl block p-2 text-center bg-wall-100 text-black mt-8"
+            target="_blank"
+            href={`https://github.com/urbit/urbit.org/blob/master/content/docs/${
+              params.slug?.join("/") || "_index"
+            }.md`}
+          >
+            Edit this page on GitHub
+          </a>
         </ContentArea>
       </div>
     </>

--- a/pages/docs/[[...slug]].js
+++ b/pages/docs/[[...slug]].js
@@ -178,7 +178,7 @@ export default function DocsLayout({
             )}
           </div>
           <a
-            className="font-semibold rounded-xl block p-2 text-center bg-wall-100 text-black mt-8"
+            className="font-semibold rounded-xl block p-2 text-wall-400 hover:text-green-400 mt-16"
             target="_blank"
             href={`https://github.com/urbit/urbit.org/blob/master/content/docs/${
               params.slug?.join("/") || "_index"


### PR DESCRIPTION
Fixes #790

Current implementation has it at the bottom, but it seems too loud. Where should this go and how should it be presented?

<img width="935" alt="image" src="https://user-images.githubusercontent.com/20846414/166390497-a0dee155-06a0-40b1-92db-a9e65904f685.png">
