### PR TITLE
pages, components: use passHref on Link component

### DIFF
--- a/components/Contact.js
+++ b/components/Contact.js
@@ -29,7 +29,7 @@ export default function Contact({ emphasize }) {
       </h4>
       <h4 className="mt-6 text-wall-500 flex-wrap">
         Boot Urbit and join{" "}
-        <Link href={`/groups/${contact.urbitCommunity}`}>
+        <Link href={`/groups/${contact.urbitCommunity}`} passHref>
           <a className={linkText}>Urbit Community</a>
         </Link>
       </h4>

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -10,25 +10,17 @@ export default function Footer() {
         <Section short className="flex flex-row flex-wrap">
           <div className="w-1/2 md:w-1/3 flex flex-col shrink">
             <h4 className="mt-16 mb-8">Use Urbit</h4>
-            <Link href="/getting-started">
-              <div>
-                <a className="type-bold text-wall-500">Getting Started</a>
-              </div>
+            <Link href="/getting-started" passHref>
+              <a className="type-bold text-wall-500">Getting Started</a>
             </Link>
-            <Link href="/using">
-              <div>
-                <a className="type-bold text-wall-500">User's Manual</a>
-              </div>
+            <Link href="/using" passHref>
+              <a className="type-bold text-wall-500">User's Manual</a>
             </Link>
-            <Link href="https://github.com/urbit/port/releases">
-              <div>
-                <a className="type-bold text-wall-500">Urbit Client</a>
-              </div>
+            <Link href="https://github.com/urbit/port/releases" passHref>
+              <a className="type-bold text-wall-500">Urbit Client</a>
             </Link>
-            <Link href="https://github.com/urbit/urbit/releases">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">Urbit Binaries</a>
-              </div>
+            <Link href="https://github.com/urbit/urbit/releases" passHref>
+              <a className="type-bold text-wall-500">Urbit Binaries</a>
             </Link>
             {
               //   <Link href="">
@@ -37,141 +29,105 @@ export default function Footer() {
               //   </div>
               // </Link>
             }
-            <Link href="/getting-started/planet/#hosting-providers">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">
-                  Hosting Providers
-                </a>
-              </div>
+            <Link href="/getting-started/planet/#hosting-providers" passHref>
+              <a className="type-bold text-wall-500">Hosting Providers</a>
             </Link>
           </div>
           <div className="w-1/2 md:w-1/3 flex flex-col shrink">
             <h4 className="mt-16 mb-8">About</h4>
-            <Link href="/understanding-urbit">
-              <div>
-                <a className="type-bold text-wall-500">What's Urbit?</a>
-              </div>
+            <Link href="/understanding-urbit" passHref>
+              <a className="type-bold text-wall-500">What's Urbit?</a>
             </Link>
-            <Link href="/understanding-urbit/urbit-id">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">Urbit ID</a>
-              </div>
+            <Link href="/understanding-urbit/urbit-id" passHref>
+              <a className="type-bold text-wall-500">Urbit ID</a>
             </Link>
-            <Link href="/understanding-urbit/urbit-os">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">Urbit OS</a>
-              </div>
+            <Link href="/understanding-urbit/urbit-os" passHref>
+              <a className="type-bold text-wall-500">Urbit OS</a>
             </Link>
-            <Link href="/audits">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">Security Audits</a>
-              </div>
+            <Link href="/audits" passHref>
+              <a className="type-bold text-wall-500">Security Audits</a>
             </Link>
-            <Link href="/faq">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">FAQ</a>
-              </div>
+            <Link href="/faq" passHref>
+              <a className="type-bold text-wall-500">FAQ</a>
             </Link>
-            <Link href="https://media.urbit.org/whitepaper.pdf">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">Whitepaper</a>
-              </div>
+            <Link href="https://media.urbit.org/whitepaper.pdf" passHref>
+              <a className="type-bold text-wall-500">Whitepaper</a>
             </Link>
           </div>
           <div className="w-1/2 md:w-1/3 flex flex-col shrink">
             <h4 className="mt-16 mb-8">News</h4>
-            <Link href="/blog">
-              <div>
-                <a className="type-bold text-wall-500">Blog</a>
-              </div>
+            <Link href="/blog" passHref>
+              <a className="type-bold text-wall-500">Blog</a>
             </Link>
-            <Link href="/events">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">Events</a>
-              </div>
+            <Link href="/events" passHref>
+              <a className="type-bold text-wall-500">Events</a>
             </Link>
-            <Link href="/updates">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">Updates</a>
-              </div>
+            <Link href="/updates" passHref>
+              <a className="type-bold text-wall-500">Updates</a>
             </Link>
           </div>
 
           <div className="w-1/2 md:w-1/3 flex flex-col">
             <h4 className="mt-16 mb-8">Develop</h4>
-            <Link href="/docs">
-              <div>
-                <a className="type-bold text-wall-500">Documentation</a>
-              </div>
+            <Link href="/docs" passHref>
+              <a className="type-bold text-wall-500">Documentation</a>
             </Link>
-            <Link href="https://github.com/urbit">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">Github</a>
-              </div>
+            <Link href="https://github.com/urbit" passHref>
+              <a className="type-bold text-wall-500">Github</a>
             </Link>
-            <Link href="https://github.com/urbit/awesome-urbit#http-apis-airlock">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">Airlock APIs</a>
-              </div>
+            <Link
+              href="https://github.com/urbit/awesome-urbit#http-apis-airlock"
+              passHref
+            >
+              <a className="type-bold text-wall-500">Airlock APIs</a>
             </Link>
           </div>
           <div className="w-1/2 md:w-1/3 flex flex-col">
             <h4 className="mt-16 mb-8">Contribute</h4>
-            <Link href="https://github.com/urbit/urbit/issues">
-              <div>
-                <a className="type-bold text-wall-500">Issue Tracker</a>
-              </div>
+            <Link href="https://github.com/urbit/urbit/issues" passHref>
+              <a className="type-bold text-wall-500">Issue Tracker</a>
             </Link>
             <Link href="/grants">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">Urbit Grants</a>
-              </div>
+              <a className="type-bold text-wall-500" passHref>
+                Urbit Grants
+              </a>
             </Link>
           </div>
 
           <div className="w-1/2 md:w-1/3 flex flex-col">
             <h4 className="mt-16 mb-8">Community</h4>
-            <Link href="https://groups.google.com/a/urbit.org/g/dev?pli=1">
-              <div>
-                <a className="type-bold text-wall-500">Dev Mailing List</a>
-              </div>
+            <Link
+              href="https://groups.google.com/a/urbit.org/g/dev?pli=1"
+              passHref
+            >
+              <a className="type-bold text-wall-500">Dev Mailing List</a>
             </Link>
-            <Link href="https://github.com/urbit/azimuth">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">Governance</a>
-              </div>
+            <Link href="https://github.com/urbit/azimuth" passHref>
+              <a className="type-bold text-wall-500">Governance</a>
             </Link>
-            <Link href="https://twitter.com/urbit">
-              <div>
-                <a className="mt-2 type-bold text-wall-500">Twitter</a>
-              </div>
+            <Link href="https://twitter.com/urbit" passHref>
+              <a className="type-bold text-wall-500">Twitter</a>
             </Link>
           </div>
         </Section>
         <Section className="flex flex-col md:flex-row">
           <div className="md:w-1/3">
-            <Link href="/privacy">
-              <div>
-                <a className="type-bold text-wall-500">Privacy Policy</a>
-              </div>
+            <Link href="/privacy" passHref>
+              <a className="type-bold text-wall-500">Privacy Policy</a>
             </Link>
           </div>
           <div className="md:w-1/3">
-            <Link href="/terms-of-service">
-              <div>
-                <a className="type-bold text-wall-500">Terms of Service</a>
-              </div>
+            <Link href="/terms-of-service" passHref>
+              <a className="type-bold text-wall-500">Terms of Service</a>
             </Link>
           </div>
           <div className="md:w-1/3">
-            <div>
-              <a
-                href={"mailto:" + contact.email}
-                className="type-bold text-wall-500"
-              >
-                {contact.email}
-              </a>
-            </div>
+            <a
+              href={"mailto:" + contact.email}
+              className="type-bold text-wall-500"
+            >
+              {contact.email}
+            </a>
           </div>
         </Section>
       </SingleColumn>

--- a/components/GrantPreview.js
+++ b/components/GrantPreview.js
@@ -17,43 +17,45 @@ export default function GrantPreview({ grant }) {
       key={grant.slug}
       className={`mb-4 cursor-pointer bg-wall-100 rounded-lg ${className}`}
     >
-      <Link href={`/grants/${grant.slug}`}>
-        <div className="p-8">
-          <div className="flex items-center mb-4">
-            <h3 className="type-ui" id={grant.slug}>
-              {grant.title}
-            </h3>
-            <div className={`bg-wall-500 text-wall-100 badge-sm ml-2`}>
-              {!isCompleted ? (isOpen ? "Open" : "In Progress") : "Completed"}
+      <Link href={`/grants/${grant.slug}`} passHref>
+        <a>
+          <div className="p-8">
+            <div className="flex items-center mb-4">
+              <h3 className="type-ui" id={grant.slug}>
+                {grant.title}
+              </h3>
+              <div className={`bg-wall-500 text-wall-100 badge-sm ml-2`}>
+                {!isCompleted ? (isOpen ? "Open" : "In Progress") : "Completed"}
+              </div>
             </div>
-          </div>
-          <p className="mb-4">{grant.extra.description}</p>
-          <div className="flex w-full flex-col md:flex-row md:items-center justify-between">
-            <p className="text-wall-500">
-              <strong>Reward: </strong>
-              {grant.extra.reward}
-            </p>
-            <div className="flex items-center flex-wrap md:mt-0 mt-4">
-              {grant.taxonomies.grant_type.map((category) => {
-                const className = classnames({
-                  "bg-blue-400 text-white": category === "Proposal",
-                  "bg-green-400 text-white": category === "Apprenticeship",
-                  "bg-yellow-300": category === "Bounty",
-                });
-                return (
-                  <div className={`${className} badge-sm mr-1 my-1`}>
+            <p className="mb-4">{grant.extra.description}</p>
+            <div className="flex w-full flex-col md:flex-row md:items-center justify-between">
+              <p className="text-wall-500">
+                <strong>Reward: </strong>
+                {grant.extra.reward}
+              </p>
+              <div className="flex items-center flex-wrap md:mt-0 mt-4">
+                {grant.taxonomies.grant_type.map((category) => {
+                  const className = classnames({
+                    "bg-blue-400 text-white": category === "Proposal",
+                    "bg-green-400 text-white": category === "Apprenticeship",
+                    "bg-yellow-300": category === "Bounty",
+                  });
+                  return (
+                    <div className={`${className} badge-sm mr-1 my-1`}>
+                      {category}
+                    </div>
+                  );
+                })}
+                {grant.taxonomies.grant_category.map((category) => (
+                  <div className="bg-wall-500 text-wall-100 badge-sm mr-1 my-1">
                     {category}
                   </div>
-                );
-              })}
-              {grant.taxonomies.grant_category.map((category) => (
-                <div className="bg-wall-500 text-wall-100 badge-sm mr-1 my-1">
-                  {category}
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
           </div>
-        </div>
+        </a>
       </Link>
     </div>
   );

--- a/components/GrantProgramOverview.js
+++ b/components/GrantProgramOverview.js
@@ -39,10 +39,10 @@ export default function GrantProgramOverview({
           <div className="type-ui text-wall-500 mt-4 md:mt-8 lg:mt-10">
             Last Revision: {formatDate(DateTime.fromISO(post.date))}
           </div>
-          <Link href={actionLink}>
-            <button className="button-sm bg-green-400 text-white mt-8">
+          <Link href={actionLink} passHref>
+            <a className="button-sm bg-green-400 text-white mt-8 max-w-fit">
               {actionText}
-            </button>
+            </a>
           </Link>
         </Section>
         <Section narrow short className="markdown">

--- a/components/Header.js
+++ b/components/Header.js
@@ -16,7 +16,7 @@ function ActiveLink({ children, href, className, currentPath }) {
   });
 
   return (
-    <Link href={href}>
+    <Link href={href} passHref>
       <a className={`${className} ${activeClassName}`}>{children}</a>
     </Link>
   );
@@ -50,11 +50,11 @@ export default function Header(props) {
   return (
     <header className="layout px-4 md:px-8 flex justify-between items-center pt-8 md:pt-10 lg:pt-12 pb-10 md:pb-12 lg:pb-24">
       <div>
-        <Link href="/">
+        <Link href="/" passHref>
           <a className="type-ui">Urbit</a>
         </Link>
         {routeDepth > 2 ? (
-          <Link href={`/${firstCrumb}`}>
+          <Link href={`/${firstCrumb}`} passHref>
             <a className="inline md:hidden type-ui text-wall-500 ml-2">
               {capitalize(firstCrumb)}
             </a>
@@ -123,7 +123,7 @@ export default function Header(props) {
         // Small screen header
       }
       <MenuTray isOpen={isOpen} setTray={setTray} search={props.search}>
-        <Link href="/">
+        <Link href="/" passHref>
           <a className="type-ui mb-12">Urbit</a>
         </Link>
         <ActiveLink

--- a/components/PostPreview.js
+++ b/components/PostPreview.js
@@ -28,7 +28,7 @@ export default function PostPreview(props) {
               </div>
             ) : null}
             {props.post.extra.ship ? (
-              <Link href={`/ids/${props.post.extra.ship}`}>
+              <Link href={`/ids/${props.post.extra.ship}`} passHref>
                 <a className="type-sub-bold text-wall-500 font-mono">
                   {props.post.extra.ship}
                 </a>

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -8,7 +8,7 @@ export default function Sidebar(props) {
     <>
       <div className="hidden md:flex flex-col w-96 bg-wall-100 max-h-screen h-screen">
         <header className="flex shrink-0 justify-between items-center pl-6 pt-12 mt-5 pb-8">
-          <Link href="/">
+          <Link href="/" passHref>
             <a className="type-ui text-wall-500">Urbit</a>
           </Link>
         </header>
@@ -20,7 +20,7 @@ export default function Sidebar(props) {
 
       <MenuTray isOpen={isOpen} setTray={setTray} search={props.search}>
         <header className="flex shrink-0 justify-between items-center pb-8">
-          <Link href="/">
+          <Link href="/" passHref>
             <a className="type-ui text-wall-500">Urbit</a>
           </Link>
         </header>

--- a/components/gateway/Gateway404.js
+++ b/components/gateway/Gateway404.js
@@ -15,7 +15,7 @@ const Gateway404 = ({ type }) => {
             item={`No ${type} at this address`}
           />
           <hr className="text-wall-200" />
-          <Link href="/">
+          <Link href="/" passHref>
             <a className="text-xl block font-semibold">Urbit.org</a>
           </Link>
         </Section>

--- a/pages/applications/[[...application]].js
+++ b/pages/applications/[[...application]].js
@@ -106,10 +106,10 @@ const ApplicationPage = ({ data, markdown, params }) => {
               <p className="text-sm font-semibold text-wall-400">
                 Learn how to install an Urbit application
               </p>
-              <Link href="/guides/installing-applications">
-                <button className="button-lg max-w-xs bg-green-400 text-white">
+              <Link href="/guides/installing-applications" passHref>
+                <a className="button-lg max-w-xs bg-green-400 text-white">
                   Installing Urbit applications
-                </button>
+                </a>
               </Link>
             </div>
           </div>
@@ -119,11 +119,11 @@ const ApplicationPage = ({ data, markdown, params }) => {
               Have an application you'd like to share publicly through
               urbit.org?
             </p>
-            <Link href="/applications/submit">
+            <Link href="/applications/submit" passHref>
               <a className="type-ui text-green-400">Submit your application</a>
             </Link>
           </div>
-          <Link href="/">
+          <Link href="/" passHref>
             <a className="text-xl pt-8 block font-semibold">Urbit.org</a>
           </Link>
         </Section>

--- a/pages/applications/submit.js
+++ b/pages/applications/submit.js
@@ -129,7 +129,7 @@ ${form?.description || ""}`
           >
             Submit with GitHub
           </button>
-          <Link href="/">
+          <Link href="/" passHref>
             <a className="text-xl pt-8 block font-semibold">Urbit.org</a>
           </Link>
         </Section>

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -61,7 +61,7 @@ export default function Blog({ posts, search }) {
                         </div>
                       ) : null}
                       {post.extra.ship ? (
-                        <Link href={`/ids/${post.extra.ship}`}>
+                        <Link href={`/ids/${post.extra.ship}`} passHref>
                           <a className="type-sub-bold text-wall-500 font-mono">
                             {post.extra.ship}
                           </a>

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -50,7 +50,7 @@ export default function Post({
               <div className="type-sub-bold mr-2">{post.extra.author}</div>
             ) : null}
             {post.extra.ship ? (
-              <Link href={`/ids/${post.extra.ship}`}>
+              <Link href={`/ids/${post.extra.ship}`} passHref>
                 <a className="type-sub-bold text-wall-500 font-mono">
                   {post.extra.ship}
                 </a>

--- a/pages/docs/[[...slug]].js
+++ b/pages/docs/[[...slug]].js
@@ -86,7 +86,7 @@ const pageTree = (thisLink, tree, level = 0) => {
             });
             return (
               <li>
-                <Link href={href}>
+                <Link href={href} passHref>
                   <a
                     className={`relative inline-block ${pageItemClasses} ${selectedClasses}`}
                   >
@@ -131,7 +131,7 @@ export default function DocsLayout({
         <Sidebar search={search}>
           <ul>
             <li>
-              <Link href="/docs">
+              <Link href="/docs" passHref>
                 <a className={`relative ${selectedClasses} ${rootClasses}`}>
                   Introduction
                 </a>

--- a/pages/getting-started/[[...slug]].js
+++ b/pages/getting-started/[[...slug]].js
@@ -53,7 +53,7 @@ const pageTree = (thisLink, tree, level = 0) => {
 
   return (
     <>
-      <Link href={thisLink}>
+      <Link href={thisLink} passHref>
         <a className={`${pageItemClasses} cursor-pointer`}>{tree.title}</a>
       </Link>
     </>
@@ -80,7 +80,7 @@ export default function UsingLayout({ posts, data, params, search, markdown }) {
         <Sidebar search={search}>
           <ul>
             <li>
-              <Link href="/getting-started">
+              <Link href="/getting-started" passHref>
                 <a className={`relative ${selectedClasses} ${rootClasses}`}>
                   Getting Started
                 </a>

--- a/pages/grants.js
+++ b/pages/grants.js
@@ -179,20 +179,20 @@ export default function Grants({
             </div>
           </div>
           <div className="flex flex-wrap">
-            <Link href="#grant-types">
-              <button className="button-lg bg-blue-400 text-white mr-2">
+            <Link href="#grant-types" passHref>
+              <a className="button-lg bg-blue-400 text-white mr-2">
                 Learn More
-              </button>
+              </a>
             </Link>
-            <Link href="#join-community">
-              <button className="button-lg bg-black text-white mr-2">
+            <Link href="#join-community" passHref>
+              <a className="button-lg bg-black text-white mr-2">
                 Join the Community
-              </button>
+              </a>
             </Link>
-            <Link href="#view-grants">
-              <button className="button-lg bg-wall-400 text-white mr-2">
+            <Link href="#view-grants" passHref>
+              <a className="button-lg bg-wall-400 text-white mr-2">
                 View Grants
-              </button>
+              </a>
             </Link>
           </div>
         </Section>
@@ -217,10 +217,10 @@ export default function Grants({
                 &mdash; we fund all kinds projects, not strictly technical ones,
                 so don't hesitate to pitch your idea!
               </p>
-              <Link href="/grants/proposals">
-                <button className="button-sm bg-blue-400 text-white mb-8">
+              <Link href="/grants/proposals" passHref>
+                <a className="button-sm bg-blue-400 text-white mb-8 max-w-fit">
                   Submit a Proposal
-                </button>
+                </a>
               </Link>
 
               {/* Apprenticeships */}
@@ -230,10 +230,10 @@ export default function Grants({
                 They're one of the best ways to level up your skills, and often
                 lead to full-time jobs.
               </p>
-              <Link href="/grants/apprenticeships">
-                <button className="button-sm bg-green-400 text-white mb-8">
+              <Link href="/grants/apprenticeships" passHref>
+                <a className="button-sm bg-green-400 text-white mb-8 max-w-fit">
                   Become an Apprentice
-                </button>
+                </a>
               </Link>
 
               {/* Bounties */}
@@ -242,15 +242,15 @@ export default function Grants({
                 Urbit Foundation or from trusted partners in our ecosystem.
               </p>
               <div className="flex flex-wrap">
-                <Link href="/grants/bounties#post-a-bounty">
-                  <button className="button-sm bg-yellow-300 text-black mr-2">
+                <Link href="/grants/bounties#post-a-bounty" passHref>
+                  <a className="button-sm bg-yellow-300 text-black mr-2 max-w-fit">
                     Post a Bounty
-                  </button>
+                  </a>
                 </Link>
-                <Link href="/grants/bounties">
-                  <button className="button-sm bg-wall-400 text-white">
+                <Link href="/grants/bounties" passHref>
+                  <a className="button-sm bg-wall-400 text-white max-w-fit">
                     Learn more
-                  </button>
+                  </a>
                 </Link>
               </div>
             </div>

--- a/pages/grants/[slug].js
+++ b/pages/grants/[slug].js
@@ -44,7 +44,7 @@ export default function Grant({ post, markdown, search }) {
             </div>
           ) : null}
           {post.extra.ship ? (
-            <Link href={`/ids/${post.extra.ship}`}>
+            <Link href={`/ids/${post.extra.ship}`} passHref>
               <a className="type-sub-bold text-wall-500 font-mono">
                 {post.extra.ship}
               </a>

--- a/pages/groups/[[...group]].js
+++ b/pages/groups/[[...group]].js
@@ -101,21 +101,21 @@ const GroupPage = ({ data, markdown, params }) => {
               <p className="text-sm font-semibold text-wall-400">
                 Get on the network and join this group.
               </p>
-              <Link href="/guides/joining-groups">
-                <button className="button-lg max-w-xs bg-green-400 text-white">
+              <Link href="/guides/joining-groups" passHref>
+                <a className="button-lg max-w-xs bg-green-400 text-white">
                   How to join a group
-                </button>
+                </a>
               </Link>
             </div>
           </div>
           <hr className="text-wall-200" />
           <div className="flex flex-col space-y-1">
             <p>Have a group you'd like to share publicly through urbit.org?</p>
-            <Link href="/groups/submit">
+            <Link href="/groups/submit" passHref>
               <a className="type-ui text-green-400">Submit your group</a>
             </Link>
           </div>
-          <Link href="/">
+          <Link href="/" passHref>
             <a className="text-xl pt-8 block font-semibold">Urbit.org</a>
           </Link>
         </Section>

--- a/pages/groups/submit.js
+++ b/pages/groups/submit.js
@@ -50,7 +50,7 @@ ${form?.description || ""}`
             </p>
             <p>
               Then, to validate that you operate this group, send a DM to{" "}
-              <Link href="/ids/~haddef-sigwen">
+              <Link href="/ids/~haddef-sigwen" passHref>
                 <a>~haddef-sigwen</a>
               </Link>{" "}
               from your group host <code>@p</code> with a link to the pull
@@ -138,7 +138,7 @@ ${form?.description || ""}`
           >
             Submit with GitHub
           </button>
-          <Link href="/">
+          <Link href="/" passHref>
             <a className="text-xl pt-8 block font-semibold">Urbit.org</a>
           </Link>
         </Section>

--- a/pages/guides/[slug].js
+++ b/pages/guides/[slug].js
@@ -31,7 +31,7 @@ export default function GuidePage({ post, markdown }) {
           <article
             dangerouslySetInnerHTML={{ __html: decode(markdown) }}
           ></article>
-          <Link href="/">
+          <Link href="/" passHref>
             <a className="text-xl pt-12 block font-semibold">Urbit.org</a>
           </Link>
         </Section>

--- a/pages/ids/[id].js
+++ b/pages/ids/[id].js
@@ -154,13 +154,13 @@ const IdPage = ({ data, markdown, applications, groups, network, params }) => {
           <hr className="text-wall-200" />
           <div className="flex flex-col space-y-1">
             <p>Have an Urbit ID?</p>
-            <Link href="/ids/submit">
+            <Link href="/ids/submit" passHref>
               <a className="type-ui text-green-400">
                 Claim and customize your Urbit ID page
               </a>
             </Link>
           </div>
-          <Link href="/">
+          <Link href="/" passHref>
             <a className="text-xl pt-8 block font-semibold">Urbit.org</a>
           </Link>
         </Section>

--- a/pages/ids/submit.js
+++ b/pages/ids/submit.js
@@ -54,7 +54,7 @@ ${form?.description || ""}`
             </p>
             <p>
               Then, to validate that you operate this group, send a DM to{" "}
-              <Link href="/ids/~haddef-sigwen">
+              <Link href="/ids/~haddef-sigwen" passHref>
                 <a>~haddef-sigwen</a>
               </Link>{" "}
               from your group host <code>@p</code> with a link to the pull
@@ -156,7 +156,7 @@ ${form?.description || ""}`
           >
             Submit with GitHub
           </button>
-          <Link href="/">
+          <Link href="/" passHref>
             <a className="text-xl pt-8 block font-semibold">Urbit.org</a>
           </Link>
         </Section>

--- a/pages/index.js
+++ b/pages/index.js
@@ -169,12 +169,12 @@ export default function Home({ posts, events, openGrantsCount, search }) {
               real ownership and authority over the network.
             </p>
             <div className="flex flex-wrap">
-              <Link href="/grants">
+              <Link href="/grants" passHref>
                 <a className="button-lg bg-blue-400 text-white mr-2 mb-8">
                   Learn More
                 </a>
               </Link>
-              <Link href="/grants#view-grants">
+              <Link href="/grants#view-grants" passHref>
                 <a className="button-lg bg-green-400 text-white mr-2 mb-8">
                   View Grants
                 </a>
@@ -200,7 +200,7 @@ export default function Home({ posts, events, openGrantsCount, search }) {
             </p>
             <p className="pb-12">
               The entire OS is a{" "}
-              <Link href="https://urbit.org/docs/nock/definition/">
+              <Link href="https://urbit.org/docs/nock/definition/" passHref>
                 <a>single pure function</a>
               </Link>{" "}
               that provides application developers with strong guarantees:
@@ -209,19 +209,22 @@ export default function Home({ posts, events, openGrantsCount, search }) {
             </p>
             <p className="pb-12">
               You can get started learning how to{" "}
-              <Link href="https://urbit.org/docs/development/develop/">
+              <Link href="https://urbit.org/docs/development/develop/" passHref>
                 <a>contribute to the project</a>
               </Link>
               , or view a variety of{" "}
-              <Link href="https://github.com/urbit/awesome-urbit#http-apis-airlock">
+              <Link
+                href="https://github.com/urbit/awesome-urbit#http-apis-airlock"
+                passHref
+              >
                 <a>libraries</a>
               </Link>{" "}
               for building on Urbit using the languages you already know.
             </p>
-            <Link href="/docs">
-              <button className="button-lg type-ui text-white bg-wall-600">
+            <Link href="/docs" passHref>
+              <a className="button-lg type-ui text-white bg-wall-600 max-w-fit">
                 Read the Developer Docs
-              </button>
+              </a>
             </Link>
           </div>
         </Section>
@@ -239,10 +242,10 @@ export default function Home({ posts, events, openGrantsCount, search }) {
             <PostPreview post={posts[1]} key={posts[1].slug} />
           </TwoUp>
 
-          <Link href="/blog">
-            <button className="button-lg type-ui text-white bg-green-400">
+          <Link href="/blog" passHref>
+            <a className="button-lg max-w-fit type-ui text-white bg-green-400">
               See More
-            </button>
+            </a>
           </Link>
         </Section>
 
@@ -259,10 +262,10 @@ export default function Home({ posts, events, openGrantsCount, search }) {
             <EventPreview event={events[1]} key={events[1].slug} />
           </TwoUp>
 
-          <Link href="/events">
-            <button className="button-lg type-ui text-white bg-wall-600">
+          <Link href="/events" passHref>
+            <a className="button-lg max-w-fit type-ui text-white bg-wall-600">
               More Events
-            </button>
+            </a>
           </Link>
         </Section>
 

--- a/pages/media/[slug].js
+++ b/pages/media/[slug].js
@@ -41,7 +41,7 @@ export default function MediaPage({ post, markdown, search }) {
             </div>
           ) : null}
           {post.extra.ship ? (
-            <Link href={`/ids/${post.extra.ship}`}>
+            <Link href={`/ids/${post.extra.ship}`} passHref>
               <a className="type-sub-bold text-wall-500 font-mono">
                 {post.extra.ship}
               </a>

--- a/pages/understanding-urbit/[[...slug]].js
+++ b/pages/understanding-urbit/[[...slug]].js
@@ -58,7 +58,7 @@ const pageTree = (thisLink, tree, level = 0) => {
 
   return (
     <>
-      <Link href={thisLink}>
+      <Link href={thisLink} passHref>
         <a className={`${pageItemClasses} cursor-pointer`}>{tree.title}</a>
       </Link>
     </>
@@ -92,7 +92,7 @@ export default function UnderstandingLayout({
         <Sidebar search={search}>
           <ul>
             <li>
-              <Link href="/understanding-urbit">
+              <Link href="/understanding-urbit" passHref>
                 <a className={`relative ${selectedClasses} ${rootClasses}`}>
                   Introduction
                 </a>

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -47,7 +47,7 @@ export default function Updates({ posts, search }) {
                         <div className="mx-1 text-wall-500">•</div>
                       ) : null}
                       {post?.extra.ship ? (
-                        <Link href={`/ids/${post.extra.ship}`}>
+                        <Link href={`/ids/${post.extra.ship}`} passHref>
                           <a className="type-sub-bold text-wall-500 font-mono">
                             {post.extra.ship}
                           </a>

--- a/pages/updates/[slug].js
+++ b/pages/updates/[slug].js
@@ -48,7 +48,7 @@ export default function Post({
             </div>
           ) : null}
           {post?.extra?.ship ? (
-            <Link href={`/ids/${post.extra.ship}`}>
+            <Link href={`/ids/${post.extra.ship}`} passHref>
               <a className="type-sub-bold text-wall-500 font-mono">
                 {post?.extra?.ship}
               </a>

--- a/pages/using/[[...slug]].js
+++ b/pages/using/[[...slug]].js
@@ -81,7 +81,7 @@ const pageTree = (thisLink, tree, level = 0) => {
             });
             return (
               <li>
-                <Link href={href}>
+                <Link href={href} passHref>
                   <a
                     className={`relative ${pageItemClasses} ${selectedClasses}`}
                   >


### PR DESCRIPTION
Fixes #1225 

As per [next/link docs](https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag):

> If the child of Link is a custom component that wraps an <a> tag, you must add passHref to Link. This is necessary if you’re using libraries like [styled-components](https://styled-components.com/). Without this, the <a> tag will not have the href attribute, which hurts your site's accessibility and might affect SEO.