### PR TITLE
search: loosen glossary search

### DIFF
--- a/components/Search.js
+++ b/components/Search.js
@@ -25,7 +25,9 @@ class Search extends Component {
 
   glossarySearch(query) {
     return glossary.filter((entry) => {
-      return query.toLowerCase() === entry.name || entry.symbol === query;
+      return (
+        entry.name.includes(query.toLowerCase()) || entry.symbol.includes(query)
+      );
     });
   }
 

--- a/lib/glossary.js
+++ b/lib/glossary.js
@@ -891,7 +891,7 @@ export const glossary = [
   },
   {
     name: "terminators",
-    symbol: "--,",
+    symbol: "--",
     usage: "Terminators",
     slug: "/docs/hoon/reference/rune/terminators/",
     desc: "Runes used to terminate expressions.",


### PR DESCRIPTION
Previously we showed exact matches for glossary results. Now it's a search like any other.