### PR TITLE
Markdown: open external links in a new tab

### DIFF
--- a/components/Markdown.js
+++ b/components/Markdown.js
@@ -7,12 +7,12 @@ import normalize from "mdurl/encode";
 import merge from "deepmerge";
 import github from "hast-util-sanitize/lib/github";
 import remarkParse from "remark-parse";
-import remarkRehype, { defaultHandlers } from "remark-rehype";
+import remarkRehype, { defaultHandlers, all } from "remark-rehype";
 import rehypeStringify from "rehype-stringify";
 import rehypeRaw from "rehype-raw";
 
 // img is wrapped in figure so that images can be extra wide in the blog posts
-function Img(h, node) {
+function img(h, node) {
   var props = { src: normalize(node.url), alt: node.alt };
   if (node.title !== null && node.title !== undefined) {
     props.title = node.title;
@@ -31,7 +31,7 @@ function Img(h, node) {
   };
 }
 
-function Link(h, node) {
+function a(h, node) {
   const url = node.url;
 
   if (
@@ -45,7 +45,7 @@ function Link(h, node) {
       properties: {
         href: url,
       },
-      children: node.children,
+      children: all(h, node),
     };
   } else {
     return {
@@ -56,14 +56,18 @@ function Link(h, node) {
         rel: "noopener",
         href: url,
       },
-      children: node.children,
+      children: all(h, node),
     };
   }
 }
 
+const handlers = defaultHandlers;
+handlers.link = a;
+handlers.image = img;
+
 const options = {
   allowDangerousHtml: true,
-  handlers: Object.assign(defaultHandlers, { image: Img, link: Link }),
+  handlers: handlers,
   sanitize: merge(github, {
     // remove user-content from github.json to remark-slug work as expected
     clobberPrefix: "",

--- a/components/Markdown.js
+++ b/components/Markdown.js
@@ -31,9 +31,41 @@ function Img(h, node) {
   };
 }
 
+function Link(h, node) {
+  const url = node.url;
+
+  if (
+    url.includes("https://urbit.org") ||
+    url.startsWith("/") ||
+    url.startsWith("#")
+  ) {
+    return {
+      type: "element",
+      tagName: "a",
+      properties: {
+        href: url,
+      },
+      children: node.children,
+    };
+  } else {
+    return {
+      type: "element",
+      tagName: "a",
+      properties: {
+        target: "_blank",
+        rel: "noopener",
+        href: url,
+      },
+      children: node.children,
+    };
+  }
+}
+
 const options = {
+  allowDangerousHtml: true,
   handlers: {
     image: Img,
+    link: Link,
   },
   sanitize: merge(github, {
     // remove user-content from github.json to remark-slug work as expected
@@ -45,14 +77,14 @@ const options = {
 // Converts markdown strings into markdown HTML/React components
 export default async function Markdown({ post }, disablePlugins) {
   const result = await remark()
-    .use(remarkParse, options)
+    .use(remarkParse)
     .use(remarkprism, {
       plugins: !disablePlugins ? ["show-invisibles"] : [],
     })
     .use(gfm)
     .use(slug)
     .use(heading)
-    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(remarkRehype, options)
     .use(rehypeRaw)
     .use(rehypeStringify)
     .process(post.content);

--- a/components/Markdown.js
+++ b/components/Markdown.js
@@ -7,7 +7,7 @@ import normalize from "mdurl/encode";
 import merge from "deepmerge";
 import github from "hast-util-sanitize/lib/github";
 import remarkParse from "remark-parse";
-import remarkRehype from "remark-rehype";
+import remarkRehype, { defaultHandlers } from "remark-rehype";
 import rehypeStringify from "rehype-stringify";
 import rehypeRaw from "rehype-raw";
 
@@ -63,10 +63,7 @@ function Link(h, node) {
 
 const options = {
   allowDangerousHtml: true,
-  handlers: {
-    image: Img,
-    link: Link,
-  },
+  handlers: Object.assign(defaultHandlers, { image: Img, link: Link }),
   sanitize: merge(github, {
     // remove user-content from github.json to remark-slug work as expected
     clobberPrefix: "",

--- a/content/blog/layer-2-faq.md
+++ b/content/blog/layer-2-faq.md
@@ -45,7 +45,7 @@ you **do not** need ETH to boot Urbit. That Urbit ID is now yours, forever.
 Unsure whether you have been invited to claim a L2 or L1 planet? The quickest
 way to identify a L2 planet is if you used the below flow to claim.
 
-![](/images/planet-l2-claim.gif)
+<img src="/images/planet-l2-claim.gif" style="max-height: 400px; width: auto; margin: 0 auto;"/>
 
 For those with L1 planets, you can avoid future transaction fees by migrating
 your L1 planet to L2. Read the migration instructions


### PR DESCRIPTION
Fixes #725.

Adds a handler to our markdown parser to take links, check if they're relative, and if not, inject `_blank` targets to open in a new tab or window.

While we're at it, this reinstates some old styling — we _lost_ our oversized blog images sometime after release, and this restores them.

@gordoncc can you click around and ensure we're good? And peek at blog posts and tell me how you feel about the oversized images? I always liked them.