### PR TITLE
index: round stars awarded, spread assignee prop

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -281,12 +281,16 @@ export async function getStaticProps() {
   const grants = getAllPosts(["extra", "taxonomies"], "grants", "date");
 
   const grantNumbers = {
-    starsAwarded: grants.reduce(
-      (total, a) =>
-        total + (Number(a?.extra?.reward.replace(/ star[s]?/, "")) || 0),
-      0
+    starsAwarded: Math.floor(
+      grants.reduce(
+        (total, a) =>
+          total + (Number(a?.extra?.reward.replace(/ star[s]?/, "")) || 0),
+        0
+      )
     ),
-    contributors: [...new Set(grants.map((e) => e.extra.assignee))].length,
+    contributors: [
+      ...new Set(...[grants.map((e) => e.extra.assignee.split(","))]),
+    ].length,
     active: grants.filter(
       (e) =>
         !e.extra.canceled &&


### PR DESCRIPTION
- Rounds to nearest integer for stars awarded
- Assignees often look like this:

<img width="465" alt="image" src="https://user-images.githubusercontent.com/20846414/167232005-66b6e603-d8cb-406a-826b-ddd592789dde.png">

We now split up the entries by `,` and treat each person independently, before deduplicating the count.