### PR TITLE
/docs, /understanding-urbit, /using: show current page in sidebars as green

### DIFF
--- a/pages/docs/[[...slug]].js
+++ b/pages/docs/[[...slug]].js
@@ -61,9 +61,9 @@ const pageTree = (thisLink, tree, level = 0) => {
   });
 
   const pageItemClasses = classnames({
-    "pl-4 text-wall-600 text-base hover:text-green-400": level === 0,
-    "pl-8 text-wall-600 text-base hover:text-green-400": level === 1,
-    "pl-12 text-wall-600 text-base hover:text-green-400": level === 2,
+    "pl-4 text-base hover:text-green-400": level === 0,
+    "pl-8 text-base hover:text-green-400": level === 1,
+    "pl-12 text-base hover:text-green-400": level === 2,
   });
 
   return (
@@ -79,12 +79,13 @@ const pageTree = (thisLink, tree, level = 0) => {
             const selectedClasses = classnames({
               dot: isSelected,
               "text-green-400": isSelected,
+              "text-wall-600": !isSelected,
             });
             return (
               <li>
                 <Link href={href} passHref>
                   <a
-                    className={`relative inline-block ${pageItemClasses} ${selectedClasses}`}
+                    className={`relative inline-block ${selectedClasses} ${pageItemClasses} `}
                   >
                     {title}
                   </a>

--- a/pages/understanding-urbit/[[...slug]].js
+++ b/pages/understanding-urbit/[[...slug]].js
@@ -45,11 +45,11 @@ const pageTree = (thisLink, tree, level = 0) => {
   const isThisPage = router.asPath === thisLink;
 
   const pageItemClasses = classnames({
-    "pl-4 text-wall-600 text-base hover:text-green-400": level === 0,
-    "pl-8 text-wall-600 text-base hover:text-green-400": level === 1,
-    "pl-12 text-wall-600 text-base hover:text-green-400": level === 2,
-    "dot relative": isThisPage,
-    "text-green-400": isThisPage,
+    "pl-4 text-base hover:text-green-400": level === 0,
+    "pl-8 text-base hover:text-green-400": level === 1,
+    "pl-12 text-base hover:text-green-400": level === 2,
+    "dot relative text-green-400": isThisPage,
+    "text-wall-600": !isThisPage,
   });
 
   return (

--- a/pages/using/[[...slug]].js
+++ b/pages/using/[[...slug]].js
@@ -60,10 +60,9 @@ const pageTree = (thisLink, tree, level = 0) => {
   });
 
   const pageItemClasses = classnames({
-    "pl-4 text-wall-600 text-base hover:text-green-400": level === 0,
-    "pl-8 text-wall-600 text-base hover:text-green-400": level === 1,
-    "pl-12 text-wall-600 text-base hover:text-green-400": level === 2,
-    dot: isThisPage,
+    "pl-4 text-base hover:text-green-400": level === 0,
+    "pl-8 text-base hover:text-green-400": level === 1,
+    "pl-12 text-base hover:text-green-400": level === 2,
   });
 
   return (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -203,8 +203,8 @@ a:hover {
   border-radius: 99px;
   content: "";
   position: absolute;
-  left: -0.75rem;
-  top: 0.4rem;
+  left: -1rem;
+  top: 33%;
   @apply bg-green-400;
 }
 


### PR DESCRIPTION
Another thing we lost around October — sidebar selected items used to be green. Now they are again.

<img width="312" alt="image" src="https://user-images.githubusercontent.com/20846414/167235835-9263e8ee-7f42-4ab2-8721-6bfa931ab3f9.png">

Also tweaking the dot CSS a little to match the disparate situations it's used in — on Getting Started it's used for header items, which looked a little awkward, and it always sort of looked uncentred.
