### PR TITLE
rss: add fallback for events

### DIFF
--- a/lib/rss.js
+++ b/lib/rss.js
@@ -31,7 +31,7 @@ const generateRSSFeed = () => {
           title: pageData.title,
           descripton: pageData.description || "",
           author: pageData.extra ? pageData.extra.author || "" : "",
-          date: pageData.date,
+          date: pageData.date || pageData.starts,
           link: `https://urbit.org/${leadingDir}/${name}`,
           content: pageContent,
         };


### PR DESCRIPTION
Fixes #1492

When events moved to `starts` and `ends` data structure instead of just a date the rss script was still checking for `date`s. Now it falls back to `starts` if `date` doesn't exist.