### PR TITLE
docs: bump %zuse --> 418 in examples

### DIFF
--- a/content/docs/development/environment.md
+++ b/content/docs/development/environment.md
@@ -201,7 +201,7 @@ compatible. You can copy it across from the `%base` desk, or just run the
 following in the terminal from within the desk directory:
 
 ```sh
-echo "[%zuse 419]" > sys.kelvin
+echo "[%zuse 418]" > sys.kelvin
 ```
 
 The other `mark` files can just be copied across from the `%base` desk.
@@ -271,7 +271,7 @@ and copy the actual files.
 Now you can just add a `sys.kelvin` file:
 
 ```
-echo "[%zuse 419]" > mydesk/sys.kelvin
+echo "[%zuse 418]" > mydesk/sys.kelvin
 ```
 
 And you'll be able to mount the desk with `|commit %mydesk`.

--- a/content/docs/userspace/dist/dist.md
+++ b/content/docs/userspace/dist/dist.md
@@ -37,7 +37,7 @@ For those of you familiar with the old `%glob` and `%file-server` agents, they h
 Desks still contain helper files in `/lib` and `/sur`, generators in `/gen`, marks in `/mar`, threads in `/ted`, tests in `/tests`, and agents in `/app`. In addition, desks now also contain these files:
 
 ```
-/sys/kelvin     ::  Kernel kelvin, e.g. [%zuse 419]
+/sys/kelvin     ::  Kernel kelvin, e.g. [%zuse 418]
 /desk/bill      ::  (optional, read by Kiln) list of agents to run
 /desk/docket-0  ::  (optional, read by Docket) app metadata
 /desk/ship      ::  (optional, read by Docket) ship of original desk publisher, e.g. ~zod

--- a/content/docs/userspace/dist/guide.md
+++ b/content/docs/userspace/dist/guide.md
@@ -44,9 +44,9 @@ lib  mar  sur
 Our desk must include a `sys.kelvin` file which specifies the kernel version it's compatible with. Let's create that:
 
 ```
-[user@host hello]$ echo "[%zuse 419]" > sys.kelvin
+[user@host hello]$ echo "[%zuse 418]" > sys.kelvin
 [user@host hello]$ cat sys.kelvin
-[%zuse 419]
+[%zuse 418]
 ```
 
 ### `desk.ship`

--- a/content/docs/userspace/dist/tools.md
+++ b/content/docs/userspace/dist/tools.md
@@ -46,7 +46,7 @@ None.
 ```
 > +vats
 %base
-  /sys/kelvin:      [%zuse 419]
+  /sys/kelvin:      [%zuse 418]
   base hash:        ~
   %cz hash:         0v6.2nqmu.oqm24.ighl6.n0gp9.s8res.feql1.dl8ap.isli3.jk0hu.acrd2
   app status:       running
@@ -60,7 +60,7 @@ None.
   pending updates:  ~
 ::
 %garden
-  /sys/kelvin:      [%zuse 419]
+  /sys/kelvin:      [%zuse 418]
   base hash:        ~
   %cz hash:         0v1e.2h7hs.elq3g.1sdt7.qfga6.ganga.7p95j.aog44.8p5fe.kpr6v.7ai82
   app status:       running

--- a/content/docs/userspace/full-stack/9-desk.md
+++ b/content/docs/userspace/full-stack/9-desk.md
@@ -43,7 +43,7 @@ We only have one agent to start, so `desk.bill` is very simple:
 Likewise, `sys.kelvin` just contains:
 
 ```
-[%zuse 419]
+[%zuse 418]
 ```
 
 The `desk.docket-0` file is slightly more complicated:


### PR DESCRIPTION
In light of [today's release](https://github.com/urbit/urbit/releases/tag/urbit-v1.9), developers should be encouraged to use kelvin 418 going forward ([see this urbit-dev announcement ](https://groups.google.com/a/urbit.org/g/dev/c/VcU_ocCcdjc)for more details).