### PR TITLE
Add warning when downloading Port for Windows

### DIFF
--- a/content/getting-started/desktop.md
+++ b/content/getting-started/desktop.md
@@ -33,6 +33,8 @@ Or to install `snap` for your distribution, snapcraft provides [installation ins
 
 {% tab label="Windows" %}
 
+**WARNING:** Support for Windows is experimental. For the best experience, we recommend using a [cloud hosting provider](https://urbit.org/getting-started/hosted) rather than running Urbit locally.
+
 To install **Port** on Windows, simply download and open the `.exe` file.
 
 {% button label="Download Port" link="https://github.com/urbit/port/releases/latest/download/PortSetup.exe" color="bg-green-400 text-white" %}


### PR DESCRIPTION
For now, Port on Windows is a degraded experience in terms of performance and stability. We're working to better understand how we can improve, but in the meantime, this PR simply adds a warning to the download page.