### PR TITLE
pages: add apprenticeships page

### DIFF
--- a/pages/apprenticeships.js
+++ b/pages/apprenticeships.js
@@ -1,0 +1,21 @@
+import { getPostBySlug } from "../lib/lib";
+import BasicPage from "../components/BasicPage";
+import { MarkdownParse } from "../components/Markdown";
+
+export default function Post({ post, markdown, search }) {
+  return <BasicPage post={post} markdown={markdown} search={search} />;
+}
+
+export async function getStaticProps() {
+  const post = getPostBySlug(
+    "/apprenticeships",
+    ["title", "slug", "content"],
+    "/"
+  );
+
+  const markdown = JSON.stringify(MarkdownParse({ post }));
+
+  return {
+    props: { post, markdown },
+  };
+}


### PR DESCRIPTION
Fixes #1557 

sidebar: We should probably make a generalised page for this root directory that uses a constant to pull slugs that itself is generated at build-time from the content directory.