### PR TITLE
schema: strip special characters from section ids

### DIFF
--- a/components/schema/Heading.markdoc.js
+++ b/components/schema/Heading.markdoc.js
@@ -11,7 +11,7 @@ function generateID(children, attributes) {
   return bottomChildren
     .filter((child) => typeof child === "string")
     .join(" ")
-    .replace(/[=?!><:;,+#^|$&~"*@\._%/]/g, "")
+    .replace(/[=?!><:;,+#^|$&~"*@\.%/]/g, "")
     .replace(/\s+/g, "-")
     .toLowerCase();
 }

--- a/components/schema/Heading.markdoc.js
+++ b/components/schema/Heading.markdoc.js
@@ -11,7 +11,7 @@ function generateID(children, attributes) {
   return bottomChildren
     .filter((child) => typeof child === "string")
     .join(" ")
-    .replace(/[?]/g, "")
+    .replace(/[?:+#]/g, "")
     .replace(/\s+/g, "-")
     .toLowerCase();
 }

--- a/components/schema/Heading.markdoc.js
+++ b/components/schema/Heading.markdoc.js
@@ -11,7 +11,7 @@ function generateID(children, attributes) {
   return bottomChildren
     .filter((child) => typeof child === "string")
     .join(" ")
-    .replace(/[?:+#]/g, "")
+    .replace(/[=?!><:;,+#^|$&~"*@\._%/]/g, "")
     .replace(/\s+/g, "-")
     .toLowerCase();
 }


### PR DESCRIPTION
Matching our previous build engine's behaviour.

`https://urbit.org/docs/hoon/reference/zuse/2d_6#++ot:dejs:format` -> `https://urbit.org/docs/hoon/reference/zuse/2d_6#otdejsformat`

