### PR TITLE
markdown: wrap links in next/link

### DIFF
--- a/components/Markdown.js
+++ b/components/Markdown.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "next/link";
 import Markdoc, { Ast, Node, Tag, Raw } from "@markdoc/markdoc";
 import { heading } from "./schema/Heading.markdoc";
 import { footnoteRef } from "./schema/footnoteRef.markdoc";
@@ -126,6 +127,14 @@ const superscript = ({ children }) => <sup>{children}</sup>;
 
 const CustomFence = ({ children }) => <pre>{children}</pre>;
 
+const NextLink = ({ href, target, children }) => {
+  return (
+    <Link href={href} passHref>
+      <a target={target}>{children}</a>
+    </Link>
+  );
+};
+
 export function MarkdownParse({ post }) {
   const tokeniser = new Markdoc.Tokenizer({ html: true, linkify: true });
   const tokens = tokeniser.tokenize(post.content);
@@ -150,6 +159,7 @@ export function MarkdownParse({ post }) {
       customFence,
       RenderHtml,
       superscript,
+      NextLink,
     },
   });
 }
@@ -164,6 +174,7 @@ export default function Markdown({ content }) {
       Callout,
       CustomFence,
       RenderHtml,
+      NextLink,
     },
   });
 }

--- a/components/schema/link.markdoc.js
+++ b/components/schema/link.markdoc.js
@@ -15,7 +15,7 @@ function checkIfExternal(attributes) {
 }
 
 export const link = {
-  render: "a",
+  render: "NextLink",
   children: ["strong", "em", "s", "code", "text", "tag"],
   attributes: {
     href: { type: String, required: true },
@@ -28,6 +28,6 @@ export const link = {
 
     const target = checkIfExternal(attributes);
 
-    return new Tag(`a`, { ...attributes, target }, children);
+    return new Tag("NextLink", { ...attributes, target }, children);
   },
 };


### PR DESCRIPTION
By wrapping all links in our Markdown in `next/link` we get the same single-page app loading behaviour on internal links we get in navigation and non-markdown content.