### PR TITLE
simplify install commands

### DIFF
--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -35,11 +35,15 @@ sudo setcap 'cap_net_bind_service=+ep' ./urbit
 {% tab label="Windows" %}
 
 ```winbatch
-curl -L https://urbit.org/install/windows/latest | tar xzk --strip=1
-urbit.exe
+curl -L https://urbit.org/install/windows/latest | tar -xzkf - --strip-components=1 && urbit
 ```
 
-> Windows 10 build 17063 and later includes the familiar `curl` and `tar` command-line tools.
+Windows 10 build 17063 and later includes the familiar `curl` and `tar`
+command-line tools. If you're running an older version of Windows, you may need
+to visit
+[https://github.com/urbit/urbit/releases/latest](https://github.com/urbit/urbit/releases/latest)
+in the browser, download the `windows.zip` file, extract it and execute the
+contained `urbit.exe` file in the command prompt.
 
 {% /tab %}
 

--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -99,10 +99,10 @@ When your comet is finished booting, you will see `~sampel_marzod:dojo>` (Dojo: 
 
 To exit Urbit, use `Ctrl-D` or enter `|exit` into Dojo.
 
-To start your comet up again, run the following (note the lack of `-c` argument):
+To start your comet up again, run the following command:
 
 ```sh
-./urbit mycomet
+./mycomet/.run
 ```
 
 ### Using the web interface

--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -12,11 +12,7 @@ If you're a power user, you can run the Urbit virtual machine directly using the
 {% tab label="MacOS" %}
 
 ```bash
-mkdir ~/urbit
-cd ~/urbit
-curl -JLO https://urbit.org/install/mac/latest
-tar zxvf ./darwin.tgz --strip=1
-~/urbit/urbit
+curl -L https://urbit.org/install/mac/latest | tar xzk --strip=1 && ./urbit
 ```
 
 {% /tab %}
@@ -24,18 +20,14 @@ tar zxvf ./darwin.tgz --strip=1
 {% tab label="Linux" %}
 
 ```shell
-mkdir ~/urbit
-cd ~/urbit
-wget --content-disposition https://urbit.org/install/linux64/latest
-tar zxvf ./linux64.tgz --strip=1
-~/urbit/urbit
+curl -L https://urbit.org/install/linux64/latest | tar xzk --strip=1 && ./urbit
 ```
 
 Linux users may need to run this command in another terminal window to access your Urbit on port 80:
 
 ```shell
 sudo apt-get install libcap2-bin
-sudo setcap 'cap_net_bind_service=+ep' ~/urbit/urbit
+sudo setcap 'cap_net_bind_service=+ep' ./urbit
 ```
 
 {% /tab %}
@@ -43,11 +35,7 @@ sudo setcap 'cap_net_bind_service=+ep' ~/urbit/urbit
 {% tab label="Windows" %}
 
 ```winbatch
-mkdir %USERPROFILE%\urbit
-cd %USERPROFILE%\urbit
-curl -JLO https://urbit.org/install/windows/latest
-tar zxvf .\windows.tgz --strip=1
-%USERPROFILE%\urbit\urbit
+curl -L https://urbit.org/install/windows/latest | tar xzk --strip=1 && urbit.exe
 ```
 
 > Windows 10 build 17063 and later includes the familiar `curl` and `tar` command-line tools.
@@ -92,10 +80,10 @@ A comet name looks like `~dasres-ragnep-lislyt-ribpyl--mosnyx-bisdem-nidful-marz
 
 ---
 
-To boot a comet, go into the command line and run the following command from the `urbit` directory you created during [Urbit installation](#os).
+To boot a comet, go into the command line and run the following command:
 
 ```sh
-~/urbit/urbit -c mycomet
+./urbit -c mycomet
 ```
 
 It may take a while to load the comet (probably only take a few minutes, but it could take longer). This comes along with it being free. When it's done you'll some messages ending like this:
@@ -111,10 +99,10 @@ When your comet is finished booting, you will see `~sampel_marzod:dojo>` (Dojo: 
 
 To exit Urbit, use `Ctrl-D` or enter `|exit` into Dojo.
 
-To start your comet up again, run the following from your `urbit` directory (note the lack of `-c` argument):
+To start your comet up again, run the following (note the lack of `-c` argument):
 
 ```sh
-~/urbit/urbit mycomet
+./urbit mycomet
 ```
 
 ### Using the web interface

--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -122,10 +122,10 @@ At the moment, the most common way to use Urbit is by launching apps like Groups
 
 Urbit comes with a recent release of the Urbit OS, but automatic updates of the `%base` desk (which contains the kernel of the OS) are not enabled by default for Comets. Many comets are used only once and thrown away, so it would be wasteful to update every single comet as soon as it boots. If you plan to use your comet for more than a quick test, you'll probably want to ensure you're running the latest version of the OS.
 
-You can enable updates for your comet by typing `|install (sein:title our now our) %kids, =local %base` into Dojo and pressing Enter.
+You can enable updates for your comet by typing `|ota (sein:title our now our)` into Dojo and pressing Enter.
 
 ```
-> |install (sein:title our now our) %kids, =local %base
+> |ota (sein:title our now our)
 >=
 kiln: activated install into %base from [~samzod %kids]
 kiln: downloading update for %base from [~samzod %kids]

--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -35,7 +35,7 @@ sudo setcap 'cap_net_bind_service=+ep' ./urbit
 {% tab label="Windows" %}
 
 ```winbatch
-curl -L https://urbit.org/install/windows/latest | tar xzk --strip=1 && urbit.exe
+curl.exe -L https://urbit.org/install/windows/latest | tar xzk --strip=1 && ./urbit
 ```
 
 > Windows 10 build 17063 and later includes the familiar `curl` and `tar` command-line tools.

--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -35,7 +35,8 @@ sudo setcap 'cap_net_bind_service=+ep' ./urbit
 {% tab label="Windows" %}
 
 ```winbatch
-curl.exe -L https://urbit.org/install/windows/latest | tar xzk --strip=1 && ./urbit
+curl.exe -L https://urbit.org/install/windows/latest | tar xzk --strip=1
+urbit.exe
 ```
 
 > Windows 10 build 17063 and later includes the familiar `curl` and `tar` command-line tools.

--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -15,6 +15,13 @@ If you're a power user, you can run the Urbit virtual machine directly using the
 curl -L https://urbit.org/install/mac/latest | tar xzk --strip=1 && ./urbit
 ```
 
+Note our Mac build is only compatible with Apple Silicon (M1/M2) via Rosetta.
+If you have such a machine you must run the following command:
+
+```
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license
+```
+
 {% /tab %}
 
 {% tab label="Linux" %}

--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -35,7 +35,7 @@ sudo setcap 'cap_net_bind_service=+ep' ./urbit
 {% tab label="Windows" %}
 
 ```winbatch
-curl.exe -L https://urbit.org/install/windows/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/windows/latest | tar xzk --strip=1
 urbit.exe
 ```
 

--- a/content/getting-started/server.md
+++ b/content/getting-started/server.md
@@ -95,7 +95,8 @@ sudo setcap 'cap_net_bind_service=+ep' ./urbit
 {% tab label="Windows" %}
 
 ```shell
-curl.exe -L https://urbit.org/install/windows/latest | tar xzk --strip=1 && ./urbit
+curl.exe -L https://urbit.org/install/windows/latest | tar xzk --strip=1
+urbit.exe
 ```
 
 > Windows 10 build 17063 and later includes the familiar `curl` and `tar` command-line tools.

--- a/content/getting-started/server.md
+++ b/content/getting-started/server.md
@@ -95,7 +95,7 @@ sudo setcap 'cap_net_bind_service=+ep' ./urbit
 {% tab label="Windows" %}
 
 ```shell
-curl.exe -L https://urbit.org/install/windows/latest | tar xzk --strip=1
+curl -L https://urbit.org/install/windows/latest | tar xzk --strip=1
 urbit.exe
 ```
 

--- a/content/getting-started/server.md
+++ b/content/getting-started/server.md
@@ -75,6 +75,13 @@ Download Urbit with the following commands:
 curl -L https://urbit.org/install/mac/latest | tar xzk --strip=1 && ./urbit
 ```
 
+Note our Mac build is only compatible with Apple Silicon (M1/M2) via Rosetta.
+If you have such a machine you must run the following command:
+
+```
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license
+```
+
 {% /tab %}
 
 {% tab label="Linux" %}

--- a/content/getting-started/server.md
+++ b/content/getting-started/server.md
@@ -72,11 +72,7 @@ Download Urbit with the following commands:
 {% tab label="MacOS" %}
 
 ```bash
-mkdir ~/urbit
-cd ~/urbit
-curl -JLO https://urbit.org/install/mac/latest
-tar zxvf ./darwin.tgz --strip=1
-~/urbit/urbit
+curl -L https://urbit.org/install/mac/latest | tar xzk --strip=1 && ./urbit
 ```
 
 {% /tab %}
@@ -84,30 +80,22 @@ tar zxvf ./darwin.tgz --strip=1
 {% tab label="Linux" %}
 
 ```shell
-mkdir ~/urbit
-cd ~/urbit
-wget --content-disposition https://urbit.org/install/linux64/latest
-tar zxvf ./linux64.tgz --strip=1
-~/urbit/urbit
+curl -L https://urbit.org/install/linux64/latest | tar xzk --strip=1 && ./urbit
 ```
 
 Linux users may need to run this command in another terminal window to access your Urbit on port 80:
 
 ```shell
 sudo apt-get install libcap2-bin
-sudo setcap 'cap_net_bind_service=+ep' ~/urbit/urbit
+sudo setcap 'cap_net_bind_service=+ep' ./urbit
 ```
 
 {% /tab %}
 
 {% tab label="Windows" %}
 
-```winbatch
-mkdir %USERPROFILE%\urbit
-cd %USERPROFILE%\urbit
-curl -JLO https://urbit.org/install/windows/latest
-tar zxvf .\windows.tgz --strip=1
-%USERPROFILE%\urbit\urbit
+```shell
+curl.exe -L https://urbit.org/install/windows/latest | tar xzk --strip=1 && ./urbit
 ```
 
 > Windows 10 build 17063 and later includes the familiar `curl` and `tar` command-line tools.
@@ -116,12 +104,12 @@ tar zxvf .\windows.tgz --strip=1
 
 {% /tabs %}
 
-Next, transfer `your-keyfile.key` to your server using scp or an FTP client, then move it to the `~/urbit` directory you created in the last step.
+Next, transfer `your-keyfile.key` to your server using scp or an FTP client.
 
 Now you can run Urbit for the first time. Run the below command, replacing ames_port with a public port number between 49152 to 65535, sampel-palnet with the name of your planet, and sampel-palnet.key with the name of your keyfile.
 
 ```sh
-./urbit -p ames_port -w sampel-palnet -k ./sampel-palnet.key
+./urbit -p ames_port -w sampel-palnet -k sampel-palnet.key
 ```
 
 Arvo, the Urbit OS, now creates a directory called `sampel-palnet/` and begins booting your planet and establishing connections with the P2P network. When that's finished, you'll see Dojo, the Urbit command line:
@@ -138,14 +126,17 @@ Check out the [cloud hosting guide](/using/running/hosting) for tips on improvin
 
 Shut down your planet by typing Ctrl+D into Dojo.
 
-To boot your planet up again, run the following command, once again replacing `ames_port` with the port you used previously, and now referencing your planet's folder.
+The `urbit` binary will have automatically "docked" with your pier, copying
+itself inside so a separate binary isn't necessary. To boot your planet up
+again, run `./sampel-palnet/.run -p ames_port`, once again replacing
+`ames_port` with the port you used previously.
 
 Your planet's folder, `sampel-palnet/`, is called your pier, and it holds all your data. If you want to migrate your data from one system to another, you must bring your pier.
 
 You should also delete your keyfile from your remote system to prevent yourself from using the same key twice, which will cause communication problems with other planets.
 
 ```sh
-rm ./your-keyfile.key
+rm your-keyfile.key
 ```
 
 ### 5. Log in

--- a/content/getting-started/server.md
+++ b/content/getting-started/server.md
@@ -94,12 +94,16 @@ sudo setcap 'cap_net_bind_service=+ep' ./urbit
 
 {% tab label="Windows" %}
 
-```shell
-curl -L https://urbit.org/install/windows/latest | tar xzk --strip=1
-urbit.exe
+```winbatch
+curl -L https://urbit.org/install/windows/latest | tar -xzkf - --strip-components=1 && urbit
 ```
 
-> Windows 10 build 17063 and later includes the familiar `curl` and `tar` command-line tools.
+Windows 10 build 17063 and later includes the familiar `curl` and `tar`
+command-line tools. If you're running an older version of Windows, you may need
+to visit
+[https://github.com/urbit/urbit/releases/latest](https://github.com/urbit/urbit/releases/latest)
+in the browser, download the `windows.zip` file, extract it and execute the
+contained `urbit.exe` file in the command prompt.
 
 {% /tab %}
 


### PR DESCRIPTION
since there's now only a single binary in the tarball, the install commands can be reduced to a one-liner. `tar` is run with the `-k` option to avoid people accidentally overriding an existing `urbit` directory with a pier inside

Can someone with a windows machine confirm the windows command is correct? @thelifeandtimes you have a windows machine no?

resolves #1718