### PR TITLE
update Windows install instructions to use Powershell/Windows Terminal commands

### DIFF
--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -43,11 +43,11 @@ sudo setcap 'cap_net_bind_service=+ep' ~/urbit/urbit
 {% tab label="Windows" %}
 
 ```winbatch
-mkdir %USERPROFILE%\urbit
-cd %USERPROFILE%\urbit
-curl -JLO https://urbit.org/install/windows/latest
+mkdir ~\urbit
+cd ~\urbit
+curl.exe -JLO https://urbit.org/install/windows/latest
 tar zxvf .\windows.tgz --strip=1
-%USERPROFILE%\urbit\urbit
+~\urbit\urbit
 ```
 
 > Windows 10 build 17063 and later includes the familiar `curl` and `tar` command-line tools.

--- a/content/getting-started/server.md
+++ b/content/getting-started/server.md
@@ -103,11 +103,11 @@ sudo setcap 'cap_net_bind_service=+ep' ~/urbit/urbit
 {% tab label="Windows" %}
 
 ```winbatch
-mkdir %USERPROFILE%\urbit
-cd %USERPROFILE%\urbit
-curl -JLO https://urbit.org/install/windows/latest
+mkdir ~\urbit
+cd ~\urbit
+curl.exe -JLO https://urbit.org/install/windows/latest
 tar zxvf .\windows.tgz --strip=1
-%USERPROFILE%\urbit\urbit
+~\urbit\urbit
 ```
 
 > Windows 10 build 17063 and later includes the familiar `curl` and `tar` command-line tools.


### PR DESCRIPTION
On fresh copies of Windows 10, the instructions for installing Urbit via the command line only work within `cmd` and error from Powershell. They also error in Windows Terminal (the "modern" application that's recommended for Windows 10 onwards) which uses Powershell as its default interpreter.

I'm not primarily a Windows dev, but my understanding is these tools are more popular than the old school command prompt as of late. For example, all of the official Windows developer documentation I've used references Powershell rather than `cmd` in their instructions.

There are two problems with the existing commands:
- [As explained here](https://stackoverflow.com/questions/30807318/running-curl-via-powershell-how-to-construct-arguments), you have to specify `curl.exe` rather than just `curl` to avoid the `Invoke-WebRequest` alias
-  By default, the commands using `%USERPROFILE%` do not reference the home directory, instead it gets interpreted as a literal path name. However, the unix-y `~` notation does work

This PR updates the commands to work from Powershell. If we want to encourage the use of `cmd` instead, we should note that in the install instructions.