### PR TITLE
search: parallelisation

### DIFF
--- a/components/Search.js
+++ b/components/Search.js
@@ -60,76 +60,72 @@ class Search extends Component {
 
   onInputValueChange = debounce(async (query) => {
     if (query.length) {
-      fetch(this.searchEndpoint(query))
+      const search = fetch(this.searchEndpoint(query))
         .then((res) => res.json())
         .then(async (res) => {
-          // Wrap results in an object which will tell React what component to use to render results.
-          const results = res.results.map((item) => ({
+          return res.results.map((item) => ({
             type: "RESULT",
             content: item,
           }));
-
-          const patp = this.patpSearch(query)
-            ? !isNaN(query)
-              ? ob.patp(query)
-              : ob.patp(ob.patp2dec(`~${deSig(query)}`))
-            : null;
-
-          const patpResult = this.patpSearch(query)
-            ? [
-                {
-                  type: "PATP",
-                  content: {
-                    patp: patp,
-                    slug: `/ids/${patp}`,
-                  },
-                },
-              ]
-            : [];
-
-          const glossarySearch = fetch(this.glossarySearch(query))
-            .then((res) => res.json())
-            .then((res) => {
-              return res.results.map((item) => ({
-                type: "GLOSSARY_RESULT",
-                content: item,
-              }));
-            });
-
-          const devSearch = fetch(this.devSearch(query))
-            .then((res) => res.json())
-            .then((res) => {
-              return res.results.map((item) => ({
-                type: "DEV_RESULT",
-                content: item,
-              }));
-            });
-
-          const opsSearch = fetch(this.opsSearch(query))
-            .then((res) => res.json())
-            .then((res) => {
-              return res.results.map((item) => ({
-                type: "OPS_RESULT",
-                content: item,
-              }));
-            });
-
-          const [glossaryResults, devResults, opsResults] = await Promise.all([
-            glossarySearch,
-            devSearch,
-            opsSearch,
-          ]);
-
-          const list = [
-            ...glossaryResults,
-            ...patpResult,
-            ...results,
-            ...devResults,
-            ...opsResults,
-          ];
-
-          this.setState({ results: list });
         });
+
+      const patp = this.patpSearch(query)
+        ? !isNaN(query)
+          ? ob.patp(query)
+          : ob.patp(ob.patp2dec(`~${deSig(query)}`))
+        : null;
+
+      const patpResult = this.patpSearch(query)
+        ? [
+            {
+              type: "PATP",
+              content: {
+                patp: patp,
+                slug: `/ids/${patp}`,
+              },
+            },
+          ]
+        : [];
+
+      const glossarySearch = fetch(this.glossarySearch(query))
+        .then((res) => res.json())
+        .then((res) => {
+          return res.results.map((item) => ({
+            type: "GLOSSARY_RESULT",
+            content: item,
+          }));
+        });
+
+      const devSearch = fetch(this.devSearch(query))
+        .then((res) => res.json())
+        .then((res) => {
+          return res.results.map((item) => ({
+            type: "DEV_RESULT",
+            content: item,
+          }));
+        });
+
+      const opsSearch = fetch(this.opsSearch(query))
+        .then((res) => res.json())
+        .then((res) => {
+          return res.results.map((item) => ({
+            type: "OPS_RESULT",
+            content: item,
+          }));
+        });
+
+      const [results, glossaryResults, devResults, opsResults] =
+        await Promise.all([search, glossarySearch, devSearch, opsSearch]);
+
+      const list = [
+        ...glossaryResults,
+        ...patpResult,
+        ...results,
+        ...devResults,
+        ...opsResults,
+      ];
+
+      this.setState({ results: list });
     } else {
       this.setState({ results: [] });
     }

--- a/components/Search.js
+++ b/components/Search.js
@@ -87,7 +87,7 @@ class Search extends Component {
               ]
             : [];
 
-          const glossaryResults = await fetch(this.glossarySearch(query))
+          const glossarySearch = fetch(this.glossarySearch(query))
             .then((res) => res.json())
             .then((res) => {
               return res.results.map((item) => ({
@@ -96,7 +96,7 @@ class Search extends Component {
               }));
             });
 
-          const devResults = await fetch(this.devSearch(query))
+          const devSearch = fetch(this.devSearch(query))
             .then((res) => res.json())
             .then((res) => {
               return res.results.map((item) => ({
@@ -105,7 +105,7 @@ class Search extends Component {
               }));
             });
 
-          const opsResults = await fetch(this.opsSearch(query))
+          const opsSearch = fetch(this.opsSearch(query))
             .then((res) => res.json())
             .then((res) => {
               return res.results.map((item) => ({
@@ -113,6 +113,12 @@ class Search extends Component {
                 content: item,
               }));
             });
+
+          const [glossaryResults, devResults, opsResults] = await Promise.all([
+            glossarySearch,
+            devSearch,
+            opsSearch,
+          ]);
 
           const list = [
             ...glossaryResults,


### PR DESCRIPTION
- Uses `Promise.all` for our fetches, making all searches run at the same time instead of one after the other
- Pulls all subsequent searches out of the initial promise return — which was making us wait for the initial search to finish

Fixes #1616 

Before/after network graphs — note the waterfall becoming parallel

<img width="1714" alt="Screen Shot 2022-07-06 at 6 52 48 PM" src="https://user-images.githubusercontent.com/20846414/177673393-3837af34-d2e2-4935-80ce-662f9ebdf3ca.png">
<img width="1467" alt="Screen Shot 2022-07-06 at 6 52 02 PM" src="https://user-images.githubusercontent.com/20846414/177673401-d9236e92-cdb4-466e-9174-a7d2a7a689ad.png">
