### PR TITLE
pages: update opengraph cards

### DIFF
--- a/components/BasicPage.js
+++ b/components/BasicPage.js
@@ -22,7 +22,7 @@ export default function BasicPage({ post, markdown, search, index = false }) {
   return (
     <Container>
       <Head>
-        <title>Urbit • {post.title}</title>
+        <title>{post.title}</title>
         {Meta(post)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={search} />

--- a/components/GrantProgramOverview.js
+++ b/components/GrantProgramOverview.js
@@ -32,7 +32,7 @@ export default function GrantProgramOverview({
   return (
     <Container>
       <Head>
-        <title>{title} • Grants • urbit.org</title>
+        <title>{title} • Grants</title>
         {Meta(post)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={search} />

--- a/components/Meta.js
+++ b/components/Meta.js
@@ -1,5 +1,6 @@
 export default function Meta(post, disableImage, large = false) {
   const author = post?.extra?.author || "Urbit";
+  const title = post?.title ? post.title : "";
   const description =
     post?.description || "Urbit is a personal server built from scratch.";
   const image =

--- a/components/Meta.js
+++ b/components/Meta.js
@@ -1,6 +1,5 @@
 export default function Meta(post, disableImage, large = false) {
   const author = post?.extra?.author || "Urbit";
-  const title = post?.title ? `${post.title} - ` : "";
   const description =
     post?.description || "Urbit is a personal server built from scratch.";
   const image =
@@ -17,7 +16,7 @@ export default function Meta(post, disableImage, large = false) {
       />
       <meta name="twitter:site" content="@urbit" key="twitter-site" />
       <meta name="twitter:creator" content="@urbit" key="twitter-creator" />
-      <meta name="og:title" content={`${title}urbit.org`} key="title" />
+      <meta name="og:title" content={title} key="title" />
       <meta name="og:description" content={description} key="description" />
       <meta name="description" content={description} />
       <meta name="author" content={author} key="author" />

--- a/components/Meta.js
+++ b/components/Meta.js
@@ -1,5 +1,5 @@
 export default function Meta(post, disableImage, large = false) {
-  const author = post?.extra?.author || "Urbit";
+  const author = post?.extra?.author || "urbit.org";
   const title = post?.title ? post.title : "";
   const description =
     post?.description || "Urbit is a personal server built from scratch.";

--- a/components/Meta.js
+++ b/components/Meta.js
@@ -1,16 +1,18 @@
-export default function Meta(post, disableImage) {
+export default function Meta(post, disableImage, large = false) {
   const author = post?.extra?.author || "Urbit";
   const title = post?.title ? `${post.title} - ` : "";
   const description =
     post?.description || "Urbit is a personal server built from scratch.";
   const image =
-    post?.extra?.image || post?.image || "https://media.urbit.org/logo/urbit-logo-card.png";
+    post?.extra?.image ||
+    post?.image ||
+    "https://media.urbit.org/logo/urbit-logo-card.png";
   return (
     <>
       <link rel="icon" type="image/png" href="/images/favicon.ico" />
       <meta
         name="twitter:card"
-        content="summary_large_image"
+        content={large ? "summary_large_image" : "summary"}
         key="twitter-card"
       />
       <meta name="twitter:site" content="@urbit" key="twitter-site" />

--- a/components/ecosystem/BasicPage.js
+++ b/components/ecosystem/BasicPage.js
@@ -25,13 +25,17 @@ export default function BasicPage({
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage />;
   }
+  const metaPost = Object.assign({}, post);
+  metaPost.title = `${post.title} - ${section}`;
+  metaPost.description =
+    section === "Podcast" ? `${post.podcast} - ${post.date}` : post.description;
   return (
     <Container>
       <Head>
         <title>
           {post.title} • {section}
         </title>
-        {Meta(post)}
+        {Meta(metaPost)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={search} />
       <SingleColumn>

--- a/components/ecosystem/BasicPage.js
+++ b/components/ecosystem/BasicPage.js
@@ -29,7 +29,7 @@ export default function BasicPage({
     <Container>
       <Head>
         <title>
-          {post.title} • {section} • Urbit
+          {post.title} • {section}
         </title>
         {Meta(post)}
       </Head>
@@ -40,12 +40,10 @@ export default function BasicPage({
           <div className="flex items-center space-x-4">
             <img src={post.image} className="w-36" />
             <div className="flex flex-col pl-2">
-              <h1
-                className={classnames({ "text-3xl": section === "Podcasts" })}
-              >
+              <h1 className={classnames({ "text-3xl": section === "Podcast" })}>
                 {post.title}
               </h1>
-              <p>{section.slice(0, -1)}</p>
+              <p>{section}</p>
             </div>
           </div>
           {/* General purpose metadata bar -- podcast listen button is special-cased URL, flexed at the end of the row */}
@@ -63,7 +61,7 @@ export default function BasicPage({
                   <p className="shrink-0">{post.date}</p>
                 </div>
               )}
-              {post?.URL && section !== "Podcasts" && (
+              {post?.URL && section !== "Podcast" && (
                 <div className="flex flex-col">
                   <p className="font-bold text-wall-400">Website</p>
                   <a
@@ -74,7 +72,7 @@ export default function BasicPage({
                   </a>
                 </div>
               )}
-              {post?.URL && section === "Marketplaces" && (
+              {post?.URL && section === "Urbit Marketplace" && (
                 <div className="flex flex-col">
                   <p className="font-bold text-wall-400">Accepts</p>
                   <p className="text-sm font-semibold font-mono">
@@ -83,7 +81,7 @@ export default function BasicPage({
                 </div>
               )}
             </div>
-            {post?.URL && section === "Podcasts" && (
+            {post?.URL && section === "Podcast" && (
               <a
                 href={post.URL}
                 className="button-lg bg-green-400 text-white cursor-pointer flex space-x-2"

--- a/content/marketplaces/azimuth-shop.md
+++ b/content/marketplaces/azimuth-shop.md
@@ -1,5 +1,6 @@
 +++
 title = "Azimuth Shop"
+description = "Azimuth.shop is a Layer 2 planet marketplace offering planets for sale at extremely competitive prices, accepting ETH for payment."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/marketplaces/azimuthshop.png"
 URL = "https://azimuth.shop/"
 payment = ["ETH"]

--- a/content/marketplaces/lanlyd.md
+++ b/content/marketplaces/lanlyd.md
@@ -1,5 +1,6 @@
 +++
 title = "~lanlyd"
+description = "~lanlyd is a star on the Urbit network."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/marketplaces/lanlyd.png"
 URL = "https://lanlyd.net"
 payment = ["USD"]

--- a/content/marketplaces/mocbel-house.md
+++ b/content/marketplaces/mocbel-house.md
@@ -1,5 +1,6 @@
 +++
 title = "~mocbel house"
+description = "~mocbel house is a layer 2 planet marketplace, accepting BTC, ETH, and ADA."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/marketplaces/mocbelhouse.png"
 URL = "https://mocbel.house/"
 payment = ["ETH","BTC","ADA"]

--- a/content/marketplaces/networked-subject.md
+++ b/content/marketplaces/networked-subject.md
@@ -1,5 +1,6 @@
 +++
 title = "networked subject_"
+description = "Networked Subject is an independent, boutique Urbit star service, planet market and a collection of Urbit information and tutorials."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/marketplaces/subject.network.png"
 URL = "https://subject.network/buy/"
 payment = ["BTC"]

--- a/content/marketplaces/opensea.md
+++ b/content/marketplaces/opensea.md
@@ -1,5 +1,6 @@
 +++
 title = "OpenSea"
+description = "Opensea is the world's largest market for NFTs."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/organizations/opensea.png"
 URL = "https://opensea.io/category/urbit-id"
 payment = ["ETH"]

--- a/content/marketplaces/planet-market.md
+++ b/content/marketplaces/planet-market.md
@@ -1,5 +1,6 @@
 +++
 title = "Planet Market"
+description = "The easiest way to get on Urbit."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/marketplaces/planet.market.png"
 URL = "https://planet.market"
 payment = ["USD"]

--- a/content/marketplaces/urbit-live.md
+++ b/content/marketplaces/urbit-live.md
@@ -1,5 +1,6 @@
 +++
 title = "Urbit.live"
+description = "Urbit.live is Urbit’s largest planet exchange and first network explorer, selling Layer 1 planets and stars for ETH."
 image = "https://urbit.live/static/media/urbit-live-logo-png-400.6ec9a92b.png"
 URL = "https://urbit.live"
 payment = ["ETH"]

--- a/content/marketplaces/urbitex.md
+++ b/content/marketplaces/urbitex.md
@@ -1,5 +1,6 @@
 +++
 title = "Urbitex"
+description = "Urbitex is an automated marketplace and network explorer for Urbit address space."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/marketplaces/urbitex-logo.png"
 URL = "https://urbitex.io"
 payment = ["ETH"]

--- a/content/marketplaces/urbitme.md
+++ b/content/marketplaces/urbitme.md
@@ -1,5 +1,6 @@
 +++
 title = "Urbit.me"
+description = "Urbit.me offers planets with rare sigils."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/marketplaces/urbitme.png"
 URL = "https://urbit.me"
 payment = ["ETH"]

--- a/content/marketplaces/wexpert-systems.md
+++ b/content/marketplaces/wexpert-systems.md
@@ -1,5 +1,6 @@
 +++
 title = "Wexpert.systems"
+description = "Wexpert Systems is an Urbit software and services company which offers full-service premium Urbit hosting on physical servers, with minimal dependence on Big Tech cloud services."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/marketplaces/wexpertsystems.png"
 URL = "https://wexpert.systems"
 payment = ["BTC"]

--- a/content/organizations/dalten.md
+++ b/content/organizations/dalten.md
@@ -1,5 +1,6 @@
 +++
 title = "Dalten Collective"
+description = "Dalten is a distributed fellowship of like minded individuals."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/organizations/dalten.jpg"
 URL = "https://dalten.org"
 ships = ["~dalten", "~magped-magped-rabsef-bicrym", "~mirler-dozzod-talwet"]

--- a/content/organizations/holium.md
+++ b/content/organizations/holium.md
@@ -1,5 +1,6 @@
 +++
 title = "Holium"
+description = "Holium's mission is to enable the networked state."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/organizations/holium.png"
 URL = "https://holium.com"
 ships = ["~livdel-binmun-lomder-librun", "~lomder-librun"]

--- a/content/organizations/mars-review-of-books.md
+++ b/content/organizations/mars-review-of-books.md
@@ -1,5 +1,6 @@
 +++
 title = "The Mars Review of Books"
+description = "The Mars Review of Books is a magazine in print and on Urbit which combines ruthlessly intelligent and fearless sense-making on subjects of global importance with today’s most stylish belletristic writing on contemporary arts and culture."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/organizations/marsreview.jpg"
 URL = "https://store.marsreview.org"
 ships = []

--- a/content/organizations/quartus.md
+++ b/content/organizations/quartus.md
@@ -1,5 +1,6 @@
 +++
 title = "Quartus by Dalten"
+description = "We build software using the novel affordances of Urbit."
 image = "https://freedom-club.sfo2.digitaloceanspaces.com/ab_Quartus-03.jpg"
 URL = "https://www.quartus.co/"
 ships = ["~mister-dozzod-dalten", "~laddys-dozzod-dalten", "~magped-magped-rabsef-bicrym", "~doller-doller-rabsef-bicrym"]

--- a/content/organizations/reciprocal.md
+++ b/content/organizations/reciprocal.md
@@ -1,5 +1,6 @@
 +++
 title = "Reciprocal Ltd."
+description = "Reciprocal Ltd. is an interactive design and development studio."
 image = "https://s3.us-east-1.amazonaws.com/haddefsigwen1/reciprocal/2022.5.20..19.52.50-B137D4AA-DA9E-4B07-98CE-C001C576C7CA_1_201_a.jpeg"
 URL = "https://reciprocal.ltd"
 ships = ["~sitden-sonnet", "~haddef-sigwen"]

--- a/content/organizations/third-earth.md
+++ b/content/organizations/third-earth.md
@@ -1,5 +1,6 @@
 +++
 title = "Third.Earth"
+description = "Third.Earth is an Urbit hosting and development company focused on bridging Web2 capabilities to the Urbit ecosystem."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/organizations/thirdearth.png"
 URL = "https://third.earth"
 ships = ["~botwet"]

--- a/content/organizations/tirrel.md
+++ b/content/organizations/tirrel.md
@@ -1,5 +1,6 @@
 +++
 title = "Tirrel Corporation"
+description = "Tirrel Corporation is an Urbit product studio."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/organizations/Tirrel%20Corp%20Logo.png"
 URL = "https://tirrel.io"
 ships = ["~tirrel"]

--- a/content/organizations/tlon.md
+++ b/content/organizations/tlon.md
@@ -1,5 +1,6 @@
 +++
 title = "Tlon"
+description = "The first developer of Urbit. Their work continues to maintain core infrastructure development in addition to designing products for communities on the network."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/organizations/tlon.png"
 URL = "https://tlon.io"
 ships = ["~mister-dister-dozzod-dozzod", "~lander-dister-dozzod-dozzod"]

--- a/content/organizations/uqbar.md
+++ b/content/organizations/uqbar.md
@@ -1,5 +1,6 @@
 +++
 title = "Uqbar"
+description = "Uqbar is a one-stop coding environment that makes writing and deploying smart contracts simple, efficient, and secure."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/organizations/uqbar.png"
 URL = "https://uqbar.network"
 ships = ["~dister-fabnev-hinmur", "~hocwyn-tipwex"]

--- a/content/organizations/urbit-foundation.md
+++ b/content/organizations/urbit-foundation.md
@@ -1,5 +1,6 @@
 +++
 title = "Urbit Foundation"
+description = "Urbit Foundation is a non-profit organization whose mission is to ensure Urbit's success as a technology."
 image = "https://storage.googleapis.com/media.urbit.org/site/ecosystem/organizations/urbit-foundation.png"
 URL = "https://urbit.org"
 ships = ["~lapdeg"]

--- a/content/overview/_index.md
+++ b/content/overview/_index.md
@@ -1,5 +1,6 @@
 +++
 title = "Introduction"
+description = "We think the internet can’t be saved."
 sort_by = "weight"
 +++
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,3 @@
-// For exporting sigil pngs on Vercel, see https://github.com/Automattic/node-canvas/issues/1779#issuecomment-895885846
-if (
-  process.env.LD_LIBRARY_PATH == null ||
-  !process.env.LD_LIBRARY_PATH.includes(
-    `${process.env.PWD}/node_modules/canvas/build/Release:`
-  )
-) {
-  process.env.LD_LIBRARY_PATH = `${
-    process.env.PWD
-  }/node_modules/canvas/build/Release:${process.env.LD_LIBRARY_PATH || ""}`;
-}
-
 module.exports = {
   reactStrictMode: false,
   // target: 'serverless',

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,15 @@
+// For exporting sigil pngs on Vercel, see https://github.com/Automattic/node-canvas/issues/1779#issuecomment-895885846
+if (
+  process.env.LD_LIBRARY_PATH == null ||
+  !process.env.LD_LIBRARY_PATH.includes(
+    `${process.env.PWD}/node_modules/canvas/build/Release:`
+  )
+) {
+  process.env.LD_LIBRARY_PATH = `${
+    process.env.PWD
+  }/node_modules/canvas/build/Release:${process.env.LD_LIBRARY_PATH || ""}`;
+}
+
 module.exports = {
   reactStrictMode: false,
   // target: 'serverless',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@urbit/markdoc": "^0.1.4",
         "axios": "^0.26.1",
         "buffer": "^6.0.3",
+        "canvas": "^2.9.3",
         "classnames": "^2.3.1",
         "deepmerge": "^4.2.2",
         "downshift": "^6.1.5",
@@ -61,6 +62,25 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz",
+      "integrity": "sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
     },
     "node_modules/@next/env": {
       "version": "12.2.4",
@@ -368,6 +388,11 @@
         "node": ">=14.7.0"
       }
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -397,6 +422,25 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -422,6 +466,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/arg": {
@@ -507,8 +568,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -546,7 +606,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -636,6 +695,20 @@
         }
       ]
     },
+    "node_modules/canvas": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.9.3.tgz",
+      "integrity": "sha512-WOUM7ghii5TV2rbhaZkh1youv/vW1/Canev6Yx6BG2W+1S07w8jKZqKkPnbiPpQEDsnJdN8ouDd7OvQEGXDcUw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.15.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -686,6 +759,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/classnames": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
@@ -728,6 +809,14 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/compute-scroll-into-view": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
@@ -736,8 +825,12 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "node_modules/core-js": {
       "version": "3.24.1",
@@ -772,6 +865,33 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/deep-rename-keys": {
@@ -809,6 +929,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/detective": {
       "version": "5.2.1",
@@ -914,6 +1047,11 @@
       "version": "1.4.211",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
       "integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -1094,6 +1232,22 @@
         "url": "https://www.patreon.com/infusion"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1111,6 +1265,25 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/get-stream": {
       "version": "5.2.0",
@@ -1133,6 +1306,25 @@
       "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -1179,6 +1371,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "node_modules/has-value": {
       "version": "0.3.1",
@@ -1253,6 +1450,18 @@
         "entities": "^3.0.1"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -1288,6 +1497,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -1354,6 +1572,14 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -1509,12 +1735,45 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/luxon": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.0.tgz",
       "integrity": "sha512-IDkEPB80Rb6gCAU+FEib0t4FeJ4uVOuX1CQ9GsvU3O+JAGIgu0J7sf1OarXKaKDygTZIoJyU6YdZzTFRu+YR0A==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/merge-stream": {
@@ -1552,11 +1811,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1569,6 +1838,40 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
+    "node_modules/minipass": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -1577,6 +1880,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multimatch": {
       "version": "4.0.0",
@@ -1593,6 +1901,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -1657,10 +1970,43 @@
         }
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -1688,6 +2034,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
       }
     },
     "node_modules/object-assign": {
@@ -1722,7 +2079,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -1790,6 +2146,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -2199,6 +2563,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2266,6 +2644,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2290,8 +2687,36 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -2329,6 +2754,30 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom-string": {
@@ -2465,6 +2914,22 @@
         "tailwindcss": "^3.0.23"
       }
     },
+    "node_modules/tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2475,6 +2940,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/transformation-matrix": {
       "version": "2.1.1",
@@ -2546,6 +3016,20 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2561,11 +3045,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/xml-js": {
       "version": "1.6.11",
@@ -2603,6 +3094,11 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
@@ -2625,6 +3121,22 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+    },
+    "@mapbox/node-pre-gyp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz",
+      "integrity": "sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==",
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      }
     },
     "@next/env": {
       "version": "12.2.4",
@@ -2783,6 +3295,11 @@
       "resolved": "https://registry.npmjs.org/@urbit/markdoc/-/markdoc-0.1.6.tgz",
       "integrity": "sha512-ocFGlhmleGkX53+kYLzN4UYjyndppEqHKIG2XVKZNkHsLvAeZRy0o13qCE9dfmZli/vSw11cUinOpxuXOBYxSQ=="
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -2803,6 +3320,19 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
     },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2819,6 +3349,20 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
+    "are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
       }
     },
     "arg": {
@@ -2876,8 +3420,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -2898,7 +3441,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2942,6 +3484,16 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
       "integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw=="
     },
+    "canvas": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.9.3.tgz",
+      "integrity": "sha512-WOUM7ghii5TV2rbhaZkh1youv/vW1/Canev6Yx6BG2W+1S07w8jKZqKkPnbiPpQEDsnJdN8ouDd7OvQEGXDcUw==",
+      "requires": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.15.0",
+        "simple-get": "^3.0.3"
+      }
+    },
     "chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -2976,6 +3528,11 @@
           }
         }
       }
+    },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "classnames": {
       "version": "2.3.1",
@@ -3013,6 +3570,11 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+    },
     "compute-scroll-into-view": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
@@ -3021,8 +3583,12 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "core-js": {
       "version": "3.24.1",
@@ -3044,6 +3610,22 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "requires": {
+        "mimic-response": "^2.0.0"
+      }
     },
     "deep-rename-keys": {
       "version": "0.2.1",
@@ -3073,6 +3655,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
     },
     "detective": {
       "version": "5.2.1",
@@ -3150,6 +3742,11 @@
       "version": "1.4.211",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
       "integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A=="
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -3271,6 +3868,19 @@
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
       "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA=="
     },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -3281,6 +3891,22 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "requires": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      }
     },
     "get-stream": {
       "version": "5.2.0",
@@ -3295,6 +3921,19 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA=="
+    },
+    "glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
     },
     "glob-parent": {
       "version": "6.0.2",
@@ -3328,6 +3967,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "has-value": {
       "version": "0.3.1",
@@ -3385,6 +4029,15 @@
         "entities": "^3.0.1"
       }
     },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -3401,6 +4054,15 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
       "version": "2.0.4",
@@ -3455,6 +4117,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
       "version": "4.0.3",
@@ -3573,10 +4240,33 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "luxon": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.0.tgz",
       "integrity": "sha512-IDkEPB80Rb6gCAU+FEib0t4FeJ4uVOuX1CQ9GsvU3O+JAGIgu0J7sf1OarXKaKDygTZIoJyU6YdZzTFRu+YR0A=="
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -3604,11 +4294,15 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -3618,11 +4312,38 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
+    "minipass": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    },
     "mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
       "dev": true
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multimatch": {
       "version": "4.0.0",
@@ -3636,6 +4357,11 @@
         "arrify": "^2.0.1",
         "minimatch": "^3.0.4"
       }
+    },
+    "nan": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
     },
     "nanoid": {
       "version": "3.3.4",
@@ -3668,10 +4394,26 @@
         "use-sync-external-store": "1.2.0"
       }
     },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "node-releases": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+    },
+    "nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "requires": {
+        "abbrev": "1"
+      }
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -3690,6 +4432,17 @@
       "dev": true,
       "requires": {
         "path-key": "^3.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "requires": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
       }
     },
     "object-assign": {
@@ -3715,7 +4468,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -3763,6 +4515,11 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-key": {
       "version": "3.1.1",
@@ -4022,6 +4779,14 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4058,6 +4823,19 @@
         "kind-of": "^6.0.0"
       }
     },
+    "semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4076,8 +4854,22 @@
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -4112,6 +4904,24 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-bom-string": {
@@ -4210,6 +5020,19 @@
         "tailwindcss": "^3.0.23"
       }
     },
+    "tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      }
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4217,6 +5040,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "transformation-matrix": {
       "version": "2.1.1",
@@ -4267,6 +5095,20 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4276,11 +5118,18 @@
         "isexe": "^2.0.0"
       }
     },
+    "wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "requires": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "xml-js": {
       "version": "1.6.11",
@@ -4311,6 +5160,11 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@urbit/markdoc": "^0.1.4",
     "axios": "^0.26.1",
     "buffer": "^6.0.3",
+    "canvas": "^2.9.3",
     "classnames": "^2.3.1",
     "deepmerge": "^4.2.2",
     "downshift": "^6.1.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "getting-started-tree": "node lib/buildPageTree getting-started weight",
     "overview-tree": "node lib/buildPageTree overview weight",
     "cache-posts": "node lib/cache.js",
-    "rss": "node lib/rss.js"
+    "rss": "node lib/rss.js",
+    "vercel-build": "yum install libuuid-devel libmount-devel && cp /lib64/{libuuid,libmount,libblkid}.so.1 node_modules/canvas/build/Release/ && npm run build"
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",

--- a/pages/api/sigil.js
+++ b/pages/api/sigil.js
@@ -1,0 +1,60 @@
+const { sigil, stringRenderer } = require("@tlon/sigil-js");
+const { createCanvas, loadImage, Image } = require("canvas");
+
+const foregroundFromBackground = (background) => {
+  const rgb = {
+    r: parseInt(background.slice(1, 3), 16),
+    g: parseInt(background.slice(3, 5), 16),
+    b: parseInt(background.slice(5, 7), 16),
+  };
+  const brightness = (299 * rgb.r + 587 * rgb.g + 114 * rgb.b) / 1000;
+  const whiteBrightness = 255;
+
+  return whiteBrightness - brightness < 50 ? "black" : "white";
+};
+
+const Sigil = ({ patp, size, color = "#24201E", icon }) => {
+  if (patp.length > 14) {
+    return <div />;
+  }
+  const foreground = foregroundFromBackground(color);
+  return (
+    <div
+      className={icon ? "p-1" : ""}
+      style={{ backgroundColor: icon ? color || "black" : "transparent" }}
+    >
+      {sigil({
+        patp: patp,
+        renderer: stringRenderer,
+        size: icon ? size / 2 : size,
+        colors: [color, foreground],
+        icon: icon || false,
+      })}
+    </div>
+  );
+};
+
+export default (req, res) => {
+  const foreground = foregroundFromBackground(
+    `#${req.query.color || "24201E"}`
+  );
+  const svg = sigil({
+    patp: req.query.patp,
+    renderer: stringRenderer,
+    size: 1024,
+    colors: [`#${req.query.color || "24201E"}`, foreground],
+    icon: false,
+  });
+  const svgDataString = "data:image/svg+xml," + svg;
+  const canvas = createCanvas(1024, 1024);
+  const ctx = canvas.getContext("2d");
+  const canvasImage = new Image();
+  canvasImage.src = svgDataString;
+  ctx.drawImage(canvasImage, 0, 0);
+  const buffer = canvas.toBuffer();
+  res.writeHead(200, {
+    "Content-Type": "image/png",
+    "Content-Length": buffer.length,
+  });
+  res.end(buffer, "binary");
+};

--- a/pages/applications/[[...application]].js
+++ b/pages/applications/[[...application]].js
@@ -24,13 +24,6 @@ const ApplicationPage = ({ data, markdown, organisation, search, params }) => {
   if (!ob.isValidPatp(application[0])) {
     return <Gateway404 type="application" />;
   }
-  const reqParams = [
-    data?.bgColor ? `color=${encodeURIComponent(data?.bgColor)}` : "",
-    data?.image ? `images=${encodeURIComponent(data?.image)}` : "",
-  ].filter((e) => e !== "");
-  const image = `https://urbit-id-og-cards-78ieodof2-urbit.vercel.app/${
-    data.title
-  }.png?${reqParams.join("&")}`;
 
   let devLink;
 
@@ -60,16 +53,12 @@ const ApplicationPage = ({ data, markdown, organisation, search, params }) => {
   return (
     <Container>
       <Head>
-        <title>{data.title} • Applications • urbit.org</title>
+        <title>{data.title} • Urbit Application</title>
         <link rel="icon" type="image/png" href="/images/favicon.ico" />
-        <meta
-          name="twitter:card"
-          content="summary_large_image"
-          key="twitter-card"
-        />
+        <meta name="twitter:card" content="summary" key="twitter-card" />
         <meta
           name="og:title"
-          content={`${data.title} • Applications • urbit.org`}
+          content={`${data.title} • Urbit Application`}
           key="title"
         />
         <meta
@@ -80,7 +69,7 @@ const ApplicationPage = ({ data, markdown, organisation, search, params }) => {
           }
           key="description"
         />
-        <meta property="twitter:image" content={image} key="image" />
+        <meta property="twitter:image" content={data.image} key="image" />
       </Head>
       <IntraNav ourSite="https://urbit.org" search={search} />
       <SingleColumn>

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -21,7 +21,6 @@ import {
 } from "@urbit/foundation-design-system";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
-import Contact from "../../components/Contact";
 import PostPreview from "../../components/PostPreview";
 import TwoUp from "../../components/TwoUp";
 
@@ -41,7 +40,7 @@ export default function Post({
     <Container>
       <Head>
         <title>{post.title} • Blog • urbit.org</title>
-        {Meta(post)}
+        {Meta(post, false, true)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={search} />
       <SingleColumn>

--- a/pages/community/[[...slug]].js
+++ b/pages/community/[[...slug]].js
@@ -62,7 +62,7 @@ export default function UsingLayout({ posts, data, markdown, params, search }) {
   return (
     <>
       <Head>
-        <title>{data.title} • Community • urbit.org</title>
+        <title>{data.title} • Community</title>
         {Meta(data)}
       </Head>
       <div className="flex h-screen min-h-screen w-screen sidebar">

--- a/pages/ecosystem/index.js
+++ b/pages/ecosystem/index.js
@@ -67,7 +67,7 @@ export default function Ecosystem({
   return (
     <Container>
       <Head>
-        <title>{title} • Urbit</title>
+        <title>{title}</title>
         {Meta(data)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={search} />

--- a/pages/ecosystem/spotlight/[slug].js
+++ b/pages/ecosystem/spotlight/[slug].js
@@ -24,7 +24,7 @@ export default function BasicPage({ post, markdown, search, index = false }) {
   return (
     <Container>
       <Head>
-        <title>Urbit • {post.title}</title>
+        <title>Ecosystem Spotlight - {post.title}</title>
         {Meta(post)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={search} />

--- a/pages/events/[slug].js
+++ b/pages/events/[slug].js
@@ -49,7 +49,7 @@ export default function Event({
     <Container>
       <Head>
         <title>{event.title} • Events • urbit.org</title>
-        {Meta(event)}
+        {Meta(event, false, true)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={search} />
       <SingleColumn>

--- a/pages/getting-started/[[...slug]].js
+++ b/pages/getting-started/[[...slug]].js
@@ -42,7 +42,7 @@ export default function UsingLayout({ posts, data, params, search, markdown }) {
   return (
     <>
       <Head>
-        <title>{data.title} • Getting Started • urbit.org</title>
+        <title>{data.title} • Getting Started</title>
         {Meta(data)}
       </Head>
       <div className="flex h-screen min-h-screen w-screen sidebar">

--- a/pages/grants/[slug].js
+++ b/pages/grants/[slug].js
@@ -42,12 +42,14 @@ export default function Grant({ post, markdown, search }) {
     ) : (
       mentor
     );
+  const metaPost = Object.assign({}, post);
+  metaPost.title = `${post.title} - Grant`;
 
   return (
     <Container>
       <Head>
-        <title>{post.title} • Grant</title>
-        {Meta(post)}
+        <title>{post.title} - Grant</title>
+        {Meta(metaPost)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={search} />
       <SingleColumn>

--- a/pages/grants/[slug].js
+++ b/pages/grants/[slug].js
@@ -46,7 +46,7 @@ export default function Grant({ post, markdown, search }) {
   return (
     <Container>
       <Head>
-        <title>{post.title} • Grants • urbit.org</title>
+        <title>{post.title} • Grant</title>
         {Meta(post)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={search} />

--- a/pages/groups/[[...group]].js
+++ b/pages/groups/[[...group]].js
@@ -24,33 +24,15 @@ const GroupPage = ({ data, markdown, params, search }) => {
     return <Gateway404 type="group" />;
   }
 
-  const color = data?.tile && data?.tile.startsWith("#");
-  const reqParams = [
-    color ? `color=${encodeURIComponent(data.tile)}` : "",
-    !color
-      ? `images=${encodeURIComponent(
-          data?.tile ||
-            "https://media.urbit.org/public-links/placeholder-image.png"
-        )}`
-      : "",
-  ].filter((e) => e !== "");
-  const image = `https://urbit-id-og-cards-667veow91-urbit.vercel.app/${
-    data.title
-  }.png?${reqParams.join("&")}`;
-
   return (
     <Container>
       <Head>
-        <title>{data.title} • Groups • urbit.org</title>
+        <title>{data.title} • Urbit Group</title>
         <link rel="icon" type="image/png" href="/images/favicon.ico" />
-        <meta
-          name="twitter:card"
-          content="summary_large_image"
-          key="twitter-card"
-        />
+        <meta name="twitter:card" content="summary" key="twitter-card" />
         <meta
           name="og:title"
-          content={`${data.title} • Groups • urbit.org`}
+          content={`${data.title} • Urbit Group`}
           key="title"
         />
         <meta
@@ -60,7 +42,7 @@ const GroupPage = ({ data, markdown, params, search }) => {
           }
           key="description"
         />
-        <meta property="twitter:image" content={image} key="image" />
+        <meta property="twitter:image" content={data.tile} key="image" />
       </Head>
       <SingleColumn>
         <Header search={search} />

--- a/pages/groups/[[...group]].js
+++ b/pages/groups/[[...group]].js
@@ -27,12 +27,12 @@ const GroupPage = ({ data, markdown, params, search }) => {
   return (
     <Container>
       <Head>
-        <title>{data.title} • Urbit Group</title>
+        <title>{data.title} - Urbit Group</title>
         <link rel="icon" type="image/png" href="/images/favicon.ico" />
         <meta name="twitter:card" content="summary" key="twitter-card" />
         <meta
           name="og:title"
-          content={`${data.title} • Urbit Group`}
+          content={`${data.title} - Urbit Group`}
           key="title"
         />
         <meta

--- a/pages/ids/[id].js
+++ b/pages/ids/[id].js
@@ -55,7 +55,7 @@ const IdPage = ({ data, markdown, applications, groups, network, params }) => {
           content={
             data?.image ||
             `https://urbit.org/api/sigil?patp=${id}&color=${
-              data?.bgColor || "24201E"
+              data?.bgColor?.slice(1) || "24201E"
             }`
           }
           key="image"

--- a/pages/ids/[id].js
+++ b/pages/ids/[id].js
@@ -54,7 +54,9 @@ const IdPage = ({ data, markdown, applications, groups, network, params }) => {
           property="twitter:image"
           content={
             data?.image ||
-            `/api/sigil?patp=${id}&color=${data?.bgColor || "24201E"}`
+            `https://urbit-org-git-mp-og-cards-urbit.vercel.app/api/sigil?patp=${id}&color=${
+              data?.bgColor || "24201E"
+            }`
           }
           key="image"
         />

--- a/pages/ids/[id].js
+++ b/pages/ids/[id].js
@@ -54,7 +54,7 @@ const IdPage = ({ data, markdown, applications, groups, network, params }) => {
           property="twitter:image"
           content={
             data?.image ||
-            `https://urbit-org-git-mp-og-cards-urbit.vercel.app/api/sigil?patp=${id}&color=${
+            `https://urbit.org/api/sigil?patp=${id}&color=${
               data?.bgColor || "24201E"
             }`
           }

--- a/pages/ids/[id].js
+++ b/pages/ids/[id].js
@@ -24,15 +24,6 @@ const IdPage = ({ data, markdown, applications, groups, network, params }) => {
     return <Gateway404 type="ID" />;
   }
 
-  const reqParams = [
-    data?.bgColor ? `color=${encodeURIComponent(data?.bgColor)}` : "",
-    data?.nickname ? `nickname=${encodeURIComponent(data?.nickname)}` : "",
-    data?.image ? `images=${encodeURIComponent(data?.image)}` : "",
-  ].filter((e) => e !== "");
-  const image = `https://urbit-id-og-cards-kappa.vercel.app/${deSig(
-    id
-  )}.png?${reqParams.join("&")}`;
-
   // Galaxies shouldn't show parents, so store it as boolean here for reference.
   const isGalaxy = ob.clan(id) === "galaxy";
 
@@ -48,24 +39,24 @@ const IdPage = ({ data, markdown, applications, groups, network, params }) => {
   return (
     <Container>
       <Head>
-        <title>{id} • Urbit ID • urbit.org</title>
+        <title>{id} • Urbit ID</title>
         <link rel="icon" type="image/png" href="/images/favicon.ico" />
-        <meta
-          name="twitter:card"
-          content="summary_large_image"
-          key="twitter-card"
-        />
-        <meta
-          name="og:title"
-          content={`${id} • Urbit ID • urbit.org`}
-          key="title"
-        />
+        <meta name="twitter:card" content="summary" key="twitter-card" />
+        <meta name="og:title" content={`${id} • Urbit ID`} key="title" />
         <meta
           name="og:description"
-          content="View more about this Urbit ID on urbit.org."
+          content={`ID Type: ${
+            ob.clan(id).slice(0, 1).toUpperCase() + ob.clan(id).slice(1)
+          }`}
           key="description"
         />
-        <meta property="twitter:image" content={image} key="image" />
+        <meta
+          property="twitter:image"
+          content={
+            data?.image || `/api/sigil?patp=${id}&color=${bgColor || "24201E"}`
+          }
+          key="image"
+        />
       </Head>
       <SingleColumn>
         <Section className="space-y-12 w-full" narrow>

--- a/pages/ids/[id].js
+++ b/pages/ids/[id].js
@@ -53,7 +53,8 @@ const IdPage = ({ data, markdown, applications, groups, network, params }) => {
         <meta
           property="twitter:image"
           content={
-            data?.image || `/api/sigil?patp=${id}&color=${bgColor || "24201E"}`
+            data?.image ||
+            `/api/sigil?patp=${id}&color=${data?.bgColor || "24201E"}`
           }
           key="image"
         />

--- a/pages/index.js
+++ b/pages/index.js
@@ -19,6 +19,7 @@ import { eventKeys } from "../lib/constants";
 import IndexCard from "../components/ecosystem/IndexCard";
 import fs from "fs";
 import path from "path";
+import Meta from "../components/Meta";
 
 export default function Home({
   posts,
@@ -27,10 +28,15 @@ export default function Home({
   grantNumbers,
   search,
 }) {
+  const post = {
+    title: "Urbit",
+    description: "A clean-slate OS and network for the 21st century.",
+  };
   return (
     <Container>
       <Head>
-        <title>urbit.org</title>
+        <title>Urbit</title>
+        {Meta(post)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={search} />
       <SingleColumn>
@@ -47,7 +53,6 @@ export default function Home({
           // Hero
         }
         <Section>
-
           <div className="bg-yellow-100 dark:bg-[#5C5037] w-full p-8 md:p-12 rounded-3xl flex flex-col md:flex-row">
             <div className="md:w-10/12 w-full md:mr-6">
               <h2 className="m-0 p-0 mr-4 pb-6">Assembly 2022</h2>
@@ -172,44 +177,44 @@ export default function Home({
           // Build on Urbit Developer CTA
         }
         <Section narrow>
-            <h2 className="pb-8">Build on Urbit</h2>
-            <h4 className="pb-6">
-              Urbit is a personal OS designed from scratch to run peer-to-peer
-              applications.
-            </h4>
-            <p className="pb-6">
-              It solves the hard problems of implementing a peer-to-peer network
-              (including identity, NAT traversal, and exactly-once delivery) in
-              the kernel so app developers can focus on business logic.
-            </p>
-            <p className="pb-6">
-              The entire OS is a{" "}
-              <Link href="https://urbit.org/docs/nock/definition/" passHref>
-                <a>single pure function</a>
-              </Link>{" "}
-              that provides application developers with strong guarantees:
-              automated persistence and memory management, repeatable builds,
-              and support for hot code reloading.
-            </p>
-            <p className="pb-10">
-              You can get started learning how to{" "}
-              <Link href="https://urbit.org/docs/development/develop/" passHref>
-                <a>contribute to the project</a>
-              </Link>
-              , or view a variety of{" "}
-              <Link
-                href="https://github.com/urbit/awesome-urbit#http-apis-airlock"
-                passHref
-              >
-                <a>libraries</a>
-              </Link>{" "}
-              for building on Urbit using the languages you already know.
-            </p>
-            <Link href="https://developers.urbit.org" passHref>
-              <a className="button-lg type-ui text-white bg-green-400 max-w-fit">
-                Visit Urbit Developers
-              </a>
+          <h2 className="pb-8">Build on Urbit</h2>
+          <h4 className="pb-6">
+            Urbit is a personal OS designed from scratch to run peer-to-peer
+            applications.
+          </h4>
+          <p className="pb-6">
+            It solves the hard problems of implementing a peer-to-peer network
+            (including identity, NAT traversal, and exactly-once delivery) in
+            the kernel so app developers can focus on business logic.
+          </p>
+          <p className="pb-6">
+            The entire OS is a{" "}
+            <Link href="https://urbit.org/docs/nock/definition/" passHref>
+              <a>single pure function</a>
+            </Link>{" "}
+            that provides application developers with strong guarantees:
+            automated persistence and memory management, repeatable builds, and
+            support for hot code reloading.
+          </p>
+          <p className="pb-10">
+            You can get started learning how to{" "}
+            <Link href="https://urbit.org/docs/development/develop/" passHref>
+              <a>contribute to the project</a>
             </Link>
+            , or view a variety of{" "}
+            <Link
+              href="https://github.com/urbit/awesome-urbit#http-apis-airlock"
+              passHref
+            >
+              <a>libraries</a>
+            </Link>{" "}
+            for building on Urbit using the languages you already know.
+          </p>
+          <Link href="https://developers.urbit.org" passHref>
+            <a className="button-lg type-ui text-white bg-green-400 max-w-fit">
+              Visit Urbit Developers
+            </a>
+          </Link>
         </Section>
 
         {
@@ -261,14 +266,29 @@ export default function Home({
 
         <Section narrow>
           <h2 className="pb-8">Social Media</h2>
-          <p className="pb-2">Follow us on <Link href="http://twitter.com/urbit">Twitter</Link></p>
-          <p className="pb-2">Check out our posts on <Link href="http://instagram.com/urbit">Instagram</Link></p>
-          <p className="pb-2">Watch livestreams on <Link href="https://www.youtube.com/channel/UCNYIS9_SktINCC9yqO4CFZw">YouTube</Link></p>
-          <p className="pb-2">Dig into code on <Link href="http://github.com/urbit">Github</Link></p>
-          <p className="pb-2">Boot Urbit and join <Link href="https://urbit.org/groups/~bitbet-bolbel/urbit-community">Urbit Community</Link></p>
+          <p className="pb-2">
+            Follow us on <Link href="http://twitter.com/urbit">Twitter</Link>
+          </p>
+          <p className="pb-2">
+            Check out our posts on{" "}
+            <Link href="http://instagram.com/urbit">Instagram</Link>
+          </p>
+          <p className="pb-2">
+            Watch livestreams on{" "}
+            <Link href="https://www.youtube.com/channel/UCNYIS9_SktINCC9yqO4CFZw">
+              YouTube
+            </Link>
+          </p>
+          <p className="pb-2">
+            Dig into code on <Link href="http://github.com/urbit">Github</Link>
+          </p>
+          <p className="pb-2">
+            Boot Urbit and join{" "}
+            <Link href="https://urbit.org/groups/~bitbet-bolbel/urbit-community">
+              Urbit Community
+            </Link>
+          </p>
         </Section>
-
-
       </SingleColumn>
       <Footer />
     </Container>

--- a/pages/marketplaces/[slug].js
+++ b/pages/marketplaces/[slug].js
@@ -12,7 +12,7 @@ export default function Marketplace({
 }) {
   return (
     <BasicPage
-      section="Marketplaces"
+      section="Urbit Marketplace"
       post={post}
       markdown={markdown}
       search={search}

--- a/pages/marketplaces/[slug].js
+++ b/pages/marketplaces/[slug].js
@@ -36,7 +36,7 @@ export default function Marketplace({
 export async function getStaticProps({ params }) {
   const post = getPostBySlug(
     params.slug,
-    ["title", "slug", "URL", "image", "payment", "content"],
+    ["title", "slug", "description", "URL", "image", "payment", "content"],
     "marketplaces"
   );
 

--- a/pages/organizations/[slug].js
+++ b/pages/organizations/[slug].js
@@ -1,6 +1,3 @@
-// Single page per organisation
-// Needs to have *associated ships* by which it polls content/applications for applications it "owns"
-// Needs to look for its title in ecosystem/spotlight
 import { getAllPosts, getPostBySlug, getPostSlugs } from "../../lib/lib";
 import BasicPage from "../../components/ecosystem/BasicPage";
 import { Markdown } from "@urbit/foundation-design-system";
@@ -19,7 +16,7 @@ export default function Organization({
 }) {
   return (
     <BasicPage
-      section="Organizations"
+      section="Organization"
       post={post}
       markdown={markdown}
       search={search}

--- a/pages/organizations/[slug].js
+++ b/pages/organizations/[slug].js
@@ -94,7 +94,16 @@ export default function Organization({
 export async function getStaticProps({ params }) {
   const post = getPostBySlug(
     params.slug,
-    ["title", "slug", "URL", "image", "ships", "group", "content"],
+    [
+      "title",
+      "slug",
+      "description",
+      "URL",
+      "image",
+      "ships",
+      "group",
+      "content",
+    ],
     "organizations"
   );
 

--- a/pages/overview/[[...slug]].js
+++ b/pages/overview/[[...slug]].js
@@ -21,7 +21,7 @@ export default function Overview({ posts, data, markdown, search }) {
   return (
     <Container>
       <Head>
-        <title>{data.title} • Overview • Urbit</title>
+        <title>{data.title} • Overview</title>
         {Meta(data)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={search} />

--- a/pages/podcasts/[slug].js
+++ b/pages/podcasts/[slug].js
@@ -12,7 +12,7 @@ export default function Podcast({
 }) {
   return (
     <BasicPage
-      section="Podcasts"
+      section="Podcast"
       post={post}
       markdown={markdown}
       search={search}

--- a/pages/updates/[slug].js
+++ b/pages/updates/[slug].js
@@ -30,7 +30,7 @@ export default function Post({ post, markdown, search }) {
   return (
     <Container>
       <Head>
-        <title>{post.title} • Updates • urbit.org</title>
+        <title>{post.title} • Updates</title>
         {Meta(post)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={search} />


### PR DESCRIPTION
- We now deploy a server-side generator of sigil .pngs at `https://urbit.org/api/sigil` that takes `patp` (with a leading `~`) and `color` (without a leading `#`) and outputs a 1024x1024 png.
- All pages except events and blog posts use `summary` and not `summary_large_image`.
- The homepage now actually has OG data. It did not before. This is crazy to me.
- All OG cards no longer have `- urbit.org` suffixes, instead declaring what they are.
- All pages in organisations and marketplaces now have descriptions. Podcasts default to describing themselves in cards in `Podcast - Date` format. This is all necessary because we use Markdown in the descriptions of all this content and we need a text-only snippet for cards.

ID pages do in fact look correct on Twitter, but they won't right now because Twitter images need to be absolute paths, so we point to the non-existent Sigil api on prod. Here's what it looks like:

<img width="603" alt="Screen Shot 2022-08-17 at 12 39 35 PM" src="https://user-images.githubusercontent.com/20846414/185228780-f46c4b56-039e-4ca2-8399-5cb9c7a0331e.png">

Fixes #1708 