### PR TITLE
index: flatten assignee arrays for counting unique contributors

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -368,7 +368,8 @@ export async function getStaticProps() {
         0
       )
     ),
-    contributors: [...new Set(...[grants.map((e) => e.extra.assignee)])].length,
+    contributors: [...new Set(...[grants.map((e) => e.extra.assignee).flat()])]
+      .length,
     active: grants.filter(
       (e) =>
         !e.extra.canceled &&


### PR DESCRIPTION
While console.logging this, found a bug — we weren't flattening arrays before deduplication so it was deduplicating the entire arrays against each other instead of their items. Our contributors were about 40 too high.