### PR TITLE
Trial comets

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -45,8 +45,9 @@ export default function Home({
           // Hero Statement
         }
         <Section className="pb-36">
-          <div>
+          <div className="space-y-8">
             <h1>A clean-slate OS and network for the 21st&nbsp;century.</h1>
+            <Link href="/trial" passHref><a className="bg-green-400 text-white button-lg max-w-fit">Explore the Network</a></Link>
           </div>
         </Section>
         {

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,27 +21,6 @@ import fs from "fs";
 import path from "path";
 import Meta from "../components/Meta";
 
-const postReq = (path, params, method='post') => {
-  const form = document.createElement('form');
-  form.method = method;
-  form.action = path;
-
-  for (const key in params) {
-    if (params.hasOwnProperty(key)) {
-      const hiddenField = document.createElement('input');
-      hiddenField.type = 'hidden';
-      hiddenField.name = key;
-      hiddenField.value = params[key];
-
-      form.appendChild(hiddenField);
-    }
-  }
-
-  document.body.appendChild(form);
-  form.submit();
-}
-
-
 export default function Home({
   posts,
   ecosystem,
@@ -73,23 +52,6 @@ export default function Home({
         {
           // Hero
         }
-        <div className="layout px-4 md:px-8">
-          <a className="p-8 button-lg bg-green-400 text-white"
-             onClick={(e) => {
-               e.stopPropagation();
-               fetch('https://api.shore.arvo.network/enter', {
-                 method: 'GET',
-                 headers: {'Content-Type': 'application/json'}
-               })
-                 .then(res => res.json())
-                 .then(data => {
-                   postReq(data.url + '/~/login', {password: data.code, redirect: '/'});
-                 });
-             }}
-          >
-            Try now
-          </a>
-        </div>
         <Section>
           <div className="bg-yellow-100 dark:bg-[#5C5037] w-full p-8 md:p-12 rounded-3xl flex flex-col md:flex-row">
             <div className="md:w-10/12 w-full md:mr-6">

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,6 +21,27 @@ import fs from "fs";
 import path from "path";
 import Meta from "../components/Meta";
 
+const postReq = (path, params, method='post') => {
+  const form = document.createElement('form');
+  form.method = method;
+  form.action = path;
+
+  for (const key in params) {
+    if (params.hasOwnProperty(key)) {
+      const hiddenField = document.createElement('input');
+      hiddenField.type = 'hidden';
+      hiddenField.name = key;
+      hiddenField.value = params[key];
+
+      form.appendChild(hiddenField);
+    }
+  }
+
+  document.body.appendChild(form);
+  form.submit();
+}
+
+
 export default function Home({
   posts,
   ecosystem,
@@ -52,6 +73,23 @@ export default function Home({
         {
           // Hero
         }
+        <div className="layout px-4 md:px-8">
+          <a className="p-8 button-lg bg-green-400 text-white"
+             onClick={(e) => {
+               e.stopPropagation();
+               fetch('https://api.shore.arvo.network/enter', {
+                 method: 'GET',
+                 headers: {'Content-Type': 'application/json'}
+               })
+                 .then(res => res.json())
+                 .then(data => {
+                   postReq(data.url + '/~/login', {password: data.code, redirect: '/'});
+                 });
+             }}
+          >
+            Try now
+          </a>
+        </div>
         <Section>
           <div className="bg-yellow-100 dark:bg-[#5C5037] w-full p-8 md:p-12 rounded-3xl flex flex-col md:flex-row">
             <div className="md:w-10/12 w-full md:mr-6">

--- a/pages/trial-over.js
+++ b/pages/trial-over.js
@@ -1,0 +1,35 @@
+import Head from "next/head";
+import Meta from "../components/Meta";
+import {
+  Container,
+  SingleColumn,
+  Section,
+  IntraNav,
+} from "@urbit/foundation-design-system";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+
+export default function TrialOver(props) {
+  const post = {
+    title: "Trial Over",
+  };
+
+
+  return (
+    <Container>
+      <Head>
+        <title>Trial Over • urbit.org</title>
+        {Meta(post)}
+      </Head>
+      <IntraNav ourSite="https://urbit.org" search={props.search} />
+      <SingleColumn>
+        <Header />
+        <Section className="pt-8">
+          <h1>Trial Over</h1>
+          <p className="mt-12">Your trial has ended.</p>
+        </Section>
+      </SingleColumn>
+      <Footer />
+    </Container>
+  );
+}

--- a/pages/trial-over.js
+++ b/pages/trial-over.js
@@ -25,7 +25,7 @@ export default function TrialOver(props) {
       <IntraNav ourSite="https://urbit.org" search={props.search} />
       <div className="h-full w-full grow flex items-center justify-center flex-col px-8 md:px-0">
         <div className="w-fit">
-          <h2>Your one week comet trial has concluded.</h2>
+          <h2>Your one day moon trial has concluded.</h2>
           <p className="my-12 max-w-prose">To keep using Urbit, we recommend getting a planet and setting up Urbit yourself or using a hosting provider.
             <Link href="/getting-started"><a className="button-lg bg-green-400 text-white max-w-fit my-12">Get Started</a></Link></p>
         </div>

--- a/pages/trial-over.js
+++ b/pages/trial-over.js
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import Link from "next/link";
 import Meta from "../components/Meta";
 import {
   Container,
@@ -22,14 +23,13 @@ export default function TrialOver(props) {
         {Meta(post)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={props.search} />
-      <SingleColumn>
-        <Header />
-        <Section className="pt-8">
-          <h1>Trial Over</h1>
-          <p className="mt-12">Your trial has ended.</p>
-        </Section>
-      </SingleColumn>
-      <Footer />
+      <div className="h-full w-full grow flex items-center justify-center flex-col px-8 md:px-0">
+        <div className="w-fit">
+          <h2>Your one week comet trial has concluded.</h2>
+          <p className="my-12 max-w-prose">To keep using Urbit, we recommend getting a planet and setting up Urbit yourself or using a hosting provider.
+            <Link href="/getting-started"><a className="button-lg bg-green-400 text-white max-w-fit my-12">Get Started</a></Link></p>
+        </div>
+      </div>
     </Container>
   );
 }

--- a/pages/trial.js
+++ b/pages/trial.js
@@ -70,11 +70,11 @@ export default function Trial(props) {
           <div className="flex flex-col items-center space-y-4 xl:space-y-0 xl:flex-row xl:space-x-4">
             <video className="max-w-md w-full min-w-0" autoPlay muted loop playsInline>
               <source
-                src="https://storage.googleapis.com/media.urbit.org/site/groupsdemo.webm"
+                src="https://storage.googleapis.com/media.urbit.org/site/explorethenetwork.webm"
                 type="video/webm"
               />
               <source
-                src="https://storage.googleapis.com/media.urbit.org/site/groupsdemo-2.mp4"
+                src="https://storage.googleapis.com/media.urbit.org/site/explorethenetwork.mp4"
                 type="video/mp4"
               />
             </video>

--- a/pages/trial.js
+++ b/pages/trial.js
@@ -1,0 +1,103 @@
+import { useState, useEffect } from 'react';
+import Head from "next/head";
+import Meta from "../components/Meta";
+import {
+  Container,
+  SingleColumn,
+  Section,
+  IntraNav,
+} from "@urbit/foundation-design-system";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+
+const postReq = (path, params, method='post') => {
+  const form = document.createElement('form');
+  form.method = method;
+  form.action = path;
+
+  for (const key in params) {
+    if (params.hasOwnProperty(key)) {
+      const hiddenField = document.createElement('input');
+      hiddenField.type = 'hidden';
+      hiddenField.name = key;
+      hiddenField.value = params[key];
+
+      form.appendChild(hiddenField);
+    }
+  }
+
+  document.body.appendChild(form);
+  form.submit();
+}
+
+
+
+export default function Trial(props) {
+  const post = {
+    title: "Trial",
+  };
+
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    fetch('https://api.shore.arvo.network/count', {
+      method: 'GET',
+      headers: {'Content-Type': 'application/json'}
+    })
+      .then(res => res.json())
+      .then(data => {
+        setCount(data.count);
+      });
+  }, []);
+
+  const available = count > 0;
+
+  const buttonBg = available ? '' : 'pink';
+
+  return (
+    <Container>
+      <Head>
+        <title>Trial • urbit.org</title>
+        {Meta(post)}
+      </Head>
+      <IntraNav ourSite="https://urbit.org" search={props.search} />
+      <SingleColumn>
+        <Header />
+        <Section className="pt-8">
+          <h1>Trial</h1>
+          <p className="mt-12">There are currently {count} trial comets left.</p>
+        </Section>
+        <div className="layout px-4 md:px-8">
+          <a className="p-8 button-lg bg-green-400 text-white"
+             style={{"backgroundColor": buttonBg}}
+             onClick={(e) => {
+               e.stopPropagation();
+
+               if (!available) {
+                 return
+               }
+
+               fetch('https://api.shore.arvo.network/enter', {
+                 method: 'GET',
+                 headers: {'Content-Type': 'application/json'}
+               })
+                 .then(res =>{
+                   if (!res.ok) {
+                     throw 'Error response from shore api.';
+                   }
+                   return res.json();
+                 })
+                 .then(data => {
+                   postReq(data.url + '/~/login', {password: data.code, redirect: '/'});
+                 })
+                 .catch(e => setCount(0));
+             }}
+          >
+            {available ? 'Try now' : 'No trial comets available, try again later'}
+          </a>
+        </div>
+      </SingleColumn>
+      <Footer />
+    </Container>
+  );
+}

--- a/pages/trial.js
+++ b/pages/trial.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import Head from "next/head";
+import Link from 'next/link';
 import Meta from "../components/Meta";
 import {
   Container,
@@ -9,8 +10,9 @@ import {
 } from "@urbit/foundation-design-system";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
+import cn from 'classnames';
 
-const postReq = (path, params, method='post') => {
+const postReq = (path, params, method = 'post') => {
   const form = document.createElement('form');
   form.method = method;
   form.action = path;
@@ -34,7 +36,8 @@ const postReq = (path, params, method='post') => {
 
 export default function Trial(props) {
   const post = {
-    title: "Trial",
+    title: "Explore the Network",
+    description: "Get one week of a complimentary hosted comet: a temporary Urbit ID."
   };
 
   const [count, setCount] = useState(0)
@@ -42,7 +45,7 @@ export default function Trial(props) {
   useEffect(() => {
     fetch('https://api.shore.arvo.network/count', {
       method: 'GET',
-      headers: {'Content-Type': 'application/json'}
+      headers: { 'Content-Type': 'application/json' }
     })
       .then(res => res.json())
       .then(data => {
@@ -52,50 +55,64 @@ export default function Trial(props) {
 
   const available = count > 0;
 
-  const buttonBg = available ? '' : 'pink';
-
   return (
     <Container>
       <Head>
-        <title>Trial • urbit.org</title>
+        <title>{post.title} • urbit.org</title>
         {Meta(post)}
       </Head>
       <IntraNav ourSite="https://urbit.org" search={props.search} />
       <SingleColumn>
         <Header />
-        <Section className="pt-8">
-          <h1>Trial</h1>
-          <p className="mt-12">There are currently {count} trial comets left.</p>
+        <Section className="space-y-12">
+          <h1>{post.title}</h1>
+          {/* Flex between image and blurb, collapse to col on mobile */}
+          <div className="flex flex-col items-center space-y-4 md:space-y-0 md:flex-row md:space-x-4">
+            <img className="max-w-lg h-auto w-full" src="https://media.urbit.org/site/getting-started/explore.png" />
+            {/* Blurb is flexed to space button and copy */}
+            <div className="flex-col flex space-y-4">
+              <p>No downloads, no signup.</p>
+              <p>Get <span className="font-bold">one week</span> of a complimentary hosted comet: a temporary Urbit ID.</p>
+              {/* Button is flexed to space potential "try again later" copy */}
+              <div className="space-x-4 flex items-center">
+                <a className={cn("p-8 button-lg text-white max-w-fit", {
+                  "bg-green-400": available,
+                  "bg-wall-300 cursor-not-allowed": !available,
+                })}
+                  onClick={(e) => {
+                    e.stopPropagation();
+
+                    if (!available) {
+                      return
+                    }
+
+                    fetch('https://api.shore.arvo.network/enter', {
+                      method: 'GET',
+                      headers: { 'Content-Type': 'application/json' }
+                    })
+                      .then(res => {
+                        if (!res.ok) {
+                          throw 'Error response from shore api.';
+                        }
+                        return res.json();
+                      })
+                      .then(data => {
+                        postReq(data.url + '/~/login', { password: data.code, redirect: '/' });
+                      })
+                      .catch(e => setCount(0));
+                  }}
+                >
+                  {available ? 'Launch Comet' : 'No Comets Available'}
+                </a>
+                {!available && <p>Try back later!</p>}
+              </div>
+            </div>
+          </div>
+          <div className="max-w-prose flex flex-col space-y-4">
+            <p>Comets are great for checking things out, but some groups may require a planet – a permanent Urbit ID.</p>
+            <p>Learn more about <Link href="/getting-started/get-planet"><a>getting a planet</a></Link>.</p>
+          </div>
         </Section>
-        <div className="layout px-4 md:px-8">
-          <a className="p-8 button-lg bg-green-400 text-white"
-             style={{"backgroundColor": buttonBg}}
-             onClick={(e) => {
-               e.stopPropagation();
-
-               if (!available) {
-                 return
-               }
-
-               fetch('https://api.shore.arvo.network/enter', {
-                 method: 'GET',
-                 headers: {'Content-Type': 'application/json'}
-               })
-                 .then(res =>{
-                   if (!res.ok) {
-                     throw 'Error response from shore api.';
-                   }
-                   return res.json();
-                 })
-                 .then(data => {
-                   postReq(data.url + '/~/login', {password: data.code, redirect: '/'});
-                 })
-                 .catch(e => setCount(0));
-             }}
-          >
-            {available ? 'Try now' : 'No trial comets available, try again later'}
-          </a>
-        </div>
       </SingleColumn>
       <Footer />
     </Container>

--- a/pages/trial.js
+++ b/pages/trial.js
@@ -67,15 +67,15 @@ export default function Trial(props) {
         <Section className="space-y-12">
           <h1>{post.title}</h1>
           {/* Flex between image and blurb, collapse to col on mobile */}
-          <div className="flex flex-col items-center space-y-4 md:space-y-0 md:flex-row md:space-x-4">
+          <div className="flex flex-col items-center space-y-4 xl:space-y-0 xl:flex-row xl:space-x-4">
             <img className="max-w-lg h-auto w-full" src="https://media.urbit.org/site/getting-started/explore.png" />
             {/* Blurb is flexed to space button and copy */}
             <div className="flex-col flex space-y-4">
               <p>No downloads, no signup.</p>
               <p>Get <span className="font-bold">one week</span> of a complimentary hosted comet: a temporary Urbit ID.</p>
               {/* Button is flexed to space potential "try again later" copy */}
-              <div className="space-x-4 flex items-center">
-                <a className={cn("p-8 button-lg text-white max-w-fit", {
+              <div className="xl:space-x-4 space-y-4 xl:space-y-0 self-center flex-col xl:flex-row flex items-center">
+                <a className={cn("p-8 button-lg text-white max-w-fit shrink-0", {
                   "bg-green-400": available,
                   "bg-wall-300 cursor-not-allowed": !available,
                 })}

--- a/pages/trial.js
+++ b/pages/trial.js
@@ -68,7 +68,16 @@ export default function Trial(props) {
           <h1>{post.title}</h1>
           {/* Flex between image and blurb, collapse to col on mobile */}
           <div className="flex flex-col items-center space-y-4 xl:space-y-0 xl:flex-row xl:space-x-4">
-            <img className="max-w-lg h-auto w-full" src="https://media.urbit.org/site/getting-started/explore.png" />
+            <video className="max-w-md w-full min-w-0" autoPlay muted loop playsInline>
+              <source
+                src="https://storage.googleapis.com/media.urbit.org/site/groupsdemo.webm"
+                type="video/webm"
+              />
+              <source
+                src="https://storage.googleapis.com/media.urbit.org/site/groupsdemo-2.mp4"
+                type="video/mp4"
+              />
+            </video>
             {/* Blurb is flexed to space button and copy */}
             <div className="flex-col flex space-y-4">
               <p>No downloads, no signup.</p>

--- a/pages/trial.js
+++ b/pages/trial.js
@@ -37,7 +37,7 @@ const postReq = (path, params, method = 'post') => {
 export default function Trial(props) {
   const post = {
     title: "Explore the Network",
-    description: "Get one week of a complimentary hosted comet: a temporary Urbit ID."
+    description: "Get one day of a complimentary hosted moon: a temporary Urbit ID."
   };
 
   const [count, setCount] = useState(0)
@@ -81,7 +81,7 @@ export default function Trial(props) {
             {/* Blurb is flexed to space button and copy */}
             <div className="flex-col flex space-y-4">
               <p>No downloads, no signup.</p>
-              <p>Get <span className="font-bold">one week</span> of a complimentary hosted comet: a temporary Urbit ID.</p>
+              <p>Get <span className="font-bold">one day</span> of a complimentary hosted moon: a temporary Urbit ID.</p>
               {/* Button is flexed to space potential "try again later" copy */}
               <div className="xl:space-x-4 space-y-4 xl:space-y-0 self-center xl:self-start w-full flex-col xl:flex-row flex items-center">
                 <a className={cn("p-8 button-lg text-white max-w-fit shrink-0", {
@@ -111,14 +111,14 @@ export default function Trial(props) {
                       .catch(e => setCount(0));
                   }}
                 >
-                  {available ? 'Launch Comet' : 'No Comets Available'}
+                  {available ? 'Launch Moon' : 'No Moons Available'}
                 </a>
-                {!available && <p>Try back later!</p>}
+                {!available && <p>Check back later!</p>}
               </div>
             </div>
           </div>
           <div className="max-w-prose flex flex-col space-y-4">
-            <p>Comets are great for checking things out, but some groups may require a planet – a permanent Urbit ID.</p>
+            <p>Moons are great for checking things out, but some groups may require a planet – a permanent Urbit ID.</p>
             <p>Learn more about <Link href="/getting-started/get-planet"><a>getting a planet</a></Link>.</p>
           </div>
         </Section>

--- a/pages/trial.js
+++ b/pages/trial.js
@@ -83,7 +83,7 @@ export default function Trial(props) {
               <p>No downloads, no signup.</p>
               <p>Get <span className="font-bold">one week</span> of a complimentary hosted comet: a temporary Urbit ID.</p>
               {/* Button is flexed to space potential "try again later" copy */}
-              <div className="xl:space-x-4 space-y-4 xl:space-y-0 self-center flex-col xl:flex-row flex items-center">
+              <div className="xl:space-x-4 space-y-4 xl:space-y-0 self-center xl:self-start w-full flex-col xl:flex-row flex items-center">
                 <a className={cn("p-8 button-lg text-white max-w-fit shrink-0", {
                   "bg-green-400": available,
                   "bg-wall-300 cursor-not-allowed": !available,


### PR DESCRIPTION
Adds a page for accessing trial comets `/trial`, and a static page where I can redirect people whose trials have ended `/trial-over`. Needs copy and possibly styling on both pages, backend is now good to go. Also, nothing links the trial landing page so we need to figure out where to put it. @gordoncc 