### PR TITLE
grants: surface deliverables, groups, bidirectionally link from application pages

### DIFF
--- a/components/JoinGroup.js
+++ b/components/JoinGroup.js
@@ -58,9 +58,9 @@ export default function Contact({ emphasize, groupName, label, className }) {
 
   return (
     <div className={className}>
-      <h4 className="mt-4 text-wall-500 flex items-baseline flex-wrap">
+      <h4 className="text-wall-500 flex items-baseline flex-wrap">
         {label ? label + " " : ""}
-        <div className="md:ml-2 rounded-lg flex items-stretch">
+        <div className="rounded-lg flex items-stretch">
           <code
             className={`rounded-l-lg px-2 md:px-4 py-2 ${washedBg} flex items-center h-full ${linkText}`}
           >

--- a/components/ecosystem/BasicPage.js
+++ b/components/ecosystem/BasicPage.js
@@ -12,6 +12,7 @@ import {
 } from "@urbit/foundation-design-system";
 import Header from "../Header";
 import Footer from "../Footer";
+import MetadataBlock from "./MetadataBlock";
 
 export default function BasicPage({
   section,
@@ -28,7 +29,7 @@ export default function BasicPage({
   metaPost.title = `${post.title} - ${section}`;
   metaPost.description =
     section === "Podcast" ? `${post.podcast} - ${post.date}` : post.description;
-    section === "Article" ? `${post.publication} - ${post.date}` : post.description;
+  section === "Article" ? `${post.publication} - ${post.date}` : post.description;
   return (
     <Container>
       <Head>
@@ -44,7 +45,7 @@ export default function BasicPage({
           <div className="flex items-center space-x-4">
             <img src={post.image} className="w-36" />
             <div className="flex flex-col pl-2">
-              <h1 className={classnames({ "text-3xl": section === "Podcast" },{ "text-3xl": section === "Article" })}>
+              <h1 className={classnames({ "text-3xl": section === "Podcast" }, { "text-3xl": section === "Article" })}>
                 {post.title}
               </h1>
               <p>{section}</p>
@@ -54,28 +55,28 @@ export default function BasicPage({
           <div className="flex justify-between">
             <div className="flex space-x-12">
               {post?.podcast && (
-                <div className="flex flex-col">
-                  <p className="font-bold text-wall-400">Podcast</p>
-                  <p>{post.podcast}</p>
-                </div>
+                <MetadataBlock
+                  title="Podcast"
+                  content={post.podcast}
+                />
               )}
               {post?.publication && (
-                <div className="flex flex-col">
-                  <p className="font-bold text-wall-400">Publication</p>
-                  <p>{post.publication}</p>
-                </div>
+                <MetadataBlock
+                  title="Publication"
+                  content={post.publication}
+                />
               )}
               {post?.author && (
-                <div className="flex flex-col">
-                  <p className="font-bold text-wall-400">Author</p>
-                  <p>{post.author}</p>
-                </div>
+                <MetadataBlock
+                  title="Author"
+                  content={post.author}
+                />
               )}
               {post?.date && (
-                <div className="flex flex-col">
-                  <p className="font-bold text-wall-400">Date</p>
-                  <p className="shrink-0">{post.date}</p>
-                </div>
+                <MetadataBlock
+                  title="Date"
+                  content={post.date}
+                />
               )}
 
               {post?.URL && section !== "Podcast" && section !== "Article" && (

--- a/components/ecosystem/MetadataBlock.js
+++ b/components/ecosystem/MetadataBlock.js
@@ -1,5 +1,5 @@
 export default function MetadataBlock({ title, content }) {
-    return <div className="flex flex-col">
+    return <div className="flex flex-col py-2 basis-1/2 md:basis-auto">
         <p className="font-bold text-wall-400">{title}</p>
         <p>{content}</p>
     </div>

--- a/components/ecosystem/MetadataBlock.js
+++ b/components/ecosystem/MetadataBlock.js
@@ -1,0 +1,7 @@
+export default function MetadataBlock({ title, content }) {
+    return <div className="flex flex-col">
+        <p className="font-bold text-wall-400">{title}</p>
+        <p>{content}</p>
+    </div>
+
+}

--- a/components/gateway/Description.js
+++ b/components/gateway/Description.js
@@ -4,7 +4,6 @@ const Description = ({ description, fallback, markdown }) => {
   return (
     (description !== fallback || markdown) && (
       <div className="flex flex-col space-y-4">
-        <p className="font-bold text-wall-400">Description</p>
         {markdown ? (
           <div className="markdown">
             <Markdown.render content={JSON.parse(markdown)} />

--- a/components/gateway/Image.js
+++ b/components/gateway/Image.js
@@ -9,7 +9,7 @@ const GatewayImage = ({
 }) => {
   if (error) {
     return (
-      <div className="overflow-hidden rounded-xl">
+      <div className="overflow-hidden rounded-xl shrink-0">
         <svg
           width={size}
           height={size}
@@ -29,7 +29,7 @@ const GatewayImage = ({
 
   if (patp) {
     return (
-      <div className="rounded-xl overflow-hidden">
+      <div className="rounded-xl overflow-hidden shrink-0">
         <Sigil patp={patp} size={size} color={color} />
       </div>
     );
@@ -39,14 +39,14 @@ const GatewayImage = ({
     return (
       <div
         style={{ height: size, width: size, backgroundColor: image }}
-        className="rounded-xl"
+        className="rounded-xl shrink-0"
       />
     );
   }
 
   return image ? (
     <div
-      className="rounded-xl overflow-hidden"
+      className="rounded-xl overflow-hidden shrink-0"
       style={{ backgroundColor: color }}
     >
       <img src={image} style={{ height: size, width: size }} />

--- a/components/gateway/ResourceCard.js
+++ b/components/gateway/ResourceCard.js
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import GatewayImage from "./Image";
 import classNames from "classnames";
+import { capitalize } from "@urbit/foundation-design-system";
 
 const ResourceCard = ({ type, shortcode, title, description = "", color, image, full }) => (
   <Link href={`/${type}s/${shortcode}`}>
@@ -13,7 +14,7 @@ const ResourceCard = ({ type, shortcode, title, description = "", color, image, 
           <a className="font-semibold">{title}</a>
           <p className="hidden lg:block">{description}</p>
         </div>
-          <a className="button-lg bg-green-400 text-white shrink-0">View {type}</a>
+          <a className="button-lg bg-green-400 text-white shrink-0">View {capitalize(type)}</a>
         </>
         : <a className="font-semibold">{title}</a>}
     </div>

--- a/components/gateway/ResourceCard.js
+++ b/components/gateway/ResourceCard.js
@@ -1,11 +1,21 @@
 import Link from "next/link";
 import GatewayImage from "./Image";
+import classNames from "classnames";
 
-const ResourceCard = ({ type, shortcode, title, color, image }) => (
+const ResourceCard = ({ type, shortcode, title, description = "", color, image, full }) => (
   <Link href={`/${type}s/${shortcode}`}>
-    <div className="cursor-pointer rounded-xl bg-wall-100 p-4 flex items-center space-x-4 mr-2 my-1">
+    <div className={classNames("cursor-pointer rounded-xl bg-wall-100 p-4 flex items-center space-x-4 mr-2 my-1", {
+      "basis-full": full
+    })}>
       <GatewayImage color={color} image={image || color} size={50} />
-      <a className="font-semibold">{title}</a>
+      {full
+        ? <><div className="flex flex-col w-full">
+          <a className="font-semibold">{title}</a>
+          <p className="hidden lg:block">{description}</p>
+        </div>
+          <a className="button-lg bg-green-400 text-white shrink-0">View {type}</a>
+        </>
+        : <a className="font-semibold">{title}</a>}
     </div>
   </Link>
 );

--- a/content/grants/2022/faux.md
+++ b/content/grants/2022/faux.md
@@ -16,7 +16,8 @@ champion = ["~littel-wolfur"]
 grant_id = "P0145"
 completed = true
 canceled = false
-link = ""
+link = "~tomdys/the-faux-shore"
+deliverable = "~midsum-salrux/faux"
 
 +++
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -15,10 +15,14 @@ const options = {
 const index = [];
 
 function buildSearchIndex(dir) {
+  // Assume years belong to Grants for now.
   const dirName = dir.split("/").slice(-1).join("");
+  const parentName = String(Number(dirName)).length === 4
+    ? "Grants"
+    : dirName.charAt(0).toUpperCase() + dirName.slice(1);
   let metadata = {
     data: {
-      title: dirName.charAt(0).toUpperCase() + dirName.slice(1),
+      title: parentName,
     },
   };
 

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -126,6 +126,34 @@ export function getGrantsTypes() {
   return uniqueTypes;
 }
 
+// Grab which directory the grant post is in
+
+export function getGrantYear(slug) {
+  const basePath = join(process.cwd(), 'content/grants')
+  const years = fs.readdirSync(basePath, { 'withFileTypes': true }).filter((f) => f.isDirectory());
+  const dir = years.find((year) => {
+    const yearDir = fs.readdirSync(join(basePath, year.name), { 'withFileTypes': true });
+    return yearDir.some((file) => file.name === `${slug}.md`)
+  });
+  return dir;
+}
+
+export function getGrantByShortcode(shortcode) {
+  const basePath = join(process.cwd(), 'content/grants')
+  const years = fs.readdirSync(basePath, { 'withFileTypes': true }).filter((f) => f.isDirectory());
+  let found = null
+  const dir = years.find((year) => {
+    const yearDir = fs.readdirSync(join(basePath, year.name), { 'withFileTypes': true });
+    const foundFile = yearDir.find((file) => {
+      const { data } = matter(fs.readFileSync(join(basePath, year.name, file.name)), options);
+      return data?.extra?.deliverable === shortcode.join("/")
+    })
+    found = foundFile;
+    return foundFile
+  });
+  return found?.name?.replace(".md", "");
+}
+
 // Groups arrays into an array of arrays with 2 members
 export const pair = (arr) =>
   arr.reduce(function (rows, key, index) {

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -138,20 +138,24 @@ export function getGrantYear(slug) {
   return dir;
 }
 
-export function getGrantByShortcode(shortcode) {
+export function getGrantsByShortcode(shortcode) {
   const basePath = join(process.cwd(), 'content/grants')
   const years = fs.readdirSync(basePath, { 'withFileTypes': true }).filter((f) => f.isDirectory());
-  let found = null
-  const dir = years.find((year) => {
+  let found = [];
+  // Get matching years by any matching grant.
+  years.forEach((year) => {
     const yearDir = fs.readdirSync(join(basePath, year.name), { 'withFileTypes': true });
-    const foundFile = yearDir.find((file) => {
+    return yearDir.forEach((file) => {
       const { data } = matter(fs.readFileSync(join(basePath, year.name, file.name)), options);
-      return data?.extra?.deliverable === shortcode.join("/")
+      if (data?.extra?.deliverable === shortcode.join("/")) {
+        found.push({
+          ...data, ...{ slug: file.name.replace('.md', '') }
+        }
+        )
+      }
     })
-    found = foundFile;
-    return foundFile
   });
-  return found?.name?.replace(".md", "");
+  return found
 }
 
 // Groups arrays into an array of arrays with 2 members

--- a/pages/applications/[[...application]].js
+++ b/pages/applications/[[...application]].js
@@ -19,8 +19,9 @@ import Gateway404 from "../../components/gateway/Gateway404";
 import MetadataBlock from "../../components/gateway/MetadataBlock";
 import MetadataLink from "../../components/gateway/MetadataLink";
 import Description from "../../components/gateway/Description";
+import { getGrantByShortcode } from "../../lib/lib";
 
-const ApplicationPage = ({ data, markdown, organisation, search, params }) => {
+const ApplicationPage = ({ data, markdown, organisation, matchedGrant, search, params }) => {
   const { application } = params;
   if (!ob.isValidPatp(application[0])) {
     return <Gateway404 type="application" />;
@@ -83,7 +84,7 @@ const ApplicationPage = ({ data, markdown, organisation, search, params }) => {
             item="Application"
           />
 
-          <div className="flex flex-wrap md:flex-nowrap justify-between">
+          <div className="flex flex-wrap justify-between">
             <MetadataBlock
               title="License"
               content={data.license ? data.license : "Unknown"}
@@ -102,15 +103,19 @@ const ApplicationPage = ({ data, markdown, organisation, search, params }) => {
               className="basis-1/2 sm:basis-1/4"
               content={data.shortcode ? data.shortcode : data.title}
             />
+            {matchedGrant && <div className="basis-full flex flex-col space-y-1">
+              <p className="font-semibold text-wall-400">Grant Proposal</p>
+              <Link href={`/grants/${matchedGrant}`} passHref>
+                <a className="text-green-400 font-medium">urbit.org/grants/{matchedGrant}
+                </a>
+              </Link>
+            </div>}
           </div>
-
           <Description
             description={data.description}
             fallback="An application on Urbit."
             markdown={markdown}
           />
-
-          <hr className="text-white" />
 
           <div class="bg-wall-100 py-4 px-6 border-2 border-wall-200 rounded-xl">
             <p class="text-sm text-wall-400">
@@ -175,6 +180,7 @@ export const getServerSideProps = async ({ params, res }) => {
       ? JSON.stringify(Markdown.parse({ post: { content } }))
       : null;
 
+  const matchedGrant = getGrantByShortcode(params.application);
   if (!data.title) {
     data = {
       title: params.application?.join("/"),
@@ -187,6 +193,7 @@ export const getServerSideProps = async ({ params, res }) => {
       data,
       markdown,
       organisation,
+      matchedGrant,
       params,
     },
   };

--- a/pages/applications/[[...application]].js
+++ b/pages/applications/[[...application]].js
@@ -180,7 +180,7 @@ export const getServerSideProps = async ({ params, res }) => {
       ? JSON.stringify(Markdown.parse({ post: { content } }))
       : null;
 
-  const matchedGrant = getGrantByShortcode(params.application);
+  const matchedGrant = getGrantByShortcode(params.application) || null;
   if (!data.title) {
     data = {
       title: params.application?.join("/"),

--- a/pages/applications/[[...application]].js
+++ b/pages/applications/[[...application]].js
@@ -19,9 +19,10 @@ import Gateway404 from "../../components/gateway/Gateway404";
 import MetadataBlock from "../../components/gateway/MetadataBlock";
 import MetadataLink from "../../components/gateway/MetadataLink";
 import Description from "../../components/gateway/Description";
-import { getGrantByShortcode } from "../../lib/lib";
+import { getGrantsByShortcode } from "../../lib/lib";
+import GrantPreview from "../../components/GrantPreview";
 
-const ApplicationPage = ({ data, markdown, organisation, matchedGrant, search, params }) => {
+const ApplicationPage = ({ data, markdown, organisation, matchedGrants, search, params }) => {
   const { application } = params;
   if (!ob.isValidPatp(application[0])) {
     return <Gateway404 type="application" />;
@@ -103,19 +104,19 @@ const ApplicationPage = ({ data, markdown, organisation, matchedGrant, search, p
               className="basis-1/2 sm:basis-1/4"
               content={data.shortcode ? data.shortcode : data.title}
             />
-            {matchedGrant && <div className="basis-full flex flex-col space-y-1">
-              <p className="font-semibold text-wall-400">Grant Proposal</p>
-              <Link href={`/grants/${matchedGrant}`} passHref>
-                <a className="text-green-400 font-medium">urbit.org/grants/{matchedGrant}
-                </a>
-              </Link>
-            </div>}
           </div>
           <Description
             description={data.description}
             fallback="An application on Urbit."
             markdown={markdown}
           />
+          <hr className="text-wall-200" />
+          {matchedGrants && <div className="basis-full flex flex-col space-y-2">
+            <p className="font-semibold text-wall-400">Related Grants</p>
+            {matchedGrants.map((grant) => {
+              return <GrantPreview grant={grant} />
+            })}
+          </div>}
 
           <div class="bg-wall-100 py-4 px-6 border-2 border-wall-200 rounded-xl">
             <p class="text-sm text-wall-400">
@@ -180,7 +181,8 @@ export const getServerSideProps = async ({ params, res }) => {
       ? JSON.stringify(Markdown.parse({ post: { content } }))
       : null;
 
-  const matchedGrant = getGrantByShortcode(params.application) || null;
+  const matchedGrants = getGrantsByShortcode(params.application) || null;
+
   if (!data.title) {
     data = {
       title: params.application?.join("/"),
@@ -193,7 +195,7 @@ export const getServerSideProps = async ({ params, res }) => {
       data,
       markdown,
       organisation,
-      matchedGrant,
+      matchedGrants,
       params,
     },
   };

--- a/pages/grants/[slug].js
+++ b/pages/grants/[slug].js
@@ -23,6 +23,7 @@ import ob from "urbit-ob";
 import { DateTime } from "luxon";
 import fs from 'fs';
 import path, { join } from 'path';
+import { getGrantYear } from "../../lib/lib";
 
 export default function Grant({ post, markdown, match, search }) {
   const router = useRouter();
@@ -202,12 +203,7 @@ export default function Grant({ post, markdown, match, search }) {
 
 export async function getStaticProps({ params }) {
   // Gets post in any year folder sharing the slug name in the param
-  const basePath = join(process.cwd(), 'content/grants')
-  const years = fs.readdirSync(basePath, { 'withFileTypes': true }).filter((f) => f.isDirectory());
-  const dir = years.find((year) => {
-    const yearDir = fs.readdirSync(join(basePath, year.name), { 'withFileTypes': true });
-    return yearDir.some((file) => file.name === `${params.slug}.md`)
-  });
+  const dir = getGrantYear(params.slug);
   const post = getPostBySlug(
     params.slug,
     ["title", "slug", "date", "description", "content", "extra", "taxonomies"],
@@ -236,6 +232,7 @@ export async function getStaticProps({ params }) {
 }
 
 export async function getStaticPaths() {
+  // Flatten all year subfolders into a flat array of slugs
   const basePath = join(process.cwd(), 'content/grants')
   const years = fs.readdirSync(basePath, { 'withFileTypes': true });
   const posts = years.filter((year) => year.isDirectory()).map((year) => {

--- a/pages/grants/[slug].js
+++ b/pages/grants/[slug].js
@@ -95,7 +95,8 @@ export default function Grant({ post, markdown, match, search }) {
         image={match.data.image}
         color={match.data.bgColor || "#000000"}
         description={match.data?.description || ""}
-        type="Application"
+        type="application"
+        shortcode={post.extra.deliverable}
         full
       />
     }

--- a/pages/grants/[slug].js
+++ b/pages/grants/[slug].js
@@ -11,17 +11,20 @@ import {
   Section,
   IntraNav,
   getPostBySlug,
-  getAllPosts,
+  getPage,
   formatDate,
 } from "@urbit/foundation-design-system";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
+import MetadataBlock from "../../components/ecosystem/MetadataBlock";
+import ResourceCard from "../../components/gateway/ResourceCard";
+import JoinGroup from "../../components/JoinGroup";
 import ob from "urbit-ob";
 import { DateTime } from "luxon";
 import fs from 'fs';
-import { join } from 'path';
+import path, { join } from 'path';
 
-export default function Grant({ post, markdown, search }) {
+export default function Grant({ post, markdown, match, search }) {
   const router = useRouter();
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage />;
@@ -65,6 +68,44 @@ export default function Grant({ post, markdown, search }) {
       );
     });
 
+  let status = "";
+  if (isOpen) {
+    status = "Open"
+  } else if (post?.extra?.completed) {
+    status = "Completed"
+  } else if (post?.extra?.canceled) {
+    status = "Canceled"
+  } else {
+    status = "In Progress"
+  }
+  const statusBadge = <div className={
+    classnames("badge-sm mr-1 my-1", {
+      "bg-red": status === "Canceled",
+      "bg-green-400 text-white": status === "Completed" || status === "Open",
+      "bg-wall-300": status === "In Progress",
+    })}>
+    {status}
+  </div>;
+
+  let deliverable = null;
+  if (post.extra.deliverable) {
+    if (match) {
+      deliverable = <ResourceCard
+        title={match.data.title}
+        image={match.data.image}
+        color={match.data.bgColor || "#000000"}
+        description={match.data?.description || ""}
+        type="Application"
+        full
+      />
+    }
+    else if (post.extra.deliverable.startsWith("~")) {
+      deliverable = <JoinGroup emphasize groupName={post.extra.deliverable} />
+    } else {
+      deliverable = <a className="font-medium text-green-400" href={post.extra.deliverable}>{post.extra.deliverable}</a>
+    }
+  }
+
   const metaPost = Object.assign({}, post);
   metaPost.title = `${post.title} - Grant`;
 
@@ -79,38 +120,8 @@ export default function Grant({ post, markdown, search }) {
         <Header search={search} />
         <Section narrow short>
           <h1>{post.title}</h1>
-          {post.extra.assignee ? (
-            <div className="type-ui text-wall-500 mt-4">
-              Grantee(s): {assigneeLink}
-            </div>
-          ) : null}
-          {post.extra.mentor ? (
-            <div className="type-ui text-wall-500 mt-4">
-              Mentor: {mentorLink}
-            </div>
-          ) : null}
-          {post.extra.champion ? (
-            <div className="type-ui text-wall-500 mt-4">
-              Champion: {mentorLink}
-            </div>
-          ) : null}
-          {post.extra.ship ? (
-            <Link href={`/ids/${post.extra.ship}`} passHref>
-              <a className="type-sub-bold text-wall-500 font-mono">
-                {post.extra.ship}
-              </a>
-            </Link>
-          ) : null}
-          <div className="type-ui text-wall-500 mt-4 md:mt-8 lg:mt-10 flex items-center space-x-1">
-            {formatDate(DateTime.fromISO(post.date))}
-            {post?.extra?.grant_id ? (
-              <>
-                <p className="ml-1 text-wall-500 type-ui">• ID:</p>
-                <p className="font-mono type-ui"> {post.extra.grant_id}</p>
-              </>
-            ) : null}
-          </div>
-          <div className="flex items-center flex-wrap mt-4 md:mt-8 lg:mt-10">
+          <div className="flex items-center flex-wrap my-4">
+            {statusBadge}
             {post.taxonomies.grant_type.map((category) => {
               const className = classnames({
                 "bg-blue-400 text-white": category === "Proposal",
@@ -129,6 +140,46 @@ export default function Grant({ post, markdown, search }) {
               </div>
             ))}
           </div>
+          <div className="flex flex-wrap md:flex-nowrap justify-between">
+            {post?.extra?.grant_id ? (
+              <>
+                <MetadataBlock
+                  title="ID"
+                  content={post.extra.grant_id}
+                />
+              </>
+            ) : null}
+            <MetadataBlock
+              title="Date"
+              content={formatDate(DateTime.fromISO(post.date))}
+            />
+            {post.extra.mentor ? (
+              <MetadataBlock
+                title="Mentor"
+                content={mentorLink}
+              />
+            ) : null}
+            {post.extra.champion ? (
+              <MetadataBlock
+                title="Champion"
+                content={mentorLink}
+              />
+            ) : null}
+            {post.extra.assignee ? (
+              <MetadataBlock
+                title="Grantee(s)"
+                content={assigneeLink}
+              />
+            ) : null}
+          </div>
+          {post?.extra?.link?.startsWith("~") && <div className="flex flex-col my-4 space-y-2">
+            <p className="text-wall-400 font-semibold">Group</p>
+            <JoinGroup emphasize groupName={post.extra.link} />
+          </div>}
+          {deliverable && <div className="flex flex-col my-4 space-y-2">
+            <p className="text-wall-400 font-semibold">Deliverable</p>
+            {deliverable}
+          </div>}
         </Section>
         <Section narrow className="markdown">
           <Markdown.render content={JSON.parse(markdown)} />
@@ -149,6 +200,7 @@ export default function Grant({ post, markdown, search }) {
 }
 
 export async function getStaticProps({ params }) {
+  // Gets post in any year folder sharing the slug name in the param
   const basePath = join(process.cwd(), 'content/grants')
   const years = fs.readdirSync(basePath, { 'withFileTypes': true }).filter((f) => f.isDirectory());
   const dir = years.find((year) => {
@@ -162,8 +214,23 @@ export async function getStaticProps({ params }) {
   )
 
   const markdown = JSON.stringify(Markdown.parse({ post }));
+
+  // Matches deliverable to page
+  let match = null;
+  if (post?.extra?.deliverable?.startsWith("~")) {
+    const ship = post.extra.deliverable.split("/")[0];
+    const application = post.extra.deliverable.split("/")[1];
+    const fileExists = fs.existsSync(path.join(process.cwd(), "content/applications", ship, `${application}.md`));
+    match = fileExists ? getPage(
+      join(
+        process.cwd(),
+        "content/applications",
+        post.extra.deliverable
+      )
+    ) : null
+  }
   return {
-    props: { post, markdown },
+    props: { post, markdown, match },
   };
 }
 

--- a/pages/organizations/[slug].js
+++ b/pages/organizations/[slug].js
@@ -52,7 +52,7 @@ export default function Organization({
                     }}
                   >
                     {app.image && (
-                      <img src={app.image} className="h-full w-full" />
+                      <img src={app.image} className="h-full w-full" style={{ aspectRatio: "1" }} />
                     )}
                   </div>
                   <p className="text-center font-bold font-xl">{app.title}</p>


### PR DESCRIPTION
Fixes #1874 

- I personally dislike seeing the years in search so now they say "Grants" again.
- Incidentally found a weird bug where non-square icons had a black border on some organisation pages and fixed that too.
- Broke out some components and revised others for the new grants additions (full-width resource cards, etc).
- Grants surface groups (`link = "~ship-name/group-name"`) and applications (`deliverable = "~ship-name/application-name"` or `deliverable = "https://github.com/shipname/deliverable"`). Groups do not surface metadata, but applications do. They attempt to match applications by the shortcode we have onhand for the page URL, not their literal shortcode for distribution. As an example, some applications are distributed through a `~dister` moon, but their application page on urbit.org is simply under their planet name. The deliverable entry should then use their planet name, not the moon.
- If no metadata exists for the application, we fall back to a copy link component.
- If the deliverable is instead a URL, we surface a URL.
- Applications look for any grant that has them as a shortcode, and surface it in turn.

Did responsive and dark mode testing, but I could be wrong ... I'd recommend propagating some data for grants in this PR for a day or two and then merging after we feel satisfied with it.

<img width="816" alt="Screen Shot 2022-11-01 at 12 56 34 PM" src="https://user-images.githubusercontent.com/20846414/199341890-851522a5-2cf3-47ba-aad6-1445ae051674.png">

<img width="821" alt="Screen Shot 2022-11-01 at 2 01 34 PM" src="https://user-images.githubusercontent.com/20846414/199341911-e0de3ed0-0011-49a1-9b4c-024e02d9f0a2.png">
