### PR TITLE
metadatablock: always use 1/2 basis

### DIFF
--- a/components/ecosystem/MetadataBlock.js
+++ b/components/ecosystem/MetadataBlock.js
@@ -1,5 +1,5 @@
 export default function MetadataBlock({ title, content }) {
-    return <div className="flex flex-col py-2 basis-1/2 md:basis-auto">
+    return <div className="flex flex-col py-2 basis-1/2">
         <p className="font-bold text-wall-400">{title}</p>
         <p>{content}</p>
     </div>

--- a/pages/grants/[slug].js
+++ b/pages/grants/[slug].js
@@ -142,7 +142,7 @@ export default function Grant({ post, markdown, match, search }) {
               </div>
             ))}
           </div>
-          <div className="flex flex-wrap md:flex-nowrap justify-between">
+          <div className="flex flex-wrap justify-between">
             {post?.extra?.grant_id ? (
               <>
                 <MetadataBlock


### PR DESCRIPTION
Quick go at it. Fixes #1885

Any better @thelifeandtimes? This also affects app pages, group pages, ID pages etc but none of those have as many content in the metadata.