### PR TITLE
pages/applications: remove related grants if none available

### DIFF
--- a/pages/applications/[[...application]].js
+++ b/pages/applications/[[...application]].js
@@ -111,7 +111,7 @@ const ApplicationPage = ({ data, markdown, organisation, matchedGrants, search, 
             markdown={markdown}
           />
           <hr className="text-wall-200" />
-          {matchedGrants && <div className="basis-full flex flex-col space-y-2">
+          {matchedGrants.length > 0 && <div className="basis-full flex flex-col space-y-2">
             <p className="font-semibold text-wall-400">Related Grants</p>
             {matchedGrants.map((grant) => {
               return <GrantPreview grant={grant} />
@@ -181,7 +181,7 @@ export const getServerSideProps = async ({ params, res }) => {
       ? JSON.stringify(Markdown.parse({ post: { content } }))
       : null;
 
-  const matchedGrants = getGrantsByShortcode(params.application) || null;
+  const matchedGrants = getGrantsByShortcode(params.application);
 
   if (!data.title) {
     data = {


### PR DESCRIPTION
Fixes #1895

I was confused because I did write all the fallback logic to just hide the section; but it turns out the getGrantsByShortcode function I wrote falls back to an empty array, which is truthy, so we don't pass null, so there's *always* a `matchedGrants` value and thus it was showing. Since we know there's always the array, we check length of the array now.