### PR TITLE
Berlin meetups

### DIFF
--- a/content/community/meetups.md
+++ b/content/community/meetups.md
@@ -26,6 +26,7 @@ Interested in hosting an Urbit event of your own? Follow our [guide to meetup be
 | Location       | Contact information                                                                             |
 | :------------- | :---------------------------------------------------------------------------------------------- |
 | Copenhagen, DK | [Twitter](https://twitter.com/UrbitCPH), [Meetup.com](https://www.meetup.com/Urbit-Copenhagen/) |
+| Berlin, DE     | [Meetup.com](https://www.meetup.com/urbit-berlin/)                                              |
 
 ### North America
 


### PR DESCRIPTION
Meeting in Berlin, Germany

~bithex-topnym is the host. There is an existing group hosted by ~nodnyd-hapsud: /1/group/~nodnyd-hapsud/berlin

Clearweb:
Meetup.com: https://www.meetup.com/urbit-berlin

I will try to get a recurring place to meet at. I have messaged [C-base](https://en.wikipedia.org/wiki/C-base) and [Full Node](https://www.fullnode.berlin/). I want to make sure there is some ability to get on the network each meeting, by either having some moons pre-spawned for people, or simply handing out planets. I want to get some short-ish presentation going, or do some workshopping -- setting up an environment to start Hoon school, moving to self-hosting -- each time. If the place we are at can't accommodate drinks or food we will move somewhere for food and/or drinks after. I anticipate people can join the technical meetup portion, the social portion, or both.