### PR TITLE
Update binary links to pull from new runtime repo

### DIFF
--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -42,7 +42,7 @@ download the Urbit runtime:
 {% tab label="Linux AArch64" %}
 
 ```shell
-curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --strip=1 && ./urbit
+curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk && ./urbit
 ```
 
 > Linux users may need to run this command in another terminal window to access
@@ -58,7 +58,7 @@ curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --strip=1 && ./
 {% tab label="Linux x86_64" %}
 
 ```shell
-curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --strip=1 && ./urbit
+curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk && ./urbit
 ```
 
 > Linux users may need to run this command in another terminal window to access
@@ -74,7 +74,7 @@ curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --strip=1 && ./u
 {% tab label="macOS AArch64" %}
 
 ```bash
-curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk --strip=1 && ./urbit
+curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk && ./urbit
 ```
 
 > Note this build is only compatible with Apple Silicon (M1/M2) via Rosetta.
@@ -89,7 +89,7 @@ curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk --strip=1 && ./
 {% tab label="macOS x86_64" %}
 
 ```bash
-curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk --strip=1 && ./urbit
+curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk && ./urbit
 ```
 
 {% /tab %}

--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -39,7 +39,7 @@ download the Urbit runtime:
 
 {% tabs %}
 
-{% tab label="Linux (`aarch64`)" %}
+{% tab label="Linux AArch64" %}
 
 ```shell
 curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --strip=1 && ./urbit
@@ -55,7 +55,7 @@ curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --strip=1 && ./
 
 {% /tab %}
 
-{% tab label="Linux (`x86_64`)" %}
+{% tab label="Linux x86_64" %}
 
 ```shell
 curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --strip=1 && ./urbit
@@ -71,7 +71,7 @@ curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --strip=1 && ./u
 
 {% /tab %}
 
-{% tab label="macOS (`aarch64`)" %}
+{% tab label="macOS AArch64" %}
 
 ```bash
 curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk --strip=1 && ./urbit
@@ -86,7 +86,7 @@ curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk --strip=1 && ./
 
 {% /tab %}
 
-{% tab label="macOS (`x86_64`)" %}
+{% tab label="macOS x86_64" %}
 
 ```bash
 curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk --strip=1 && ./urbit

--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -39,40 +39,7 @@ download the Urbit runtime:
 
 {% tabs %}
 
-{% tab label="MacOS" %}
-
-```bash
-curl -L https://urbit.org/install/mac/latest | tar xzk --strip=1 && ./urbit
-```
-
-> Note our Mac build is only compatible with Apple Silicon (M1/M2) via Rosetta.
-> If you have such a machine you may need to run the following command:
->
-> ```
-> /usr/sbin/softwareupdate --install-rosetta --agree-to-license
-> ```
-
-{% /tab %}
-
-{% tab label="Linux" %}
-
-```shell
-curl -L https://urbit.org/install/linux64/latest | tar xzk --strip=1 && ./urbit
-```
-
-> Linux users may need to run this command in another terminal window to access
-> your urbit on port 80:
->
-> ```shell
-> sudo apt-get install libcap2-bin
-> sudo setcap 'cap_net_bind_service=+ep' ./urbit
-> ```
-
-{% /tab %}
-
-{% tab label="Linux ARM64" %}
-
-Note this is for the AArch64 architecture.
+{% tab label="Linux (`aarch64`)" %}
 
 ```shell
 curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --strip=1 && ./urbit
@@ -88,18 +55,42 @@ curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --strip=1 && ./
 
 {% /tab %}
 
-{% tab label="Windows" %}
+{% tab label="Linux (`x86_64`)" %}
 
-```winbatch
-curl -L https://urbit.org/install/windows/latest | tar -xzkf - --strip-components=1 && urbit
+```shell
+curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --strip=1 && ./urbit
 ```
 
-> Windows 10 build 17063 and later includes the familiar `curl` and `tar`
-> command-line tools. If you're running an older version of Windows, you may need
-> to visit
-> [https://github.com/urbit/urbit/releases/latest](https://github.com/urbit/urbit/releases/latest)
-> in the browser, download the `windows.zip` file, extract it and execute the
-> contained `urbit.exe` file in the command prompt.
+> Linux users may need to run this command in another terminal window to access
+> your urbit on port 80:
+>
+> ```shell
+> sudo apt-get install libcap2-bin
+> sudo setcap 'cap_net_bind_service=+ep' ./urbit
+> ```
+
+{% /tab %}
+
+{% tab label="macOS (`aarch64`)" %}
+
+```bash
+curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk --strip=1 && ./urbit
+```
+
+> Note this build is only compatible with Apple Silicon (M1/M2) via Rosetta.
+> If you have such a machine you may need to run the following command:
+>
+> ```
+> /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+> ```
+
+{% /tab %}
+
+{% tab label="macOS (`x86_64`)" %}
+
+```bash
+curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk --strip=1 && ./urbit
+```
 
 {% /tab %}
 

--- a/content/getting-started/cli.md
+++ b/content/getting-started/cli.md
@@ -42,7 +42,7 @@ download the Urbit runtime:
 {% tab label="Linux AArch64" %}
 
 ```shell
-curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk && ./urbit
+curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk --strip=1 && ./urbit
 ```
 
 > Linux users may need to run this command in another terminal window to access
@@ -58,7 +58,7 @@ curl -L https://urbit.org/install/linux-aarch64/latest | tar xzk && ./urbit
 {% tab label="Linux x86_64" %}
 
 ```shell
-curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk && ./urbit
+curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk --strip=1 && ./urbit
 ```
 
 > Linux users may need to run this command in another terminal window to access
@@ -74,7 +74,7 @@ curl -L https://urbit.org/install/linux-x86_64/latest | tar xzk && ./urbit
 {% tab label="macOS AArch64" %}
 
 ```bash
-curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk && ./urbit
+curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk --strip=1 && ./urbit
 ```
 
 > Note this build is only compatible with Apple Silicon (M1/M2) via Rosetta.
@@ -89,7 +89,7 @@ curl -L https://urbit.org/install/macos-aarch64/latest | tar xzk && ./urbit
 {% tab label="macOS x86_64" %}
 
 ```bash
-curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk && ./urbit
+curl -L https://urbit.org/install/macos-x86_64/latest | tar xzk --strip=1 && ./urbit
 ```
 
 {% /tab %}

--- a/vercel.json
+++ b/vercel.json
@@ -98,12 +98,12 @@
     },
     {
       "source": "/install/linux-aarch64/latest",
-      "destination": "https://github.com/urbit/urbit/releases/latest/download/linux-aarch64.tgz",
+      "destination": "https://github.com/urbit/vere/releases/latest/download/linux-aarch64.tgz",
       "permanent": true
     },
     {
       "source": "/install/linux-x86_64/latest",
-      "destination": "https://github.com/urbit/urbit/releases/latest/download/linux-x86_64.tgz",
+      "destination": "https://github.com/urbit/vere/releases/latest/download/linux-x86_64.tgz",
       "permanent": true
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -4,28 +4,28 @@
   },
   "redirects": [
     {
-    "source": "/groups/~wolref-podlex/foundation",
-    "destination": "/groups/~halbex-palheb/uf-public"
+      "source": "/groups/~wolref-podlex/foundation",
+      "destination": "/groups/~halbex-palheb/uf-public"
     },
     {
-     "source": "/docs/getting-started",
-     "destination": "/getting-started"
+      "source": "/docs/getting-started",
+      "destination": "/getting-started"
     },
     {
-     "source": "/getinvolved",
-     "destination": "https://developers.urbit.org/blog/get-involved"
+      "source": "/getinvolved",
+      "destination": "https://developers.urbit.org/blog/get-involved"
     },
     {
-     "source": "/getting-started/server",
-     "destination": "/getting-started/cli"
+      "source": "/getting-started/server",
+      "destination": "/getting-started/cli"
     },
     {
-     "source": "/applications",
-     "destination": "/ecosystem?type=applications"
+      "source": "/applications",
+      "destination": "/ecosystem?type=applications"
     },
     {
-     "source": "/understanding-urbit/:path*",
-     "destination": "/overview/:path*"
+      "source": "/understanding-urbit/:path*",
+      "destination": "/overview/:path*"
     },
     {
       "source": "/blog/layer-2-guides",
@@ -97,23 +97,23 @@
       "permanent": true
     },
     {
-      "source": "/install/mac/latest",
-      "destination": "https://github.com/urbit/urbit/releases/latest/download/darwin.tgz",
-      "permanent": true
-    },
-    {
-      "source": "/install/linux64/latest",
-      "destination": "https://github.com/urbit/urbit/releases/latest/download/linux64.tgz",
-      "permanent": true
-    },
-    {
       "source": "/install/linux-aarch64/latest",
       "destination": "https://github.com/urbit/urbit/releases/latest/download/linux-aarch64.tgz",
       "permanent": true
     },
     {
-      "source": "/install/windows/latest",
-      "destination": "http://github.com/urbit/urbit/releases/latest/download/windows.tgz",
+      "source": "/install/linux-x86_64/latest",
+      "destination": "https://github.com/urbit/urbit/releases/latest/download/linux-x86_64.tgz",
+      "permanent": true
+    },
+    {
+      "source": "/install/macos-aarch64/latest",
+      "destination": "https://github.com/urbit/vere/releases/latest/download/macos-aarch64.tgz",
+      "permanent": true
+    },
+    {
+      "source": "/install/macos-x86_64/latest",
+      "destination": "https://github.com/urbit/vere/releases/latest/download/macos-x86_64.tgz",
       "permanent": true
     },
     {


### PR DESCRIPTION
WIP until final filenames/URLs are confirmed.

See https://github.com/urbit/developers.urbit.org/pull/268 for similar `developers.urbit.org` changes.