### PR TITLE
Updating Dalten / Quartus related ecosystem pages

### DIFF
--- a/content/applications/~dister-dozzod-dalten/books.md
+++ b/content/applications/~dister-dozzod-dalten/books.md
@@ -1,8 +1,8 @@
 +++
-title = "books"
+title = "Books"
 developer = "Quartus Co."
-shortcode = "~doller-doller-rabsef-bicrym/books"
-description = "it just makes cents"
+shortcode = "~dister-dozzod-dalten/books"
+description = "It just makes cents"
 license = "MIT"
 website = "https://dalten.org"
 bgColor = "#E44D11"

--- a/content/applications/~dister-dozzod-dalten/gora.md
+++ b/content/applications/~dister-dozzod-dalten/gora.md
@@ -21,3 +21,4 @@ Gora has two distros in
 circulation - these can be found at:
 ~laddys-dozzod-dalten (Vue.js frontend)
 ~mister-dozzod-dalten (sail frontend)
+The canonical distro for all Quartus and Dalten Collective apps can always be found at ~dister-dozzod-dalten

--- a/content/applications/~dister-dozzod-dalten/keep.md
+++ b/content/applications/~dister-dozzod-dalten/keep.md
@@ -1,0 +1,13 @@
++++
+title = "Keep"
+developer = "Quartus Co."
+shortcode = "~dister-dozzod-dalten/keep"
+description = "State backup for your agents"
+license = "MIT"
+website = "https://dalten.org"
+bgColor = "#E44D11"
++++
+
+Keep is backup utility for preserving the state of your applications across breaches. Unlike [peat](https://urbit.org/ecosystem/applications/~dister-dozzod-dalten/peat), Keep can backup the state of any arbitrary agent, but does not offer granular control of specific graphs or other targeted contexts.
+
+For support with any of Quartus' applications, please visit the [Quartus public group](https://urbit.org/ecosystem/groups/~mister-hilper-dozzod-dalten/quartus)

--- a/content/applications/~dister-dozzod-dalten/orca.md
+++ b/content/applications/~dister-dozzod-dalten/orca.md
@@ -1,12 +1,14 @@
 +++
-title = "orca"
-developer = "~dalten"
-shortcode = "~magped-magped-rabsef-bicrym/orca"
+title = "Orca"
+developer = "Quartus Co."
+shortcode = "~dister-dozzod-dalten/orca"
 description = "Now THIS is podchatting"
 license = "MIT"
 website = "https://dalten.org"
 bgColor = "#13181C"
 +++
+
+** ocra has been deprecated and will soon be replaced with updated tooling supporting chat federation for the new Groups backend **
 
 Now THIS is podchatting
 

--- a/content/applications/~dister-dozzod-dalten/peat.md
+++ b/content/applications/~dister-dozzod-dalten/peat.md
@@ -1,14 +1,14 @@
 +++
 title = "peat"
 developer = "Quartus Co."
-shortcode = "~magped-magped-rabsef-bicrym/peat"
+shortcode = "~dister-dozzod-dalten/peat"
 description = "Graph Backup and Restoration Utility"
 license = "REKT"
 website = "https://dalten.org"
 bgColor = "#574D5A"
 +++
 
-Peat is Urbit's first backup utility.
+Peat is Urbit's first backup utility and works with the %graph-store backend. Quartus is also working to support backup and recovery for arbitrary agent state via %keep, as well as updated utility tooling that supports the new Groups backend.
 
 ![Screenshot](https://storage.googleapis.com/media.urbit.org/site/ecosystem/applications/peat.png)
 

--- a/content/applications/~dister-dozzod-dalten/wrdu.md
+++ b/content/applications/~dister-dozzod-dalten/wrdu.md
@@ -1,8 +1,8 @@
 +++
 title = "wrdu"
-developer = "~dalten"
-shortcode = "~magped-magped-rabsef-bicrym/wrdu"
-description = "word game by ~dalten for our mothers"
+developer = "Quartus Co."
+shortcode = "~dister-dozzod-dalten/wrdu"
+description = "Word game by ~dalten for our mothers"
 license = "MIT"
 website = "https://dalten.org"
 bgColor = "#79A86B"

--- a/content/groups/~dalten/aera.md
+++ b/content/groups/~dalten/aera.md
@@ -1,0 +1,10 @@
++++
+title = "Quartus"
+shortcode = "~mister-hilper-dozzod-dalten/quartus"
+description = "Applications, Tech Support, and Community with Quartus"
+type = "Public"
+tile = "https://freedom-club.sfo2.digitaloceanspaces.com/rabsef-bicrym/2022.2.03..19.39.35-vertical_on_corporate_by_logaster.png"
+participant_range = "200+"
++++
+
+The Quartus public group is a place to find up to date application distribution information, get hands on tech support, and build community with other urbiters using the tools we build. 

--- a/content/groups/~mister-hilper-dozzod-dalten/quartus.md
+++ b/content/groups/~mister-hilper-dozzod-dalten/quartus.md
@@ -1,0 +1,10 @@
++++
+title = "Quartus"
+shortcode = "~mister-hilper-dozzod-dalten/quartus"
+description = "Applications, Tech Support, and Community with Quartus"
+type = "Public"
+tile = "https://freedom-club.sfo2.digitaloceanspaces.com/rabsef-bicrym/2022.2.03..19.39.35-vertical_on_corporate_by_logaster.png"
+participant_range = "200+"
++++
+
+The Quartus public group is a place to find up to date application distribution information, get hands on tech support, and build community with other urbiters using the tools we build. 

--- a/content/organizations/quartus.md
+++ b/content/organizations/quartus.md
@@ -3,7 +3,7 @@ title = "Quartus by Dalten"
 description = "We build software using the novel affordances of Urbit."
 image = "https://freedom-club.sfo2.digitaloceanspaces.com/ab_Quartus-03.jpg"
 URL = "https://www.quartus.co/"
-ships = ["~mister-dozzod-dalten", "~laddys-dozzod-dalten", "~magped-magped-rabsef-bicrym", "~doller-doller-rabsef-bicrym"]
+ships = ["~mister-hilper-dozzod-dalten", "~dister-dozzod-dalten"]
 +++
 
 ### Quartus is Fulfilling Urbit's Covenant with Users
@@ -16,6 +16,6 @@ We build software, according to specification, on a contract basis. Contact one 
 
 ### Quartus is
 
-Headed by [~rabsef-bicrym](https://urbit.org/ids/~rabsef-bicrym), with Chief Products Officer [~sogrum-savluc](https://urbit.org/ids/~sogrum-savluc) and Chief Technical Officer [~wicrum-wicrun](https://urbit.org/ids/~wicrum-wicrun).
+Headed by [~rabsef-bicrym](https://urbit.org/ids/~rabsef-bicrym), with Chief Product Officer [~sogrum-savluc](https://urbit.org/ids/~sogrum-savluc), and Chief Technical Officer [~wicrum-wicrun](https://urbit.org/ids/~wicrum-wicrun), along with [~sarlev-sarsen](https://urbit.org/ids/~sarlev-sarsen) and [~simfur-ritwed](https://urbit.org/ids/~simfur-ritwed).
 
-Founded by [~sicdev-pilnup](https://urbit.org/ids/~sicdev-pilnup) and ~rabsef-bicrym, as a product of the [Dalten Collective](https://dalten.org/).
+Founded by [~sicdev-pilnup](https://urbit.org/ids/~sicdev-pilnup) and [~rabsef-bicrym](https://urbit.org/ids/~rabsef-bicrym), as a product of the [Dalten Collective](https://dalten.org/).


### PR DESCRIPTION
updating the Quartus app listings to occur under ~dister-dozzod-dalten and adding a few dalten/quartus related groups/apps.