### PR TITLE
Add 6 initial RFPs

### DIFF
--- a/content/grants/2023/network-weather.md
+++ b/content/grants/2023/network-weather.md
@@ -1,0 +1,24 @@
++++
+
+title = "Network Weather Simulator for %pyro/%aqua"
+date = "2023-03-02"
+
+[taxonomies]
+grant_type = ["Request"]
+grant_category = ["Core Dev"]
+
+[extra]
+image = ""
+description = "Network Weather Simulator for `%pyro`/`%aqua"
+reward = "TBD"
+assignee = [""]
+champion = [""]
+grant_id = "P1004"
+completed = false
+canceled = false
++++
+
+`%pyro` and `%aqua` are virtualization tools that allow developers to run one or many virtual ships within their ship. This opens up many testing possibilities, since it's possible to spin up an entire fleet of virtual ships with state and orchestrate them within your ship. But since all of hte ships run one one computer, the network conditions are unrealistically good. In the real world, network connections fail, time out and generally perform in unexpected ways.
+
+Write a library that allows developers to easily add realistic "network weather" to fleet testing in `%pyro`/`%aqua`
+

--- a/content/grants/2023/pastebin.md
+++ b/content/grants/2023/pastebin.md
@@ -10,7 +10,7 @@ grant_category = ["App Dev"]
 [extra]
 image = ""
 description = "Share plaintext snippets on Urbit"
-reward = ""
+reward = "TBD"
 assignee = [""]
 champion = [""]
 grant_id = "P1000"

--- a/content/grants/2023/pastebin.md
+++ b/content/grants/2023/pastebin.md
@@ -1,0 +1,24 @@
++++
+
+title = "Pastebin on Urbit"
+date = "2023-03-02"
+
+[taxonomies]
+grant_type = ["Request"]
+grant_category = ["App Dev"]
+
+[extra]
+image = ""
+description = "Share plaintext snippets on Urbit"
+reward = ""
+assignee = [""]
+champion = [""]
+grant_id = "P1000"
+completed = false
+canceled = false
+
++++
+
+Tools like pastebin and Github gists allow users to easily share plain text snippets. This is useful for sharing code or simple writeups.
+
+Implement minimal plaintext snippet sharing for Urbit, with support for both public (anyone with the path can read the snippet) and private (only invited individuals can read snippets).

--- a/content/grants/2023/text-search.md
+++ b/content/grants/2023/text-search.md
@@ -1,0 +1,24 @@
++++
+
+title = "Generic Text Search Tool for Urbit"
+date = "2023-03-02"
+
+[taxonomies]
+grant_type = ["Request"]
+grant_category = ["Core Dev"]
+
+[extra]
+image = ""
+description = "Build Urbit's answer to grep."
+reward = "TBD"
+assignee = [""]
+champion = [""]
+grant_id = "P1002"
+completed = false
+canceled = false
+
++++
+
+Text search is a key part of many different use cases, but Urbit currently has no equivalent to `grep`, the general purpose GNU search tool. 
+
+Build Urbit's answer to `grep`.

--- a/content/grants/2023/tinygrad.md
+++ b/content/grants/2023/tinygrad.md
@@ -1,0 +1,24 @@
++++
+
+title = "Tinygrad ML Library in Hoon"
+date = "2023-03-02"
+
+[taxonomies]
+grant_type = ["Request"]
+grant_category = ["Core Dev"]
+
+[extra]
+image = ""
+description = "Implement a small machine learning library (and jets!) in hoon."
+reward = "TBD"
+assignee = [""]
+champion = [""]
+grant_id = "P1003"
+completed = false
+canceled = false
+
++++
+
+Geohot has published the [Tinygrad library](https://github.com/geohot/tinygrad) for doing basic machine learning. This library is small and simple which makes it a potentially good target for jetting. Doing so would give basic ML functionality in Urbit.
+
+Implement Tinygrad (with jets) in Urbit

--- a/content/grants/2023/treesitter.md
+++ b/content/grants/2023/treesitter.md
@@ -1,0 +1,24 @@
++++
+
+title = "Treesitter Hoon Parser"
+date = "2023-03-02"
+
+[taxonomies]
+grant_type = ["Request"]
+grant_category = ["Core Dev"]
+
+[extra]
+image = ""
+description = "Create a better hoon parser with Treesitter"
+reward = "TBD"
+assignee = [""]
+champion = [""]
+grant_id = "P1001"
+completed = false
+canceled = false
+
++++
+
+[Tree-sitter](https://github.com/tree-sitter/tree-sitter) represents the state of the art for multi-language parsing. It is used by Atom and Github to parse any language, on every keystroke, in an editor.
+
+Use tree-sitter to write a superior hoon parser.

--- a/content/grants/2023/update-mass.md
+++ b/content/grants/2023/update-mass.md
@@ -1,0 +1,26 @@
++++
+
+title = "Modernize |mass"
+date = "2023-03-02"
+
+[taxonomies]
+grant_type = ["Request"]
+grant_category = ["Core Dev"]
+
+[extra]
+image = ""
+description = "Update the |mass utility to reinject the output into arvo from the runtime."
+reward = "TBD"
+assignee = [""]
+champion = [""]
+grant_id = "P1001"
+completed = false
+canceled = false
+
++++
+
+`|mass` is a utility for measuring a pier's resource usage. It is used for debugging and development. Currently, the output of this utility is a mixture of data from within arvo and from the runtime. This heterogeneity means that what is produced is not a noun but interleaved print statements to the terminal. 
+
+Once `|mass` produces a noun, it can be sent to other ships over `%ames` for bug reports, collected in a central location or analyzed for further action by arvo.
+
+Update the `|mass` utility to reinject the output into arvo from the runtime.


### PR DESCRIPTION
Adds RFPs for 

- Network Weather simulation in `%pyro`
- `grep`-like text search tool
- Tinygrad implementation in hoon
 - Treesitter hoon parser
 - Modernizing `|mass`

None of these have work IDs or work request urls which seems appropriate to me since they'll get them should they be submitted as proposals. 
