### PR TITLE
updating featured card with new HSL link

### DIFF
--- a/content/highlights/highlight-3.md
+++ b/content/highlights/highlight-3.md
@@ -1,6 +1,6 @@
 +++
-title = "Hoon School Live March 23'"
-image = "https://storage.googleapis.com/media.urbit.org/site/featured/hoon-school-23.png"
+title = "Hoon School Live Summer '23"
+image = "https://storage.googleapis.com/media.urbit.org/site/featured/hsl-june-2023.png"
 url="https://developers.urbit.org/courses/hsl"
-description = "Sign up now to learn the basics of Urbit development."
+description = "Sign up now to learn the foundations of Urbit development."
 +++


### PR DESCRIPTION
I updated developers.urbit.org to include a link to a featured c2a to the next hoon school since the current one was out of date.  Doing the same on urbit.org.