### PR TITLE
Added UrbitSG Page

### DIFF
--- a/content/communities/urbit-sg.md
+++ b/content/communities/urbit-sg.md
@@ -1,0 +1,21 @@
++++
+title = "Urbit SG"
+description = ""
+image = "https://doppeg-tonwel.github.io/assets/images/urbitsg-redlky.jpg"
++++
+
+From Third World to Fourth.
+
+The first of many Urbit communities in SEA, UrbitSG provides the phone lines for both _sinkies_ and our friendly neighbours with regards to the Urbit ecosystem.
+
+We know it sounds damn _cheem_, so we'll have regular workshops and presentations to get you started and guide you along the way.
+
+Don't say _bojio_, just join only.
+
+––
+
+~monmus-migsyp/urbitsg
+
+[Organiser's Twitter](https://www.twitter.com/doppeg_tonwel)
+
+[Telegram](https://t.me/urbitsg)


### PR DESCRIPTION
Adding UrbitSG to the communities page. Image is currently stored in my github page (https://doppeg-tonwel.github.io/assets/images/urbitsg-redlky.jpg). An alternative, less received image would be https://doppeg-tonwel.github.io/assets/images/urbitsg-mbs.jpg