### PR TITLE
Malformed newlines in chat bots grant

### DIFF
--- a/content/grants/2024/tlon-chat-bots.md
+++ b/content/grants/2024/tlon-chat-bots.md
@@ -64,8 +64,8 @@ Reward: 1 Star
 
 The ideas below are meant to minimally showcase common use case patterns we expect for chatbots in groups. The idea is that most apps likely follow one of these patterns, allowing devs to build their bots with minimal effort by selecting the correct sample and modifying it to their needs.
 
-*Reminder* - @ yourself with a reminder after a certain amount of time passes.
-*Downtime* - Receive alerts when HTTP endpoints become unreachable.
+*Reminder* - @ yourself with a reminder after a certain amount of time passes.  
+*Downtime* - Receive alerts when HTTP endpoints become unreachable.  
 *Triviality* - Trivia game powered by OpenAI’s API
 
 Each bot sample above intends to cover a common category of bot that we expect.


### PR DESCRIPTION
Currently, Milestone 2 has a section that looks like this:

<img width="1013" alt="Screenshot 2024-07-02 at 2 40 45 a m" src="https://github.com/urbit/urbit.org/assets/104947308/7a30fb13-9c92-458f-bc33-d32f22d038db">

Markdown mungs single newlines unless you add two spaces at the end. This PR adds the spaces so that the newlines render correctly.
