### PR TITLE
Create Subassembly PNW listing

### DIFF
--- a/content/events/2024-10-20-Subassembly-PNW.md
+++ b/content/events/2024-10-20-Subassembly-PNW.md
@@ -1,26 +1,28 @@
-+++ 
-title = "Subassembly PNW" 
-starts = "2024-10-20T14:00:00" 
-ends = "2024-10-22T11:00:00" 
-timezone = "America/Pacific" 
-location = "Wellspring Spa & Woodland Retreat - 154922 Kernahan Rd E, Ashford, WA 98304" 
-image = "https://sfo3.digitaloceanspaces.com/sarlev-sarsen/sarlev-sarsen/2024.5.16..5.20.19..6f5c.28f5.c28f.5c28-image.png" 
-registration_url = "https://docs.google.com/forms/d/e/1FAIpQLSfbHcFLRgGKBW91qINxhZ6TAgSDgsY_ikG1ATauHL7AVeLqDA/viewform" 
-event_details = "https://subassembly.tocwexsyndicate.com/details.html"
-description = "a community gathering about identity, trust, and reputation" 
-dark = true 
++++
+title = "Subassembly PNW"
+starts = "2024-10-20T14:00:00"
+ends = "2024-10-22T11:00:00"
+timezone = "America/Pacific"
+location = "Wellspring Spa & Woodland Retreat - 154922 Kernahan Rd E, Ashford, WA 98304"
+image = "https://sfo3.digitaloceanspaces.com/sarlev-sarsen/sarlev-sarsen/2024.5.16..5.20.19..6f5c.28f5.c28f.5c28-image.png"
+links = [
+  { label = "Register", url = "https://docs.google.com/forms/d/e/1FAIpQLSfbHcFLRgGKBW91qINxhZ6TAgSDgsY_ikG1ATauHL7AVeLqDA/viewform" },
+  { label = "Event Details", url = "https://subassembly.tocwexsyndicate.com/details.html" }
+]
+description = "a community gathering about identity, trust, and reputation"
+dark = true
 darken_image = "true"
 +++
 
-Inspired by the scale and connections made during Urbit developer summits such as the Volcano Summit and Lake Summit, Subassembly PNW is the inaugural occurrence of the subassembly community event series. 
+Inspired by the scale and connections made during Urbit developer summits such as the Volcano Summit and Lake Summit, Subassembly PNW is the inaugural occurrence of the subassembly community event series.
 
 By gathering in focused groups who are interested not just in Urbit as a technology, but who are interested in building "Urbit as a Society", we aim to make the coordination of reality a major focus of Urbit. The early tools and primitives are ready, and the timing is viciously elegant.
 
 As legacy society accelerates it's migration to the digital realm, which holds both the extremely dangerous potential for a loss of long-held context and values in the process of translation, we see Urbit as a place for those seeking tools to allow dramatically more agentic coordination.
 
-Core to Urbit are the opportunities it offers to free capital, capacity, and trust loose from their rotting bindings, and assemble them into functional organs of a human-oriented digital civilization. 
+Core to Urbit are the opportunities it offers to free capital, capacity, and trust loose from their rotting bindings, and assemble them into functional organs of a human-oriented digital civilization.
 
-If you are a visionary in building new systems of self-sovereign human organization— Whether you're a developer, investor, poet, creator, artist, entrepreneur, product manager, or the mastermind behind a startup—this is your moment. 
+If you are a visionary in building new systems of self-sovereign human organization— Whether you're a developer, investor, poet, creator, artist, entrepreneur, product manager, or the mastermind behind a startup—this is your moment.
 
 We invite you to join us in the foothills of Mount Rainier, this October 20th-22nd, 2024, to discuss and plan the representation of reality and the possibilities of its coordination on the Urbit network.
 

--- a/content/events/2024-10-20-Subassembly-PNW.md
+++ b/content/events/2024-10-20-Subassembly-PNW.md
@@ -1,0 +1,43 @@
++++ 
+title = "Subassembly PNW" 
+starts = "2024-10-20T14:00:00" 
+ends = "2024-10-22T11:00:00" 
+timezone = "America/Pacific" 
+location = "Wellspring Spa & Woodland Retreat - 154922 Kernahan Rd E, Ashford, WA 98304" 
+image = "https://sfo3.digitaloceanspaces.com/sarlev-sarsen/sarlev-sarsen/2024.5.16..5.20.19..6f5c.28f5.c28f.5c28-image.png" 
+registration_url = "https://docs.google.com/forms/d/e/1FAIpQLSfbHcFLRgGKBW91qINxhZ6TAgSDgsY_ikG1ATauHL7AVeLqDA/viewform" 
+event_details = "https://subassembly.tocwexsyndicate.com/details.html"
+description = "a community gathering about identity, trust, and reputation" 
+dark = true 
+darken_image = "true"
++++
+
+Inspired by the scale and connections made during Urbit developer summits such as the Volcano Summit and Lake Summit, Subassembly PNW is the inaugural occurrence of the subassembly community event series. 
+
+By gathering in focused groups who are interested not just in Urbit as a technology, but who are interested in building "Urbit as a Society", we aim to make the coordination of reality a major focus of Urbit. The early tools and primitives are ready, and the timing is viciously elegant.
+
+As legacy society accelerates it's migration to the digital realm, which holds both the extremely dangerous potential for a loss of long-held context and values in the process of translation, we see Urbit as a place for those seeking tools to allow dramatically more agentic coordination.
+
+Core to Urbit are the opportunities it offers to free capital, capacity, and trust loose from their rotting bindings, and assemble them into functional organs of a human-oriented digital civilization. 
+
+If you are a visionary in building new systems of self-sovereign human organization— Whether you're a developer, investor, poet, creator, artist, entrepreneur, product manager, or the mastermind behind a startup—this is your moment. 
+
+We invite you to join us in the foothills of Mount Rainier, this October 20th-22nd, 2024, to discuss and plan the representation of reality and the possibilities of its coordination on the Urbit network.
+
+[Visit the event site](https://subassembly.tocwexsyndicate.com)
+[Read the manifesto](https://subassembly.tocwexsyndicate.com/manifesto.html)
+[Submit an attendee application](https://docs.google.com/forms/d/e/1FAIpQLSfbHcFLRgGKBW91qINxhZ6TAgSDgsY_ikG1ATauHL7AVeLqDA/viewform)
+
+Some topics we’ll discuss:
+- Computational verification and zk pseudonymization of local and network actions
+- Mutual attestation of actions, data storage
+- Protocol and internal economy use cases to spur ID/reputation adoption
+- Post-SaaS protocol business moats in the Urbit future
+- Subnets as reputational rehypothecation mechanisms for Urbit address space
+- Integrations with other ID systems, blockchains, and reputational data sources
+- IP and software licenses as group-owned assets on Urbit
+- Uptake of reputational data from legacy systems
+- Proof-of-human, ML agents, ephemeral identities on Urbit
+- Sources of truth from the physical world (PoL, POAPs, node dispersal, physical decentralization) that inform uniqueness and reputation of identity
+- Hardware and hosting environment interactions with identity and reputation
+- And more to come!

--- a/content/events/2024-10-20-Subassembly-PNW.md
+++ b/content/events/2024-10-20-Subassembly-PNW.md
@@ -28,9 +28,12 @@ We invite you to join us in the foothills of Mount Rainier, this October 20th-22
 
 [Visit the event site](https://subassembly.tocwexsyndicate.com)
 
+
 [Read the manifesto](https://subassembly.tocwexsyndicate.com/manifesto.html)
 
+
 [Submit an attendee application](https://docs.google.com/forms/d/e/1FAIpQLSfbHcFLRgGKBW91qINxhZ6TAgSDgsY_ikG1ATauHL7AVeLqDA/viewform)
+
 
 Some topics we’ll discuss:
 - Computational verification and zk pseudonymization of local and network actions

--- a/content/events/2024-10-20-Subassembly-PNW.md
+++ b/content/events/2024-10-20-Subassembly-PNW.md
@@ -27,7 +27,9 @@ If you are a visionary in building new systems of self-sovereign human organizat
 We invite you to join us in the foothills of Mount Rainier, this October 20th-22nd, 2024, to discuss and plan the representation of reality and the possibilities of its coordination on the Urbit network.
 
 [Visit the event site](https://subassembly.tocwexsyndicate.com)
+
 [Read the manifesto](https://subassembly.tocwexsyndicate.com/manifesto.html)
+
 [Submit an attendee application](https://docs.google.com/forms/d/e/1FAIpQLSfbHcFLRgGKBW91qINxhZ6TAgSDgsY_ikG1ATauHL7AVeLqDA/viewform)
 
 Some topics we’ll discuss:

--- a/content/events/2024-10-20-Subassembly-PNW.md
+++ b/content/events/2024-10-20-Subassembly-PNW.md
@@ -9,7 +9,7 @@ links = [
   { label = "Register", url = "https://docs.google.com/forms/d/e/1FAIpQLSfbHcFLRgGKBW91qINxhZ6TAgSDgsY_ikG1ATauHL7AVeLqDA/viewform" },
   { label = "Event Details", url = "https://subassembly.tocwexsyndicate.com/details.html" }
 ]
-description = "a community gathering about identity, trust, and reputation"
+description = "A community gathering about identity, trust, and reputation"
 dark = true
 darken_image = "true"
 +++
@@ -47,4 +47,4 @@ Some topics we’ll discuss:
 - Proof-of-human, ML agents, ephemeral identities on Urbit
 - Sources of truth from the physical world (PoL, POAPs, node dispersal, physical decentralization) that inform uniqueness and reputation of identity
 - Hardware and hosting environment interactions with identity and reputation
-- And more to come!
+- More to come!

--- a/content/events/2024-10-20-Subassembly-PNW.md
+++ b/content/events/2024-10-20-Subassembly-PNW.md
@@ -2,7 +2,7 @@
 title = "Subassembly PNW"
 starts = "2024-10-20T14:00:00"
 ends = "2024-10-22T11:00:00"
-timezone = "America/Pacific"
+timezone = "America/Los_Angeles"
 location = "Wellspring Spa & Woodland Retreat - 154922 Kernahan Rd E, Ashford, WA 98304"
 image = "https://sfo3.digitaloceanspaces.com/sarlev-sarsen/sarlev-sarsen/2024.5.16..5.20.19..6f5c.28f5.c28f.5c28-image.png"
 links = [


### PR DESCRIPTION
Adds an entry to urbit.org for the Subassembly event.

I also added a property, `event_details`. Would be preferred to add a button to event pages that use this property (next to the 'register' button.