### PR TITLE
Add online events calendar to Events page, also slight renovation of that page

### DIFF
--- a/content/grants/2023/aera.md
+++ b/content/grants/2023/aera.md
@@ -15,7 +15,7 @@ assignee = ["~talwet"]
 champion = ["~dalten"]
 grant_id = "P0276"
 completed = false
-canceled = false
+canceled = true
 
 +++
 

--- a/content/grants/2023/turf.md
+++ b/content/grants/2023/turf.md
@@ -15,7 +15,7 @@ assignee = ["~midlev-mindyr"]
 champion = ["~reb"]
 grant_id = "P0265"
 completed = false
-canceled = false
+canceled = true
 
 +++
 

--- a/content/grants/2024/hoon-and-app-books.md
+++ b/content/grants/2024/hoon-and-app-books.md
@@ -1,0 +1,97 @@
++++
+
+title = "Hoon and App School Books"
+date = "2024-09-03"
+
+[taxonomies]
+grant_type = ["Proposal"]
+grant_category = ["Other"]
+
+[extra]
+image = ""
+description = "Physical books for Hoon School and App School"
+reward = "1 star"
+assignee = ["~tasrut-sippyx"]
+champion = ["~tamlut-modnys"]
+grant_id = "P0386"
+completed = false
+canceled = false
+
++++
+
+# Project Summary
+This project aims to create two comprehensive books that will serve as essential resources for
+Urbit developers:
+
+1. The Hoon School Book: A guide to learning the Hoon programming language
+
+2. The App School Book: A complete guide to Urbit application development
+
+Both books will transform existing Urbit docs into well-formatted, visually appealing, and
+accessible learning resources, with additional content.
+
+# Detailed Description
+This project will produce two books aimed at supporting Urbit developers at different stages of
+their learning journey.
+
+## Book 1: The Hoon School Book
+
+Based on the Hoon School guide from docs.urbit.org, this book will:
+
+• Compile all chapters of the Hoon School guide.
+• Feature a visually distinct format for code examples.
+• Include highlighted runes throughout the text.
+• Provide footnotes with video links for chapters with accompanying videos.
+• Include a comprehensive table of contents.
+• Also include rune, syntax and aura notation cheatsheet.
+
+## Book 2: The App School Book
+
+Based on App School I & II and additional resources, this book will:
+
+• Compile all content from App School I & II.
+• Feature a distinct graphical style (slightly different from the Hoon School Book).
+• Include extra content and reference materials with integrated cross-referencing system:
+◦ External API Reference
+◦ Low-level guide
+◦ JSON
+◦ Zuse
+◦ Software Distribution
+◦ HTTP API
+◦ Sail (HTML)
+• Contain a guide on Shrubbery.
+
+# Technical Approach
+For both books:
+1. Content Extraction: Systematically extract relevant content from docs.urbit.org.
+2. Content Cleanup: Convert content to a clean text format.
+3. Layout Design: Create book layouts using industry-standard software.
+4. Formatting: Develop distinct visual styles for chapters, subchapters, quotes and mainly
+Hoon code examples.
+5. Graphic Design: Apply color schemes, typography, and other design elements.
+6. Cover Design: Create eye-catching covers representing Urbit, Hoon, and app development.
+7. Proofreading and Editing: Ensure accuracy of content and formatting.
+8. Incorporate the latest updates and changes made to the Urbit docs.
+9. File Preparation: Produce print-ready files in appropriate formats (PDF).
+
+5. Timeline and Milestones
+For the Hoon School book, 2 print-ready book files (cover and content) along with physical copy.
+
+App School I&II Book
+Deliverable: 2 print-ready book files (cover and content) and physical copy
+Completion date: November 2024
+Payment: 1 star
+
+7. Expected Impact
+Hoon and App School I&II Books will:
+1. Provide comprehensive offline resources for learning Hoon and Urbit app development.
+2. Increase accessibility of Urbit education, potentially attracting more developers to the
+ecosystem.
+3. Serve as polished representations of Urbit's educational resources.
+4. Become offline go-to references for Hoon programmers and Urbit developers at various
+skill levels.
+5. Demonstrate the maturity and user-friendliness of the Urbit project to a wider audience.
+6. Consolidate documentation into cohesive, easy-to-navigate volumes.
+By creating these books in conjunction with the active Hoon and App Academy programs, I aim
+to accelerate the learning process, provide comprehensive offline references for academy
+participants, and contribute to the growth of the Urbit ecosystem.

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -46,7 +46,7 @@ export default function Events({
 }) {
   const post = {
     title: "Events",
-    description: "In-person, remote, and recorded events about Urbit.",
+    description: "In-person and online events about Urbit.",
   };
 
   return (
@@ -60,7 +60,50 @@ export default function Events({
         <section>
           <h1 className="h1 mt-12 mb-8 md:mt-16 md:mb-16 lg:mb-20">Events</h1>
           <p className="h1">
-            Urbit organizes events <strong>worldwide</strong>. Join your local
+            Explore Urbit and our community, in-person and online.
+          </p>
+        </section>
+        {upcomingEvents.length > 0 && (
+          <Section divider={"border-primary"}>
+            <h1 className="h1">Upcoming</h1>
+            <FatBlock className="grid grid-cols-1 sm:grid-cols-2 gap-1 lg:gap-6 xl:gap-8">
+              {upcomingEvents.map((props) => (
+                <EventCard className="w-full" {...props} />
+              ))}
+            </FatBlock>
+          </Section>
+        )}
+          <Section divider={"border-primary"}>
+            <h1 className="h1">Online Events Calendar</h1>
+            <section className="w-full space-y-5 md:space-y-[1.875rem] markdown layout-narrow">
+            <p className="h2">
+             We regularly hold online events where you can learn, get involved, or just hang out with Urbiters. Most events are in the Urbit Hacker House, a shared virtual office space.
+              </p>
+            </section>
+            <Link
+            className="btn bg-primary hover:bg-secondary text-surface body-lg w-min mr-4"
+            href="https://app.gather.town/app/xAYeiPI2XDYhRM9t/urbit-hacker-house"
+            >
+            Enter Hacker House
+            </Link>
+            <Link
+            className="btn bg-primary hover:bg-secondary text-surface body-lg w-min"
+            href="https://calendar.google.com/calendar/ical/c_13647438d00ef31237be88b19de24de30aeb2609657c80cfb6b22350941c61dd%40group.calendar.google.com/public/basic.ics"
+            >
+            Import Calendar
+            </Link>
+            <iframe 
+            src="https://calendar.google.com/calendar/embed?height=600&wkst=1&ctz=America%2FNew_York&bgcolor=%23ffffff&showPrint=0&showTitle=0&showTabs=0&showCalendars=0&showDate=1&src=Y18xMzY0NzQzOGQwMGVmMzEyMzdiZTg4YjE5ZGUyNGRlMzBhZWIyNjA5NjU3YzgwY2ZiNmIyMjM1MDk0MWM2MWRkQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20&color=%23D81B60" 
+            style={{ width: '100%', borderWidth: 0, padding: '20px'}}
+            height="600" 
+            frameBorder="0" 
+            scrolling="no">
+            </iframe>
+          </Section>
+        <Section divider={"border-primary"}>
+        <h2 className="h1">Communities</h2>
+          <p className="h2">
+            Urbit has meetups <strong>worldwide</strong>. Join your local
             communities or{" "}
             <Link
               className="hover:text-secondary"
@@ -70,9 +113,6 @@ export default function Events({
             </Link>{" "}
             your own.
           </p>
-        </section>
-        <Section divider={"border-primary"}>
-          <h2 className="h2">Communities</h2>
           <Carousel>
             {communities.map((props) => (
               <CommunityCard className="w-44 sm:w-56 md:w-80" {...props} />
@@ -89,18 +129,8 @@ export default function Events({
             </FatBlock>
           </Section>
         )}
-        {upcomingEvents.length > 0 && (
-          <Section divider={"border-primary"}>
-            <h2 className="h2">Upcoming</h2>
-            <FatBlock className="grid grid-cols-1 sm:grid-cols-2 gap-1 lg:gap-6 xl:gap-8">
-              {upcomingEvents.map((props) => (
-                <EventCard className="w-full" {...props} />
-              ))}
-            </FatBlock>
-          </Section>
-        )}
         <Section divider={"border-primary"}>
-          <h2 className="h2">Past events</h2>
+          <h1 className="h1">Past events</h1>
           <FatBlock className="grid grid-cols-1 sm:grid-cols-2 gap-1 lg:gap-6 xl:gap-8">
             {pastEvents &&
               pastEvents


### PR DESCRIPTION
We'd like there to be a public calendar of our Hacker House and other online events (such as ~sorreg-namtyv's addresses) so that people can easily know when events happen and get alerts.