### PR TITLE
docs: add litneb-maltyp spotlight post

### DIFF
--- a/app/content/blog/contributor-spotlight-litneb-maltyp.md
+++ b/app/content/blog/contributor-spotlight-litneb-maltyp.md
@@ -7,14 +7,16 @@ description = "A conversation with ~litneb-maltyp on Urbit identity, community, 
 [extra]
 # author = ""
 ship = "~sarlev-sarsen"
-image = "https://placehold.co/1600x900.jpg"
-imageCard = "https://placehold.co/1200x630.jpg"
-# imageIndex = "<IMAGE_INDEX_URL>"
+image = "https://s3.us-east-1.amazonaws.com/urbit.orgcontent/Blog/Blog+QA+litneb-maltyp/Blog_QA+litneb-maltyp_Social.png"
+imageCard = "https://s3.us-east-1.amazonaws.com/urbit.orgcontent/Blog/Blog+QA+litneb-maltyp/Blog_QA+litneb-maltyp_Social16_9.png"
+# imageIndex = "https://s3.us-east-1.amazonaws.com/urbit.orgcontent/Blog/Blog+QA+litneb-maltyp/Blog_QA+litneb-maltyp_Banner.png"
 # imageDark = ""
 # imageCardDark = ""
 # imageIndexDark = ""
 tags = ["spotlight", "identity", "design"]
 +++
+ 
+![~litneb-maltyp contributor spotlight image](https://s3.us-east-1.amazonaws.com/urbit.orgcontent/Blog/Blog+QA+litneb-maltyp/Blog_QA+litneb-maltyp_no+text_Social16_9.png)
 
 > **\~sarlev:** What was the first thing that drew you into the idea that we needed to throw away and rewrite the entire networked computing stack?
 

--- a/app/content/blog/contributor-spotlight-litneb-maltyp.md
+++ b/app/content/blog/contributor-spotlight-litneb-maltyp.md
@@ -1,0 +1,79 @@
++++
+title = "Contributor Spotlight: ~litneb-maltyp"
+date = "2026-02-17"
+description = "A conversation with ~litneb-maltyp on Urbit identity, community, and the personal server"
+# aliases = []
+
+[extra]
+# author = ""
+ship = "~sarlev-sarsen"
+image = "https://placehold.co/1600x900.jpg"
+imageCard = "https://placehold.co/1200x630.jpg"
+# imageIndex = "<IMAGE_INDEX_URL>"
+# imageDark = ""
+# imageCardDark = ""
+# imageIndexDark = ""
+tags = ["spotlight", "identity", "design"]
++++
+
+> **\~sarlev:** What was the first thing that drew you into the idea that we needed to throw away and rewrite the entire networked computing stack?
+
+**\~litneb-maltyp:** It’s interesting because I didn’t come in with that framing.
+
+A friend showed me OS1 and it looked cool. It was a little gated, which made it feel exciting to explore. I wanted to get on the list and see what was going on. I was just getting into command line stuff and the design materials around OS1 felt parallel to that, so it seemed like a fun outlet.
+
+It wasn’t until the first Assembly that I started to understand the “ball of mud” framing. I got on Urbit around January 2021, so the first six or nine months were mostly about meeting people and falling in love with the community before fully understanding the technical story. That first Assembly in Austin, TX was where that clicked. Jonathan Blow’s closing talk about Eternal September and smaller communities really landed for me. That moment opened my eyes to the limitations of stack we were all participating in and why it might need a rethink.
+
+> **\~sarlev:** It sounds like you came in through design and community rather than a “I hate JavaScript” mindset. Is that right?
+
+**\~litneb-maltyp:** Exactly, I'm a designer. My background is in architecture and I run a fragrance business. Prior to Urbit I had played with websites and computers, but that wasn't really what drew me in about Urbit. Rather, The friend who introduced me was someone I wasn’t seeing in person as much during COVID, so we were exploring new ways to stay in touch. Discord was the obvious option, but Urbit felt like a different, cooler alternative.
+
+I was also seeing a lot of the design work coming out of `~fabled-faster` on Arena and into OS1, and that pulled me in.
+
+That friend also knew someone at Tlon, so we were learning about Urbit through that connection. We did keep a Discord, but I ended up dedicating more time to Urbit. It felt creatively interesting and, honestly, more beautiful.
+
+> **\~sarlev:** Once you got deeper, did you develop an affinity for a particular part of the system? What kept drawing you in?
+
+**\~litneb-maltyp:** The first thing was the identity system. I didn’t really understand that Urbit is a computer; I just felt like I was on a website. The thing that clicked was the IDs. I was constantly scrolling through `@p` lists, trying to find one to buy and boot. It felt so foreign. I eventually went to a Bitcoin meetup where `~pindet-timmut` was giving away planets, and that’s how I got my first Urbit ID.
+
+From then on, I had this obsession with `@p`s, IDs, and sigils. I kept hunting for them and trying to understand how the shapes worked and how the hierarchy of galaxies, stars, planets, and comets showed up in the `@p`. 
+
+I was also around the grant program early on. My original proposal was “sigil totems” or “sigil biscuits,” an idea where every Urbit ID would be rendered as a physical object. I had designs for a sigil rug and a Coke can with a sigil screen-printed on it. It didn’t totally make sense yet, but I was very early on the idea of giving IDs physical representation. I actually went to Assembly because `~ravmel-ropdyl` wanted me to make a bespoke Tlon fragrance. That, coupled with my early experiments with these "sigil totems" contributed to why I built [Olif](https://urbit.fragrance.services), which was a project I created later in my Urbit exploration: I wanted to understand how the parts fit together. 
+
+> **\~sarlev:** Where does the identity layer inspire you now? What feels different about it compared to legacy computing?
+
+**\~litneb-maltyp:** I still love the ownership aspect of Urbit IDs. The NFT hype has come and gone, but the idea that you can own your address still hits. It's a stark contrast to something like social handles which can be revoked. I’m not sure I even own my phone number. I still try to get the same handle everywhere, but Urbit is the one place where that feels real.
+
+Owning your identity also changes how you behave. Early on, it felt heterodox. You could say whatever. Over time, you know more people and you tighten up your behavior a bit, perhaps. I ran a burner for a while too. It gave me a more complete understanding of what reputation means digitally.
+
+My perspective evolved a lot from 2021 to the [Subassembly](https://urbit.org/blog/subassembly-hackathon-2024) era, with regards to Urbit as a system. I am a three-time [Hoon School](https://docs.urbit.org/build-on-urbit/hoon-school) dropout, but some of it eventually stuck. The core structural pieces at least. Since around 2024, my technical understanding has been steadier, but it almost feels more in reach because the system keeps improving as the Core devs keep shipping. Recently, the portability of identity feels more interesting, especially with projects like GroundWire.
+
+> **\~sarlev:** As the world outside Urbit evolves with AI and agents, how do you want to interact with different digital identities? Do you care if it’s a human or a bot?
+
+**\~litneb-maltyp:** The agent wave feels like a perfect match for Urbit ID. When I spun up my first moon, I loved the idea that it could serve as a little raft when my planet was down. Later, I kept thinking about the idea that your family could have planets and all your devices could have moons. I wanted a Raspberry Pi in my car talking to the OBD2 port and reporting back to my planet.
+
+For a while, this seemed a bit out of reach. Why would you need 4.3B sub-identities? Agents are the missing piece. Those moons become little worker bees that can actually think and do things, not just transmit data. The hierarchy makes it feel cohesive. You could name agents informally, but tying them into the Azimuth identity tree feels like the right structure.
+
+> **\~sarlev:** One of the goals of Urbit is to make a forever computer. What would that mean to you?
+
+**\~litneb-maltyp:** The heirloom computer idea is the best version of this. I’m a digital packrat: I save everything, take tons of screenshots, and then turn them into physical things. I have books of screenshots and binders of printed stuff. I back things up everywhere. I have storage drives all over the place. 
+
+At this point, My ship, `~litneb-maltyp` is five years old and I’ve never breached, which is a testament to the improving reliability of the system, really. But yea, at this point my ship has a massive tail. Being able to pass that down to my kid so they can extract it into something meaningful would be incredible. That’s the sort of permanence I want.
+
+> **\~sarlev:** Beyond reliability, what do you want your personal server to let you do?
+
+**\~litneb-maltyp:** I want Urbit to replace the set of apps I rely on. There have been moments where it felt close, but apps don’t always get maintained. I want a few crystallized pieces of software I can truly depend on.
+
+If I am being a little more aspirational, I’d love an off-grid mesh network for my neighborhood, with reliable backups of the sites I care about. An offline internet I can trust. I was also excited about sensor and IO projects—having a ship attached to my van that reports engine temperature and reminds me about oil changes. Add agents to that and it becomes a daily assistant. I can see all of it. I know it exists. I just want it to all be connected.
+
+> **\~sarlev:** Did your relationship with computers change once you found Urbit?
+
+**\~litneb-maltyp:** It gave me a lot more agency and confidence. Before Urbit, my relationship with computers was mostly through design software. I went to school for architecture, did CAD and 3D rendering, and worked as a product designer for a leather company. You could say the change happened slowly and then all at once as I realized how dependent I was on these companies. I was torrenting Adobe because I didn’t want to pay for Creative Cloud, and then everything became subscription-based. I invested in learning a particular 3D modeling tool and then the free tier disappeared. 
+
+Urbit made the old “you buy software and you own it” model feel tangible again. And it sparked a bigger shift: now I have a home lab. I used to have one computer; now I have thirteen. People ask how I can be on more than one computer at once and I’m like, “You kind of are, but you aren’t.” Some are virtual, some I check once a month. You could say it's just another ball of mud, but *it’s my ball of mud*. But, that agency and curiosity was the biggest shift.
+
+> **\~sarlev:** If you hadn’t come across Urbit, what do you think you’d be doing instead?
+
+**\~litneb-maltyp:** I was getting into no-code tools around the same time I found Urbit, and I might have leaned further into that. But I always felt frustrated that I’d never be able to take those projects off their platforms. The ownership issues pushed me away.
+
+On the physical side, I do a lot of 3D printing for my business. I’ve always liked cyberdecks, Arduino, and Raspberry Pi projects. I was tinkering with things like building a custom diffuser, candle warmers, and timed mixers. So maybe I would have gone deeper into that world, doing less on peer-to-peer networked personal servers, more small hardware devices solving business problems. But I can see how it all would have led me back to the same place eventually.


### PR DESCRIPTION
## Summary
- add the litneb-maltyp contributor spotlight post to the blog content
- use placeholder image URLs to avoid frontmatter parsing errors