### PR TITLE
docs: fix DHH ONCE link in Gall 2026

### DIFF
--- a/app/content/blog/gall-2026.md
+++ b/app/content/blog/gall-2026.md
@@ -36,7 +36,7 @@ Urbit's decades-long journey includes a wide swath of interesting computer scien
 
 But the wider world is beginning to notice that legacy systems have 'solved' these problems with duct tape and bubble gum. 
 
-Why is [DHH building a docker container manager, called 'ONCE'](http://TK)? Because people are sick of the subscription model and not being able–or even *allowed*–to run their own software. 
+Why is [DHH building a docker container manager, called 'ONCE'](https://x.com/dhh/status/2033580762402902188?s=20)? Because people are sick of the subscription model and not being able–or even *allowed*–to run their own software.
 
 Why is [Perplexity building their ‘Personal Computer’ offering](https://x.com/perplexity_ai/status/2031790180521427166?s=20)? Because they can’t escape the fact that their ‘cloud-based’ Perplexity Computer product puts all your most personal information directly into their hands. And that people don’t actually want that.
 

--- a/public/.agents/blog/gall-2026.md
+++ b/public/.agents/blog/gall-2026.md
@@ -31,7 +31,7 @@ Urbit's decades-long journey includes a wide swath of interesting computer scien
 
 But the wider world is beginning to notice that legacy systems have 'solved' these problems with duct tape and bubble gum. 
 
-Why is [DHH building a docker container manager, called 'ONCE'](http://TK)? Because people are sick of the subscription model and not being able–or even *allowed*–to run their own software. 
+Why is [DHH building a docker container manager, called 'ONCE'](https://x.com/dhh/status/2033580762402902188?s=20)? Because people are sick of the subscription model and not being able–or even *allowed*–to run their own software.
 
 Why is [Perplexity building their ‘Personal Computer’ offering](https://x.com/perplexity_ai/status/2031790180521427166?s=20)? Because they can’t escape the fact that their ‘cloud-based’ Perplexity Computer product puts all your most personal information directly into their hands. And that people don’t actually want that.
 

--- a/public/blog/gall-2026.md
+++ b/public/blog/gall-2026.md
@@ -13,7 +13,7 @@ Urbit's decades-long journey includes a wide swath of interesting computer scien
 
 But the wider world is beginning to notice that legacy systems have 'solved' these problems with duct tape and bubble gum. 
 
-Why is [DHH building a docker container manager, called 'ONCE'](http://TK)? Because people are sick of the subscription model and not being able–or even *allowed*–to run their own software. 
+Why is [DHH building a docker container manager, called 'ONCE'](https://x.com/dhh/status/2033580762402902188?s=20)? Because people are sick of the subscription model and not being able–or even *allowed*–to run their own software.
 
 Why is [Perplexity building their ‘Personal Computer’ offering](https://x.com/perplexity_ai/status/2031790180521427166?s=20)? Because they can’t escape the fact that their ‘cloud-based’ Perplexity Computer product puts all your most personal information directly into their hands. And that people don’t actually want that.
 


### PR DESCRIPTION
## Summary
- replaces the placeholder DHH ONCE link in gall-2026.md with the provided X post URL
- updates generated public and agent markdown copies of the article

## Validation
- git diff --check