### PR TITLE
docs: add ~sicdev-pilnup contributor spotlight

### DIFF
--- a/app/content/blog/contributor-spotlight-sicdev-pilnup.md
+++ b/app/content/blog/contributor-spotlight-sicdev-pilnup.md
@@ -1,0 +1,154 @@
++++
+
+title = "Contributor Spotlight: ~sicdev-pilnup"
+date = "2026-07-14"
+description = "A conversation with ~sicdev-pilnup on coordination technologies, AI sovereignty, Urbit, and collective intelligence"
+summary = "~sicdev-pilnup discusses Urbit as sovereign infrastructure for identity, memory, coordination, and collective intelligence; the risks of centralized AI; and paths toward hosting, federation, and distributed inference."
+# aliases = []
+search_terms = [
+    "contributor spotlight",
+    "~sicdev-pilnup",
+    "AI sovereignty",
+    "coordination technology",
+    "collective intelligence",
+    "Dalten",
+    "Urbit Foundation",
+    "Vere64",
+    "Directed Messaging",
+    "Model Context Protocol",
+    "Groundwire",
+    "Urbit hosting",
+    "Azimuth identity",
+    "distributed inference"
+]
+
+[extra]
+# author = ""
+ship = "~sarlev-sarsen"
+image = "https://s3.us-east-1.amazonaws.com/urbit.orgcontent/Blog/Blog+QA+sicdev-pilnup/Blog_QA+sicdev-pilnup_Social.jpg"
+imageCard = "https://s3.us-east-1.amazonaws.com/urbit.orgcontent/Blog/Blog+QA+sicdev-pilnup/Blog_QA+sicdev-pilnup_Social16_9.jpg"
+imageIndex = "https://s3.us-east-1.amazonaws.com/urbit.orgcontent/Blog/Blog+QA+sicdev-pilnup/Blog_QA+sicdev-pilnup_Banner.jpg"
+imageEmail = "https://s3.us-east-1.amazonaws.com/urbit.orgcontent/Blog/Blog+QA+sicdev-pilnup/Blog_QA+sicdev-pilnup_Mail.jpg"
+# imageDark = ""
+# imageCardDark = ""
+# imageIndexDark = ""
+tags = ["spotlight", "coordination", "ai", "sovereignty"]
++++
+
+![~sicdev-pilnup Contributor Spotlight Art](https://s3.us-east-1.amazonaws.com/urbit.orgcontent/Blog/Blog+QA+sicdev-pilnup/Blog_QA+sicdev-pilnup_Hero.jpg)
+
+> **\~sarlev:** What first drew you to the idea that we needed to throw away and rewrite the networked computing stack?
+
+**\~sicdev-pilnup:** I don't know if attraction is exactly the right word, but I'm attracted to ambition: big things, things larger than myself, that kind of call to action. People usually see projects that try to boil the ocean or start from a clean slate as destined to fail because they take on too much, and I generally agree with that criticism. The difference is that most of them don't actually return to first principles. Urbit did, and that gave it a kind of purity that went beyond the particular thing being built.
+
+The idea was: no, we're not going to get there by adding more layers. We're going to get there by subtracting. Make the system small enough and diamond-hard, get the specification onto a T-shirt, and then build outward from there.
+
+That always felt different from projects that pursue ambition by accumulating technologies. Urbit stands on the shoulders of giants, obviously, but it is still a reworking and a rethinking. That's why it isn't Earth technology. It's Martian technology. Starting fresh also connects to exit: regaining some sovereignty, authority, and ability to act within the digital spaces we inhabit.
+
+> **\~sarlev:** Is exit what you are looking for from the system, or is there something else about Urbit that you think will change our digital lives?
+
+**\~sicdev-pilnup:** I think exit is the leverage. It's the promise. Urbit hasn't fully delivered that promise yet, but what matters right now is the learning. You learn the system and participate in the culture. You also take on the ownership and responsibility that come with operating your own infrastructure.
+
+I never meant to become a Linux system administrator. Urbit has always said people shouldn't need to become system administrators, yet I became an expert Linux administrator anyway. I didn't intend for that to happen. But taking responsibility forced me to understand more of the stack, including Linux, servers, and hardware.
+
+That's not where everyone should have to begin. Hosting is an important bridge from software as a service into a model with more ownership. Sovereignty is a spectrum, and people are going to stop at different points along it.
+
+But the more control you have over your digital life, the more it starts to resemble the rest of your life. If you can, you want to own your house and your tools rather than rent them forever. That requires knowledge and responsibility, but it also builds both. I think that can make you a better person.
+
+> **\~sarlev:** Urbit is sometimes described as a forever computer. Would having a computer that lasts forever change how you think about your digital life?
+
+**\~sicdev-pilnup:** I don't mean that anything is literally permanent. You probably don't still have the clothes you wore as a baby, though a few things may have made it through. What matters is the sense of continuity, and that is either missing or just false in most of our digital lives.
+
+You might have used Twitter, Facebook, or Instagram for a decade, but what you really have is mostly a set of memories. If a third party decides you no longer have access, the record is gone. I think the loss would feel surprisingly close to having your house burn down.
+
+My Urbit life does have that sense of continuity, even though I'm not running the computer I started with and I've breached several times. I still have artifacts and old piers with years of history on them. I keep them in what amounts to a digital locker.
+
+Call that sentimental or call it history. Either way, it's something most people don't have. I think durable memory matters because it gives people and groups a basis for culture. It helps us form a shared narrative while becoming more autonomous and responsible for our own actions, rather than leaving our continuity in the hands of third parties.
+
+> **\~sarlev:** You have spent a lot of time thinking about and working on how groups coordinate, from your current role as the Executive Director of the Urbit Foundation to cultivating communities like Dalten. Did that interest lead you to Urbit, or did Urbit draw you into coordination?
+
+**\~sicdev-pilnup:** Not exactly. I'd say my interest probably began with the financial crisis in 2008. That was when I first understood money as a coordination technology. Following that question led me into crypto, where people were experimenting with money, governance, and new ways for groups to act together.
+
+I participated in a lot of those experiments. I was part of The DAO, [the project whose hack led to the Ethereum network being forked](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3014782). What I came away with is that people generally coordinate best through some form of hierarchy. Calling an organization decentralized doesn't remove leadership, judgment, or accountability. If those things aren't explicit, they tend to come back in ways that are harder to see.
+
+At the same time, distributed teams are very powerful. They let people who don't share a city organize around a problem that otherwise might never get addressed. Smart contracts can automate parts of that work. The combination can be very efficient if the group stays actually organized.
+
+Crypto got very focused on global consensus, which was expensive and only solved part of the problem. When I found Urbit, it felt like: okay, here we go. This is a surface for the rest of it. It can hold identity, communication, memory, and the local context a distributed group needs in order to function as an actual group.
+
+AI just extends the same line of thought. It's a tremendous lever, but it's also a huge centralizing force. We need some counterweight that lets us use intelligence through computers, networks, and data within our own sphere of influence. Money, governance, Urbit, and AI aren't separate interests for me. They're all part of the same question: how do people coordinate, and who holds the power when they do?
+
+> **\~sarlev:** In an AI-enabled world, what kinds of context are most important to keep in a system you control?
+
+**\~sicdev-pilnup:** Context is very important. A lot of us, including me, are creating it in places where we don't ultimately want it to live. I'm willing to do that during this transition, but I want a plan for getting it out. Where is the accumulated record of my work and thought going to go? I want that place to be something like an Urbit.
+
+I don't know how far Urbit itself needs to scale in storage, compute, or processing power. I don't expect frontier models to run inside an Urbit anytime soon. To me, Urbit is more important as the layer where identity, memory, permissions and private data live. It can connect to intelligence somewhere else.
+
+I can see that extending to agents themselves. Urbit is nearly a perfect substrate for an independent agent that has to earn its keep and coordinate with others. It can hold secrets and control private keys. It can develop an identity and reputation, communicate over a network, store documents, and enter into contracts.
+
+If you were designing a vessel for an AI that needed continuity and agency, I think it would look a lot like Urbit. That is still science fiction. It's probably further away than we think. The immediate goal is simpler: I want the second brain I'm building now to stay within a scope I control. I want to preserve it, use it, and eventually pass it down or turn it into an archive.
+
+> **\~sarlev:** The sovereign alternative is not fully built, and most useful frontier models still belong to large providers. What would you tell someone who wants to benefit from those tools without surrendering control of their digital life?
+
+**\~sicdev-pilnup:** I think of it as a transition, not a purity test. A lot of the immediate benefit is still at the frontier. These systems feel like roughly competent coworkers. I give them work and they come back with it quickly, sometimes more cheaply. But they aren't superintelligent. They make silly mistakes, nuke things by accident, apologize, and tell me I'm right often enough that I should probably be concerned.
+
+I think over time a lot of this capability will become good enough and more widely available. I don't assume that scaling one architecture forever produces infinite returns. We may get more leverage from ensembles of smaller models, open models, and collaborative infrastructure that can be brought closer to home.
+
+The more cynical version is that we've seen this before. The early internet was supposed to connect us, and social media turned into a system for targeting us. AI providers are building unusually complete models of their users. When token revenue isn't enough, there will be pressure to monetize those models. The nudges may be subtler than advertisements, but the incentive is going to look familiar.
+
+I don't think this is do or die for everyone today. But it is a reason to have a transition plan. You should be able to gather the information you've given these systems somewhere you control, back it up, and use intelligence against it without losing the underlying data. The most important tools in your life should serve you, not somebody else's bottom line.
+
+> **\~sarlev:** If access to intelligence becomes unequal or politically constrained, what can individuals and communities do in practice?
+
+**\~sicdev-pilnup:** Beyond monetization, access is also becoming political. Governments are taking a much greater interest in when frontier models are released, what they can do, and who gets to use them. The people and institutions with the earliest access will accumulate an advantage and may put even more distance between themselves and everyone else.
+
+The alternative is to pool resources and develop other infrastructure. Distributed inference, decentralized infrastructure, and crypto rails all seem promising to me. In [Dalten](https://dalten.org), we've pooled resources to buy compute, experiment with these products, and put them to use in a collective setting.
+
+In practice, get a group of your Urbit friends together, buy a large GPU, and see if you can actually run inference on it. Practice the skills before you urgently need them. I didn't plan to become a Linux administrator. Do I want to become a GPU orchestrator? Not particularly, but maybe that is the next responsibility.
+
+If you want to go fast, go alone. If you want to go far, go with others. That's basically how I think about the infrastructure problem too.
+
+> **\~sarlev:** What improvements across Urbit are you most looking forward to?
+
+**\~sicdev-pilnup:** `Vere64` is probably the biggest one. Directed Messaging is also novel and interesting. Beyond those, I'm interested in experiments that let people get into the network with less friction.
+
+That includes more than conventional hosting. It includes applications where all you need is an Azimuth identity, as well as federated models where one person or organization takes responsibility for infrastructure used by a smaller group. We talk a lot about personal ownership, but federation is the layer above it. It lets people share capacity without ending up back at one big provider.
+
+I think the onboarding path should be progressive. You might begin with a passkey and an application on your phone. Later you turn on a ship and enter a different relationship with the network. Maybe you operate it yourself, or maybe you rely on someone you trust. These aren't binary categories. They're steps toward a greater degree of sovereignty.
+
+Some people will stop at hosting, and that's fine. Urbit should be able to power useful experiences for people who don't care about Urbit for its own sake. It can become important infrastructure without ever becoming a household name.
+
+> **\~sarlev:** Are AI tools beginning to make Urbit easier to operate, understand, and build on?
+
+**\~sicdev-pilnup:** Yes. One thing I'm doing is experimenting with several Model Context Protocol (MCP) servers, including [the one from Groundwire](https://github.com/gwbtc/urbit-mcp). People in Dalten are also building harnesses that feel, in an almost spiritual way, very Urbit.
+
+My own use is mostly operational. These tools are good at tracing bugs and working through system administration.
+
+When Directed Messaging caused resource problems on my ship, I could have dropped into the Urbit hacker house in Gather and asked the core developers. They meet there Monday, Wednesday, and Friday. But I didn't need to. I had a tool that could inspect the available diagnostics, narrow down the source, and help mitigate the traffic.
+
+I also use the same tools for routine jobs, like updating binaries across several machines. They're good teaching aids too. I can ask what a gate does, have a piece of Hoon explained, or find a nesting error without searching through documentation for an hour.
+
+Over time, I think AI is going to become very useful for keeping a ship healthy and making it your own. That was part of Urbit's original promise. We're reaching a point where a power user can create software that matters to a particular person or group, then distribute it across a private network. That's more interesting to me than one more isolated JavaScript dashboard or another tiny application trapped inside somebody else's app store.
+
+> **\~sarlev:** What are the kinds of problems you expect to get solved by the blend of powerful coordination technology, collective ownership, and AI together?
+
+**\~sicdev-pilnup:** There's something that happens as a company grows. At the beginning, two or three people share most of the context. They know what's happening and they're closely aligned. As the organization expands, it has to build a hierarchy so information can flow toward the people responsible for decisions.
+
+Eventually, the people at the top discover that important things are happening outside their view. That's deeply disorienting for someone who once held the whole organization in their head. A lot of corporate life becomes coordination overhead: meetings, messages, and documents trying to reconstruct enough shared context for the group to act.
+
+The same problem exists in a group of friends. Dalten meets every week to make sense of what's happening in the world. We have different opinions and different ways of thinking, and we've tried several ways to preserve those conversations. Some kind of collective intelligence that could retain that context is very appealing to me.
+
+The privacy part matters too. Some members would stop participating if our conversations were simply sent to Claude. The system would have to be something we own together, much as we own the star together. Its memory and whatever intelligence comes out of it would be collective property.
+
+Then maybe `~dalten` (the star, and actual ship) could form an opinion that wasn't just the opinion of one member or the result of a vote. We have approximations of collective judgment today, but not many things that can take in a group's history, stay accountable to the group, and develop a recognizable point of view. I would love to see that become real.
+
+> **\~sarlev:** Is that where these threads converge: Urbit giving a collective intelligence a durable identity and a sense of self?
+
+**\~sicdev-pilnup:** Yes. "The Dalten Collective" is the name of our group, but also, `~dalten` is already a point on the network. It's a computer and an identity, and it could eventually become a personality.
+
+If those three things come together, that's something new. It wouldn't just average the views of its members. It could remember and form judgments while still being governed by the people who sustain it. That's what the Urbit namespace affords.
+
+> **\~sarlev:** If you were not working on Urbit, what would you be doing instead?
+
+**\~sicdev-pilnup:** I think I'm drawn to the frontier of coordination technologies, and to technological frontiers in general. AI is clearly one of them. Space is finally becoming one too.
+
+It's those places where the rules haven't been written yet, the opportunities are still open, and the responsibilities are enormous. Whatever form that takes, that's where I want to play.

--- a/public/.agents/blog.md
+++ b/public/.agents/blog.md
@@ -7,6 +7,7 @@ agent_mode: "fallback"
 dependencies: []
 related_pages:
   - "/blog.md"
+  - "/blog/contributor-spotlight-sicdev-pilnup.md"
   - "/blog/this-month-in-urbit-june-2026.md"
   - "/blog/languages-on-nock.md"
   - "/blog/contributor-spotlight-lagrev-nocfep.md"
@@ -16,7 +17,6 @@ related_pages:
   - "/blog/this-month-in-urbit-april-2026.md"
   - "/blog/obelisk-beta-release.md"
   - "/blog/contributor-spotlight-nomryg-nilref.md"
-  - "/blog/gall-2026.md"
 ---
 
 Human-oriented content: /blog.md
@@ -25,6 +25,7 @@ Human-oriented content: /blog.md
 
 Agent companions for urbit.org blog posts. When a source file includes ---agent---, the companion contains only the dedicated agent appendix plus a pointer back to the human mirror.
 
+- [Contributor Spotlight: ~sicdev-pilnup](/.agents/blog/contributor-spotlight-sicdev-pilnup.md) — A conversation with ~sicdev-pilnup on coordination technologies, AI sovereignty, Urbit, and collective intelligence
 - [This Month in Urbit: June 2026](/.agents/blog/this-month-in-urbit-june-2026.md) — June 2026 brings non-Hoon languages, Nock learning tools, Tlon's public launch, and the Urbit skills alpha.
 - [Languages on Nock](/.agents/blog/languages-on-nock.md) — A survey of Hoon, Jock, Yamoon, North, Loon, and the programming languages emerging around Nock
 - [Contributor Spotlight: ~lagrev-nocfep](/.agents/blog/contributor-spotlight-lagrev-nocfep.md) — A conversation with ~lagrev-nocfep on Nock, language design, computation, and the forever computer

--- a/public/.agents/blog/contributor-spotlight-sicdev-pilnup.md
+++ b/public/.agents/blog/contributor-spotlight-sicdev-pilnup.md
@@ -1,0 +1,138 @@
+---
+title: "Contributor Spotlight: ~sicdev-pilnup"
+source_kind: "blog"
+canonical_url: "/blog/contributor-spotlight-sicdev-pilnup"
+human_md_url: "/blog/contributor-spotlight-sicdev-pilnup.md"
+agent_mode: "fallback"
+dependencies: []
+related_pages:
+  - "/blog.md"
+  - "/blog/contributor-spotlight-sicdev-pilnup.md"
+---
+
+Human-oriented content: /blog/contributor-spotlight-sicdev-pilnup.md
+
+# Contributor Spotlight: ~sicdev-pilnup
+
+A conversation with ~sicdev-pilnup on coordination technologies, AI sovereignty, Urbit, and collective intelligence
+
+- Date: 2026-07-14
+- Author: ~sarlev-sarsen
+
+![~sicdev-pilnup Contributor Spotlight Art](https://s3.us-east-1.amazonaws.com/urbit.orgcontent/Blog/Blog+QA+sicdev-pilnup/Blog_QA+sicdev-pilnup_Hero.jpg)
+
+> **\~sarlev:** What first drew you to the idea that we needed to throw away and rewrite the networked computing stack?
+
+**\~sicdev-pilnup:** I don't know if attraction is exactly the right word, but I'm attracted to ambition: big things, things larger than myself, that kind of call to action. People usually see projects that try to boil the ocean or start from a clean slate as destined to fail because they take on too much, and I generally agree with that criticism. The difference is that most of them don't actually return to first principles. Urbit did, and that gave it a kind of purity that went beyond the particular thing being built.
+
+The idea was: no, we're not going to get there by adding more layers. We're going to get there by subtracting. Make the system small enough and diamond-hard, get the specification onto a T-shirt, and then build outward from there.
+
+That always felt different from projects that pursue ambition by accumulating technologies. Urbit stands on the shoulders of giants, obviously, but it is still a reworking and a rethinking. That's why it isn't Earth technology. It's Martian technology. Starting fresh also connects to exit: regaining some sovereignty, authority, and ability to act within the digital spaces we inhabit.
+
+> **\~sarlev:** Is exit what you are looking for from the system, or is there something else about Urbit that you think will change our digital lives?
+
+**\~sicdev-pilnup:** I think exit is the leverage. It's the promise. Urbit hasn't fully delivered that promise yet, but what matters right now is the learning. You learn the system and participate in the culture. You also take on the ownership and responsibility that come with operating your own infrastructure.
+
+I never meant to become a Linux system administrator. Urbit has always said people shouldn't need to become system administrators, yet I became an expert Linux administrator anyway. I didn't intend for that to happen. But taking responsibility forced me to understand more of the stack, including Linux, servers, and hardware.
+
+That's not where everyone should have to begin. Hosting is an important bridge from software as a service into a model with more ownership. Sovereignty is a spectrum, and people are going to stop at different points along it.
+
+But the more control you have over your digital life, the more it starts to resemble the rest of your life. If you can, you want to own your house and your tools rather than rent them forever. That requires knowledge and responsibility, but it also builds both. I think that can make you a better person.
+
+> **\~sarlev:** Urbit is sometimes described as a forever computer. Would having a computer that lasts forever change how you think about your digital life?
+
+**\~sicdev-pilnup:** I don't mean that anything is literally permanent. You probably don't still have the clothes you wore as a baby, though a few things may have made it through. What matters is the sense of continuity, and that is either missing or just false in most of our digital lives.
+
+You might have used Twitter, Facebook, or Instagram for a decade, but what you really have is mostly a set of memories. If a third party decides you no longer have access, the record is gone. I think the loss would feel surprisingly close to having your house burn down.
+
+My Urbit life does have that sense of continuity, even though I'm not running the computer I started with and I've breached several times. I still have artifacts and old piers with years of history on them. I keep them in what amounts to a digital locker.
+
+Call that sentimental or call it history. Either way, it's something most people don't have. I think durable memory matters because it gives people and groups a basis for culture. It helps us form a shared narrative while becoming more autonomous and responsible for our own actions, rather than leaving our continuity in the hands of third parties.
+
+> **\~sarlev:** You have spent a lot of time thinking about and working on how groups coordinate, from your current role as the Executive Director of the Urbit Foundation to cultivating communities like Dalten. Did that interest lead you to Urbit, or did Urbit draw you into coordination?
+
+**\~sicdev-pilnup:** Not exactly. I'd say my interest probably began with the financial crisis in 2008. That was when I first understood money as a coordination technology. Following that question led me into crypto, where people were experimenting with money, governance, and new ways for groups to act together.
+
+I participated in a lot of those experiments. I was part of The DAO, [the project whose hack led to the Ethereum network being forked](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3014782). What I came away with is that people generally coordinate best through some form of hierarchy. Calling an organization decentralized doesn't remove leadership, judgment, or accountability. If those things aren't explicit, they tend to come back in ways that are harder to see.
+
+At the same time, distributed teams are very powerful. They let people who don't share a city organize around a problem that otherwise might never get addressed. Smart contracts can automate parts of that work. The combination can be very efficient if the group stays actually organized.
+
+Crypto got very focused on global consensus, which was expensive and only solved part of the problem. When I found Urbit, it felt like: okay, here we go. This is a surface for the rest of it. It can hold identity, communication, memory, and the local context a distributed group needs in order to function as an actual group.
+
+AI just extends the same line of thought. It's a tremendous lever, but it's also a huge centralizing force. We need some counterweight that lets us use intelligence through computers, networks, and data within our own sphere of influence. Money, governance, Urbit, and AI aren't separate interests for me. They're all part of the same question: how do people coordinate, and who holds the power when they do?
+
+> **\~sarlev:** In an AI-enabled world, what kinds of context are most important to keep in a system you control?
+
+**\~sicdev-pilnup:** Context is very important. A lot of us, including me, are creating it in places where we don't ultimately want it to live. I'm willing to do that during this transition, but I want a plan for getting it out. Where is the accumulated record of my work and thought going to go? I want that place to be something like an Urbit.
+
+I don't know how far Urbit itself needs to scale in storage, compute, or processing power. I don't expect frontier models to run inside an Urbit anytime soon. To me, Urbit is more important as the layer where identity, memory, permissions and private data live. It can connect to intelligence somewhere else.
+
+I can see that extending to agents themselves. Urbit is nearly a perfect substrate for an independent agent that has to earn its keep and coordinate with others. It can hold secrets and control private keys. It can develop an identity and reputation, communicate over a network, store documents, and enter into contracts.
+
+If you were designing a vessel for an AI that needed continuity and agency, I think it would look a lot like Urbit. That is still science fiction. It's probably further away than we think. The immediate goal is simpler: I want the second brain I'm building now to stay within a scope I control. I want to preserve it, use it, and eventually pass it down or turn it into an archive.
+
+> **\~sarlev:** The sovereign alternative is not fully built, and most useful frontier models still belong to large providers. What would you tell someone who wants to benefit from those tools without surrendering control of their digital life?
+
+**\~sicdev-pilnup:** I think of it as a transition, not a purity test. A lot of the immediate benefit is still at the frontier. These systems feel like roughly competent coworkers. I give them work and they come back with it quickly, sometimes more cheaply. But they aren't superintelligent. They make silly mistakes, nuke things by accident, apologize, and tell me I'm right often enough that I should probably be concerned.
+
+I think over time a lot of this capability will become good enough and more widely available. I don't assume that scaling one architecture forever produces infinite returns. We may get more leverage from ensembles of smaller models, open models, and collaborative infrastructure that can be brought closer to home.
+
+The more cynical version is that we've seen this before. The early internet was supposed to connect us, and social media turned into a system for targeting us. AI providers are building unusually complete models of their users. When token revenue isn't enough, there will be pressure to monetize those models. The nudges may be subtler than advertisements, but the incentive is going to look familiar.
+
+I don't think this is do or die for everyone today. But it is a reason to have a transition plan. You should be able to gather the information you've given these systems somewhere you control, back it up, and use intelligence against it without losing the underlying data. The most important tools in your life should serve you, not somebody else's bottom line.
+
+> **\~sarlev:** If access to intelligence becomes unequal or politically constrained, what can individuals and communities do in practice?
+
+**\~sicdev-pilnup:** Beyond monetization, access is also becoming political. Governments are taking a much greater interest in when frontier models are released, what they can do, and who gets to use them. The people and institutions with the earliest access will accumulate an advantage and may put even more distance between themselves and everyone else.
+
+The alternative is to pool resources and develop other infrastructure. Distributed inference, decentralized infrastructure, and crypto rails all seem promising to me. In [Dalten](https://dalten.org), we've pooled resources to buy compute, experiment with these products, and put them to use in a collective setting.
+
+In practice, get a group of your Urbit friends together, buy a large GPU, and see if you can actually run inference on it. Practice the skills before you urgently need them. I didn't plan to become a Linux administrator. Do I want to become a GPU orchestrator? Not particularly, but maybe that is the next responsibility.
+
+If you want to go fast, go alone. If you want to go far, go with others. That's basically how I think about the infrastructure problem too.
+
+> **\~sarlev:** What improvements across Urbit are you most looking forward to?
+
+**\~sicdev-pilnup:** `Vere64` is probably the biggest one. Directed Messaging is also novel and interesting. Beyond those, I'm interested in experiments that let people get into the network with less friction.
+
+That includes more than conventional hosting. It includes applications where all you need is an Azimuth identity, as well as federated models where one person or organization takes responsibility for infrastructure used by a smaller group. We talk a lot about personal ownership, but federation is the layer above it. It lets people share capacity without ending up back at one big provider.
+
+I think the onboarding path should be progressive. You might begin with a passkey and an application on your phone. Later you turn on a ship and enter a different relationship with the network. Maybe you operate it yourself, or maybe you rely on someone you trust. These aren't binary categories. They're steps toward a greater degree of sovereignty.
+
+Some people will stop at hosting, and that's fine. Urbit should be able to power useful experiences for people who don't care about Urbit for its own sake. It can become important infrastructure without ever becoming a household name.
+
+> **\~sarlev:** Are AI tools beginning to make Urbit easier to operate, understand, and build on?
+
+**\~sicdev-pilnup:** Yes. One thing I'm doing is experimenting with several Model Context Protocol (MCP) servers, including [the one from Groundwire](https://github.com/gwbtc/urbit-mcp). People in Dalten are also building harnesses that feel, in an almost spiritual way, very Urbit.
+
+My own use is mostly operational. These tools are good at tracing bugs and working through system administration.
+
+When Directed Messaging caused resource problems on my ship, I could have dropped into the Urbit hacker house in Gather and asked the core developers. They meet there Monday, Wednesday, and Friday. But I didn't need to. I had a tool that could inspect the available diagnostics, narrow down the source, and help mitigate the traffic.
+
+I also use the same tools for routine jobs, like updating binaries across several machines. They're good teaching aids too. I can ask what a gate does, have a piece of Hoon explained, or find a nesting error without searching through documentation for an hour.
+
+Over time, I think AI is going to become very useful for keeping a ship healthy and making it your own. That was part of Urbit's original promise. We're reaching a point where a power user can create software that matters to a particular person or group, then distribute it across a private network. That's more interesting to me than one more isolated JavaScript dashboard or another tiny application trapped inside somebody else's app store.
+
+> **\~sarlev:** What are the kinds of problems you expect to get solved by the blend of powerful coordination technology, collective ownership, and AI together?
+
+**\~sicdev-pilnup:** There's something that happens as a company grows. At the beginning, two or three people share most of the context. They know what's happening and they're closely aligned. As the organization expands, it has to build a hierarchy so information can flow toward the people responsible for decisions.
+
+Eventually, the people at the top discover that important things are happening outside their view. That's deeply disorienting for someone who once held the whole organization in their head. A lot of corporate life becomes coordination overhead: meetings, messages, and documents trying to reconstruct enough shared context for the group to act.
+
+The same problem exists in a group of friends. Dalten meets every week to make sense of what's happening in the world. We have different opinions and different ways of thinking, and we've tried several ways to preserve those conversations. Some kind of collective intelligence that could retain that context is very appealing to me.
+
+The privacy part matters too. Some members would stop participating if our conversations were simply sent to Claude. The system would have to be something we own together, much as we own the star together. Its memory and whatever intelligence comes out of it would be collective property.
+
+Then maybe `~dalten` (the star, and actual ship) could form an opinion that wasn't just the opinion of one member or the result of a vote. We have approximations of collective judgment today, but not many things that can take in a group's history, stay accountable to the group, and develop a recognizable point of view. I would love to see that become real.
+
+> **\~sarlev:** Is that where these threads converge: Urbit giving a collective intelligence a durable identity and a sense of self?
+
+**\~sicdev-pilnup:** Yes. "The Dalten Collective" is the name of our group, but also, `~dalten` is already a point on the network. It's a computer and an identity, and it could eventually become a personality.
+
+If those three things come together, that's something new. It wouldn't just average the views of its members. It could remember and form judgments while still being governed by the people who sustain it. That's what the Urbit namespace affords.
+
+> **\~sarlev:** If you were not working on Urbit, what would you be doing instead?
+
+**\~sicdev-pilnup:** I think I'm drawn to the frontier of coordination technologies, and to technological frontiers in general. AI is clearly one of them. Space is finally becoming one too.
+
+It's those places where the rules haven't been written yet, the opportunities are still open, and the responsibilities are enormous. Whatever form that takes, that's where I want to play.

--- a/public/blog.md
+++ b/public/blog.md
@@ -5,6 +5,7 @@ Latest updates, developer spotlights, and technical deep dives from the Urbit co
 
 ## 2026
 
+- [Contributor Spotlight: ~sicdev-pilnup](/blog/contributor-spotlight-sicdev-pilnup.md) — A conversation with ~sicdev-pilnup on coordination technologies, AI sovereignty, Urbit, and collective intelligence
 - [This Month in Urbit: June 2026](/blog/this-month-in-urbit-june-2026.md) — June 2026 brings non-Hoon languages, Nock learning tools, Tlon's public launch, and the Urbit skills alpha.
 - [Languages on Nock](/blog/languages-on-nock.md) — A survey of Hoon, Jock, Yamoon, North, Loon, and the programming languages emerging around Nock
 - [Contributor Spotlight: ~lagrev-nocfep](/blog/contributor-spotlight-lagrev-nocfep.md) — A conversation with ~lagrev-nocfep on Nock, language design, computation, and the forever computer

--- a/public/blog/contributor-spotlight-sicdev-pilnup.md
+++ b/public/blog/contributor-spotlight-sicdev-pilnup.md
@@ -1,0 +1,124 @@
+# Contributor Spotlight: ~sicdev-pilnup
+
+A conversation with ~sicdev-pilnup on coordination technologies, AI sovereignty, Urbit, and collective intelligence
+
+- Date: 2026-07-14
+- Author: ~sarlev-sarsen
+
+![~sicdev-pilnup Contributor Spotlight Art](https://s3.us-east-1.amazonaws.com/urbit.orgcontent/Blog/Blog+QA+sicdev-pilnup/Blog_QA+sicdev-pilnup_Hero.jpg)
+
+> **\~sarlev:** What first drew you to the idea that we needed to throw away and rewrite the networked computing stack?
+
+**\~sicdev-pilnup:** I don't know if attraction is exactly the right word, but I'm attracted to ambition: big things, things larger than myself, that kind of call to action. People usually see projects that try to boil the ocean or start from a clean slate as destined to fail because they take on too much, and I generally agree with that criticism. The difference is that most of them don't actually return to first principles. Urbit did, and that gave it a kind of purity that went beyond the particular thing being built.
+
+The idea was: no, we're not going to get there by adding more layers. We're going to get there by subtracting. Make the system small enough and diamond-hard, get the specification onto a T-shirt, and then build outward from there.
+
+That always felt different from projects that pursue ambition by accumulating technologies. Urbit stands on the shoulders of giants, obviously, but it is still a reworking and a rethinking. That's why it isn't Earth technology. It's Martian technology. Starting fresh also connects to exit: regaining some sovereignty, authority, and ability to act within the digital spaces we inhabit.
+
+> **\~sarlev:** Is exit what you are looking for from the system, or is there something else about Urbit that you think will change our digital lives?
+
+**\~sicdev-pilnup:** I think exit is the leverage. It's the promise. Urbit hasn't fully delivered that promise yet, but what matters right now is the learning. You learn the system and participate in the culture. You also take on the ownership and responsibility that come with operating your own infrastructure.
+
+I never meant to become a Linux system administrator. Urbit has always said people shouldn't need to become system administrators, yet I became an expert Linux administrator anyway. I didn't intend for that to happen. But taking responsibility forced me to understand more of the stack, including Linux, servers, and hardware.
+
+That's not where everyone should have to begin. Hosting is an important bridge from software as a service into a model with more ownership. Sovereignty is a spectrum, and people are going to stop at different points along it.
+
+But the more control you have over your digital life, the more it starts to resemble the rest of your life. If you can, you want to own your house and your tools rather than rent them forever. That requires knowledge and responsibility, but it also builds both. I think that can make you a better person.
+
+> **\~sarlev:** Urbit is sometimes described as a forever computer. Would having a computer that lasts forever change how you think about your digital life?
+
+**\~sicdev-pilnup:** I don't mean that anything is literally permanent. You probably don't still have the clothes you wore as a baby, though a few things may have made it through. What matters is the sense of continuity, and that is either missing or just false in most of our digital lives.
+
+You might have used Twitter, Facebook, or Instagram for a decade, but what you really have is mostly a set of memories. If a third party decides you no longer have access, the record is gone. I think the loss would feel surprisingly close to having your house burn down.
+
+My Urbit life does have that sense of continuity, even though I'm not running the computer I started with and I've breached several times. I still have artifacts and old piers with years of history on them. I keep them in what amounts to a digital locker.
+
+Call that sentimental or call it history. Either way, it's something most people don't have. I think durable memory matters because it gives people and groups a basis for culture. It helps us form a shared narrative while becoming more autonomous and responsible for our own actions, rather than leaving our continuity in the hands of third parties.
+
+> **\~sarlev:** You have spent a lot of time thinking about and working on how groups coordinate, from your current role as the Executive Director of the Urbit Foundation to cultivating communities like Dalten. Did that interest lead you to Urbit, or did Urbit draw you into coordination?
+
+**\~sicdev-pilnup:** Not exactly. I'd say my interest probably began with the financial crisis in 2008. That was when I first understood money as a coordination technology. Following that question led me into crypto, where people were experimenting with money, governance, and new ways for groups to act together.
+
+I participated in a lot of those experiments. I was part of The DAO, [the project whose hack led to the Ethereum network being forked](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3014782). What I came away with is that people generally coordinate best through some form of hierarchy. Calling an organization decentralized doesn't remove leadership, judgment, or accountability. If those things aren't explicit, they tend to come back in ways that are harder to see.
+
+At the same time, distributed teams are very powerful. They let people who don't share a city organize around a problem that otherwise might never get addressed. Smart contracts can automate parts of that work. The combination can be very efficient if the group stays actually organized.
+
+Crypto got very focused on global consensus, which was expensive and only solved part of the problem. When I found Urbit, it felt like: okay, here we go. This is a surface for the rest of it. It can hold identity, communication, memory, and the local context a distributed group needs in order to function as an actual group.
+
+AI just extends the same line of thought. It's a tremendous lever, but it's also a huge centralizing force. We need some counterweight that lets us use intelligence through computers, networks, and data within our own sphere of influence. Money, governance, Urbit, and AI aren't separate interests for me. They're all part of the same question: how do people coordinate, and who holds the power when they do?
+
+> **\~sarlev:** In an AI-enabled world, what kinds of context are most important to keep in a system you control?
+
+**\~sicdev-pilnup:** Context is very important. A lot of us, including me, are creating it in places where we don't ultimately want it to live. I'm willing to do that during this transition, but I want a plan for getting it out. Where is the accumulated record of my work and thought going to go? I want that place to be something like an Urbit.
+
+I don't know how far Urbit itself needs to scale in storage, compute, or processing power. I don't expect frontier models to run inside an Urbit anytime soon. To me, Urbit is more important as the layer where identity, memory, permissions and private data live. It can connect to intelligence somewhere else.
+
+I can see that extending to agents themselves. Urbit is nearly a perfect substrate for an independent agent that has to earn its keep and coordinate with others. It can hold secrets and control private keys. It can develop an identity and reputation, communicate over a network, store documents, and enter into contracts.
+
+If you were designing a vessel for an AI that needed continuity and agency, I think it would look a lot like Urbit. That is still science fiction. It's probably further away than we think. The immediate goal is simpler: I want the second brain I'm building now to stay within a scope I control. I want to preserve it, use it, and eventually pass it down or turn it into an archive.
+
+> **\~sarlev:** The sovereign alternative is not fully built, and most useful frontier models still belong to large providers. What would you tell someone who wants to benefit from those tools without surrendering control of their digital life?
+
+**\~sicdev-pilnup:** I think of it as a transition, not a purity test. A lot of the immediate benefit is still at the frontier. These systems feel like roughly competent coworkers. I give them work and they come back with it quickly, sometimes more cheaply. But they aren't superintelligent. They make silly mistakes, nuke things by accident, apologize, and tell me I'm right often enough that I should probably be concerned.
+
+I think over time a lot of this capability will become good enough and more widely available. I don't assume that scaling one architecture forever produces infinite returns. We may get more leverage from ensembles of smaller models, open models, and collaborative infrastructure that can be brought closer to home.
+
+The more cynical version is that we've seen this before. The early internet was supposed to connect us, and social media turned into a system for targeting us. AI providers are building unusually complete models of their users. When token revenue isn't enough, there will be pressure to monetize those models. The nudges may be subtler than advertisements, but the incentive is going to look familiar.
+
+I don't think this is do or die for everyone today. But it is a reason to have a transition plan. You should be able to gather the information you've given these systems somewhere you control, back it up, and use intelligence against it without losing the underlying data. The most important tools in your life should serve you, not somebody else's bottom line.
+
+> **\~sarlev:** If access to intelligence becomes unequal or politically constrained, what can individuals and communities do in practice?
+
+**\~sicdev-pilnup:** Beyond monetization, access is also becoming political. Governments are taking a much greater interest in when frontier models are released, what they can do, and who gets to use them. The people and institutions with the earliest access will accumulate an advantage and may put even more distance between themselves and everyone else.
+
+The alternative is to pool resources and develop other infrastructure. Distributed inference, decentralized infrastructure, and crypto rails all seem promising to me. In [Dalten](https://dalten.org), we've pooled resources to buy compute, experiment with these products, and put them to use in a collective setting.
+
+In practice, get a group of your Urbit friends together, buy a large GPU, and see if you can actually run inference on it. Practice the skills before you urgently need them. I didn't plan to become a Linux administrator. Do I want to become a GPU orchestrator? Not particularly, but maybe that is the next responsibility.
+
+If you want to go fast, go alone. If you want to go far, go with others. That's basically how I think about the infrastructure problem too.
+
+> **\~sarlev:** What improvements across Urbit are you most looking forward to?
+
+**\~sicdev-pilnup:** `Vere64` is probably the biggest one. Directed Messaging is also novel and interesting. Beyond those, I'm interested in experiments that let people get into the network with less friction.
+
+That includes more than conventional hosting. It includes applications where all you need is an Azimuth identity, as well as federated models where one person or organization takes responsibility for infrastructure used by a smaller group. We talk a lot about personal ownership, but federation is the layer above it. It lets people share capacity without ending up back at one big provider.
+
+I think the onboarding path should be progressive. You might begin with a passkey and an application on your phone. Later you turn on a ship and enter a different relationship with the network. Maybe you operate it yourself, or maybe you rely on someone you trust. These aren't binary categories. They're steps toward a greater degree of sovereignty.
+
+Some people will stop at hosting, and that's fine. Urbit should be able to power useful experiences for people who don't care about Urbit for its own sake. It can become important infrastructure without ever becoming a household name.
+
+> **\~sarlev:** Are AI tools beginning to make Urbit easier to operate, understand, and build on?
+
+**\~sicdev-pilnup:** Yes. One thing I'm doing is experimenting with several Model Context Protocol (MCP) servers, including [the one from Groundwire](https://github.com/gwbtc/urbit-mcp). People in Dalten are also building harnesses that feel, in an almost spiritual way, very Urbit.
+
+My own use is mostly operational. These tools are good at tracing bugs and working through system administration.
+
+When Directed Messaging caused resource problems on my ship, I could have dropped into the Urbit hacker house in Gather and asked the core developers. They meet there Monday, Wednesday, and Friday. But I didn't need to. I had a tool that could inspect the available diagnostics, narrow down the source, and help mitigate the traffic.
+
+I also use the same tools for routine jobs, like updating binaries across several machines. They're good teaching aids too. I can ask what a gate does, have a piece of Hoon explained, or find a nesting error without searching through documentation for an hour.
+
+Over time, I think AI is going to become very useful for keeping a ship healthy and making it your own. That was part of Urbit's original promise. We're reaching a point where a power user can create software that matters to a particular person or group, then distribute it across a private network. That's more interesting to me than one more isolated JavaScript dashboard or another tiny application trapped inside somebody else's app store.
+
+> **\~sarlev:** What are the kinds of problems you expect to get solved by the blend of powerful coordination technology, collective ownership, and AI together?
+
+**\~sicdev-pilnup:** There's something that happens as a company grows. At the beginning, two or three people share most of the context. They know what's happening and they're closely aligned. As the organization expands, it has to build a hierarchy so information can flow toward the people responsible for decisions.
+
+Eventually, the people at the top discover that important things are happening outside their view. That's deeply disorienting for someone who once held the whole organization in their head. A lot of corporate life becomes coordination overhead: meetings, messages, and documents trying to reconstruct enough shared context for the group to act.
+
+The same problem exists in a group of friends. Dalten meets every week to make sense of what's happening in the world. We have different opinions and different ways of thinking, and we've tried several ways to preserve those conversations. Some kind of collective intelligence that could retain that context is very appealing to me.
+
+The privacy part matters too. Some members would stop participating if our conversations were simply sent to Claude. The system would have to be something we own together, much as we own the star together. Its memory and whatever intelligence comes out of it would be collective property.
+
+Then maybe `~dalten` (the star, and actual ship) could form an opinion that wasn't just the opinion of one member or the result of a vote. We have approximations of collective judgment today, but not many things that can take in a group's history, stay accountable to the group, and develop a recognizable point of view. I would love to see that become real.
+
+> **\~sarlev:** Is that where these threads converge: Urbit giving a collective intelligence a durable identity and a sense of self?
+
+**\~sicdev-pilnup:** Yes. "The Dalten Collective" is the name of our group, but also, `~dalten` is already a point on the network. It's a computer and an identity, and it could eventually become a personality.
+
+If those three things come together, that's something new. It wouldn't just average the views of its members. It could remember and form judgments while still being governed by the people who sustain it. That's what the Urbit namespace affords.
+
+> **\~sarlev:** If you were not working on Urbit, what would you be doing instead?
+
+**\~sicdev-pilnup:** I think I'm drawn to the frontier of coordination technologies, and to technological frontiers in general. AI is clearly one of them. Space is finally becoming one too.
+
+It's those places where the rules haven't been written yet, the opportunities are still open, and the responsibilities are enormous. Whatever form that takes, that's where I want to play.

--- a/public/content-index.json
+++ b/public/content-index.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-26T21:33:19.103Z",
-  "total": 355,
+  "generatedAt": "2026-07-14T18:02:22.468Z",
+  "total": 356,
   "entries": [
     {
       "id": "synthetic/homepage",
@@ -1157,6 +1157,41 @@
       "search_terms": [],
       "human_md_url": "https://urbit.org/blog/contributor-spotlight-palfun-foslup.md",
       "agent_url": "https://urbit.org/.agents/blog/contributor-spotlight-palfun-foslup.md",
+      "agent_available": true,
+      "agent_mode": "fallback"
+    },
+    {
+      "id": "blog/contributor-spotlight-sicdev-pilnup.md",
+      "url": "https://urbit.org/blog/contributor-spotlight-sicdev-pilnup",
+      "type": "blog",
+      "source_kind": "blog",
+      "title": "Contributor Spotlight: ~sicdev-pilnup",
+      "summary": "~sicdev-pilnup discusses Urbit as sovereign infrastructure for identity, memory, coordination, and collective intelligence; the risks of centralized AI; and paths toward hosting, federation, and distributed inference.",
+      "description": "A conversation with ~sicdev-pilnup on coordination technologies, AI sovereignty, Urbit, and collective intelligence",
+      "tags": [
+        "spotlight",
+        "coordination",
+        "ai",
+        "sovereignty"
+      ],
+      "search_terms": [
+        "contributor spotlight",
+        "~sicdev-pilnup",
+        "AI sovereignty",
+        "coordination technology",
+        "collective intelligence",
+        "Dalten",
+        "Urbit Foundation",
+        "Vere64",
+        "Directed Messaging",
+        "Model Context Protocol",
+        "Groundwire",
+        "Urbit hosting",
+        "Azimuth identity",
+        "distributed inference"
+      ],
+      "human_md_url": "https://urbit.org/blog/contributor-spotlight-sicdev-pilnup.md",
+      "agent_url": "https://urbit.org/.agents/blog/contributor-spotlight-sicdev-pilnup.md",
       "agent_available": true,
       "agent_mode": "fallback"
     },

--- a/public/search-index.json
+++ b/public/search-index.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-26T21:33:18.899Z",
-  "total": 192,
+  "generatedAt": "2026-07-14T18:02:22.267Z",
+  "total": 193,
   "entries": [
     {
       "id": "blurbs/add-and-remove-applications.md",
@@ -2291,6 +2291,42 @@
       "section": "blog",
       "sectionLabel": "Blog",
       "searchText": "contributor spotlight: ~palfun-foslup a conversation with ~palfun-foslup on gall, userspace, and making simple software spotlight gall userspace ~sarlev-sarsen /blog/contributor-spotlight-palfun-foslup blog 2026-03-17 tlon engineer ~palfun-foslup discusses building gall apps like %pals and %rumors, why user-owned servers lower the barrier for peer-to-peer software, and what gall 2026 aims to deliver with userspace compatibility and permissions. https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog_qa_palfun-foslup/blog_qa+palfun-foslup_social.png https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog_qa_palfun-foslup/blog_qa+palfun-foslup_social16_9.png spotlight gall userspace contributor spotlight ~palfun-foslup gall 2026 userspace permissions userspace compatibility tlon messenger pals app rumors app peer to peer software personal server urbit security vere64"
+    },
+    {
+      "id": "blog/contributor-spotlight-sicdev-pilnup.md",
+      "title": "Contributor Spotlight: ~sicdev-pilnup",
+      "description": "A conversation with ~sicdev-pilnup on coordination technologies, AI sovereignty, Urbit, and collective intelligence",
+      "tags": [
+        "spotlight",
+        "coordination",
+        "ai",
+        "sovereignty"
+      ],
+      "searchTerms": [
+        "contributor spotlight",
+        "~sicdev-pilnup",
+        "AI sovereignty",
+        "coordination technology",
+        "collective intelligence",
+        "Dalten",
+        "Urbit Foundation",
+        "Vere64",
+        "Directed Messaging",
+        "Model Context Protocol",
+        "Groundwire",
+        "Urbit hosting",
+        "Azimuth identity",
+        "distributed inference"
+      ],
+      "authors": [
+        "~sarlev-sarsen"
+      ],
+      "publishedTimestamp": 1783987200000,
+      "source": "blog",
+      "path": "/blog/contributor-spotlight-sicdev-pilnup",
+      "section": "blog",
+      "sectionLabel": "Blog",
+      "searchText": "contributor spotlight: ~sicdev-pilnup a conversation with ~sicdev-pilnup on coordination technologies, ai sovereignty, urbit, and collective intelligence spotlight coordination ai sovereignty contributor spotlight ~sicdev-pilnup ai sovereignty coordination technology collective intelligence dalten urbit foundation vere64 directed messaging model context protocol groundwire urbit hosting azimuth identity distributed inference ~sarlev-sarsen /blog/contributor-spotlight-sicdev-pilnup blog 2026-07-14 ~sicdev-pilnup discusses urbit as sovereign infrastructure for identity, memory, coordination, and collective intelligence; the risks of centralized ai; and paths toward hosting, federation, and distributed inference. contributor spotlight ~sicdev-pilnup ai sovereignty coordination technology collective intelligence dalten urbit foundation vere64 directed messaging model context protocol groundwire urbit hosting azimuth identity distributed inference https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+qa+sicdev-pilnup/blog_qa+sicdev-pilnup_social.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+qa+sicdev-pilnup/blog_qa+sicdev-pilnup_social16_9.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+qa+sicdev-pilnup/blog_qa+sicdev-pilnup_banner.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+qa+sicdev-pilnup/blog_qa+sicdev-pilnup_mail.jpg spotlight coordination ai sovereignty"
     },
     {
       "id": "blog/contributor-spotlight-sitful-hatred.md",


### PR DESCRIPTION
## Summary
- publish the July 2026 contributor spotlight for `~sicdev-pilnup` from the edited Q&A
- add Banner, Hero, Social, Social 16:9, and Mail imagery in their site-specific roles
- add summary/search metadata and regenerate public human/agent mirrors and indexes

## Validation
- `npm run lint` (passes with 3 existing warnings)
- `npm run build`
- `npm run test:agent-snapshot`
- verified all five supplied S3 image URLs return HTTP 200

## Notes
- The agent artifact generator reports the same non-fatal missing `---agent---` appendix warning used by recent contributor spotlights and emits a fallback companion.