### PR TITLE
Shorten White Marble article title

### DIFF
--- a/app/content/blog/building-white-marble.md
+++ b/app/content/blog/building-white-marble.md
@@ -1,5 +1,5 @@
 +++
-title = "Building White Marble: Capital, Membership, and Software on Urbit"
+title = "Building White Marble"
 date = "2026-07-28"
 description = "White Marble Syndicate connects member-governed data, local AI compute, and portable software through Urbit."
 summary = "A case study of how White Marble Syndicate used Urbit and Syndicate tooling to fund a private classical library, coordinate token-based membership, and connect community data to locally operated AI inference."

--- a/public/.agents/blog.md
+++ b/public/.agents/blog.md
@@ -25,7 +25,7 @@ Human-oriented content: /blog.md
 
 Agent companions for urbit.org blog posts. When a source file includes ---agent---, the companion contains only the dedicated agent appendix plus a pointer back to the human mirror.
 
-- [Building White Marble: Capital, Membership, and Software on Urbit](/.agents/blog/building-white-marble.md) — White Marble Syndicate connects member-governed data, local AI compute, and portable software through Urbit.
+- [Building White Marble](/.agents/blog/building-white-marble.md) — White Marble Syndicate connects member-governed data, local AI compute, and portable software through Urbit.
 - [Contributor Spotlight: ~sicdev-pilnup](/.agents/blog/contributor-spotlight-sicdev-pilnup.md) — A conversation with ~sicdev-pilnup on coordination technologies, AI sovereignty, Urbit, and collective intelligence
 - [This Month in Urbit: June 2026](/.agents/blog/this-month-in-urbit-june-2026.md) — June 2026 brings non-Hoon languages, Nock learning tools, Tlon's public launch, and the Urbit skills alpha.
 - [Languages on Nock](/.agents/blog/languages-on-nock.md) — A survey of Hoon, Jock, Yamoon, North, Loon, and the programming languages emerging around Nock

--- a/public/.agents/blog/building-white-marble.md
+++ b/public/.agents/blog/building-white-marble.md
@@ -1,5 +1,5 @@
 ---
-title: "Building White Marble: Capital, Membership, and Software on Urbit"
+title: "Building White Marble"
 source_kind: "blog"
 canonical_url: "/blog/building-white-marble"
 human_md_url: "/blog/building-white-marble.md"

--- a/public/blog.md
+++ b/public/blog.md
@@ -5,7 +5,7 @@ Latest updates, developer spotlights, and technical deep dives from the Urbit co
 
 ## 2026
 
-- [Building White Marble: Capital, Membership, and Software on Urbit](/blog/building-white-marble.md) — White Marble Syndicate connects member-governed data, local AI compute, and portable software through Urbit.
+- [Building White Marble](/blog/building-white-marble.md) — White Marble Syndicate connects member-governed data, local AI compute, and portable software through Urbit.
 - [Contributor Spotlight: ~sicdev-pilnup](/blog/contributor-spotlight-sicdev-pilnup.md) — A conversation with ~sicdev-pilnup on coordination technologies, AI sovereignty, Urbit, and collective intelligence
 - [This Month in Urbit: June 2026](/blog/this-month-in-urbit-june-2026.md) — June 2026 brings non-Hoon languages, Nock learning tools, Tlon's public launch, and the Urbit skills alpha.
 - [Languages on Nock](/blog/languages-on-nock.md) — A survey of Hoon, Jock, Yamoon, North, Loon, and the programming languages emerging around Nock

--- a/public/blog/building-white-marble.md
+++ b/public/blog/building-white-marble.md
@@ -1,4 +1,4 @@
-# Building White Marble: Capital, Membership, and Software on Urbit
+# Building White Marble
 
 White Marble Syndicate connects member-governed data, local AI compute, and portable software through Urbit.
 

--- a/public/content-index.json
+++ b/public/content-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-28T19:06:00.785Z",
+  "generatedAt": "2026-07-28T21:42:46.438Z",
   "total": 357,
   "entries": [
     {
@@ -943,7 +943,7 @@
       "url": "https://urbit.org/blog/building-white-marble",
       "type": "blog",
       "source_kind": "blog",
-      "title": "Building White Marble: Capital, Membership, and Software on Urbit",
+      "title": "Building White Marble",
       "summary": "A case study of how White Marble Syndicate used Urbit and Syndicate tooling to fund a private classical library, coordinate token-based membership, and connect community data to locally operated AI inference.",
       "description": "White Marble Syndicate connects member-governed data, local AI compute, and portable software through Urbit.",
       "tags": [

--- a/public/search-index.json
+++ b/public/search-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-28T19:06:00.578Z",
+  "generatedAt": "2026-07-28T21:42:46.226Z",
   "total": 194,
   "entries": [
     {
@@ -2032,7 +2032,7 @@
     },
     {
       "id": "blog/building-white-marble.md",
-      "title": "Building White Marble: Capital, Membership, and Software on Urbit",
+      "title": "Building White Marble",
       "description": "White Marble Syndicate connects member-governed data, local AI compute, and portable software through Urbit.",
       "tags": [
         "ai",
@@ -2065,7 +2065,7 @@
       "path": "/blog/building-white-marble",
       "section": "blog",
       "sectionLabel": "Blog",
-      "searchText": "building white marble: capital, membership, and software on urbit white marble syndicate connects member-governed data, local ai compute, and portable software through urbit. ai syndicates data-sovereignty case-study white marble syndicate white marble dao whtmrbl private ai data sovereignty collective intelligence privateer computeer ames urbit compute sharing portable digital organization tocwex syndicate fund slab classical scholarship ~sicdev-pilnup /blog/building-white-marble blog 2026-07-28 a case study of how white marble syndicate used urbit and syndicate tooling to fund a private classical library, coordinate token-based membership, and connect community data to locally operated ai inference. white marble syndicate white marble dao whtmrbl private ai data sovereignty collective intelligence privateer computeer ames urbit compute sharing portable digital organization tocwex syndicate fund slab classical scholarship https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+white+marble/blog_white+marble_social.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+white+marble/blog_white+marble_social16_9.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+white+marble/blog_white+marble_banner.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+white+marble/blog_white+marble_mail.jpg ai syndicates data-sovereignty case-study"
+      "searchText": "building white marble white marble syndicate connects member-governed data, local ai compute, and portable software through urbit. ai syndicates data-sovereignty case-study white marble syndicate white marble dao whtmrbl private ai data sovereignty collective intelligence privateer computeer ames urbit compute sharing portable digital organization tocwex syndicate fund slab classical scholarship ~sicdev-pilnup /blog/building-white-marble blog 2026-07-28 a case study of how white marble syndicate used urbit and syndicate tooling to fund a private classical library, coordinate token-based membership, and connect community data to locally operated ai inference. white marble syndicate white marble dao whtmrbl private ai data sovereignty collective intelligence privateer computeer ames urbit compute sharing portable digital organization tocwex syndicate fund slab classical scholarship https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+white+marble/blog_white+marble_social.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+white+marble/blog_white+marble_social16_9.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+white+marble/blog_white+marble_banner.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+white+marble/blog_white+marble_mail.jpg ai syndicates data-sovereignty case-study"
     },
     {
       "id": "blog/pseudonymous-reputation.md",


### PR DESCRIPTION
## Summary
- shorten the article title to `Building White Marble`
- regenerate human, agent, search, and content-index artifacts

## Validation
- `npm run lint` (passes with 3 pre-existing warnings)
- `npm run build` (passes)