### PR TITLE
Correct %graph-viz dependency guidance in July TMIU

### DIFF
--- a/app/content/blog/this-month-in-urbit-july-2026.md
+++ b/app/content/blog/this-month-in-urbit-july-2026.md
@@ -129,7 +129,7 @@ End users are able to render [Graphviz](https://graphviz.org/) DOT diagrams as S
 
 For full documentation and related agent skills, check out the [repo on GitHub](https://github.com/jackfoxy/graph-viz).
 
-> *Correction August 5, 2026: An earlier version of this post noted `%obelisk` as a dependency for `%graph-viz`. That was incorrect.
+> *Correction August 5, 2026: An earlier version of this post noted `%obelisk` as a dependency for `%graph-viz`. That was incorrect.*
 
 ## Hawk, revisited
 
@@ -163,7 +163,7 @@ This is a huge improvement for anyone who has tried to use agents via Telegram o
 
 # Agent companion: This Month in Urbit, July 2026
 
-This companion is for AI agents helping a user reproduce or explore the July 2026 _This Month in Urbit_ items. The human-facing article is intentionally narrative; use this section as the operational checklist and source map. This article includes the July TMIU pill, the 408k Directed Messaging rollout, `%docs`, `%cliff`, Mondrian, `%caderno`, `%graph-viz`, `%obelisk`, Hawk 499, and new Tlon Messenger features.
+This companion is for AI agents helping a user reproduce or explore the July 2026 _This Month in Urbit_ items. The human-facing article is intentionally narrative; use this section as the operational checklist and source map. This article includes the July TMIU pill, the 408k Directed Messaging rollout, `%docs`, `%cliff`, Mondrian, `%caderno`, the self-contained `%graph-viz` app, Hawk 499, and new Tlon Messenger features.
 
 ## Start with the public Urbit skills
 
@@ -174,7 +174,6 @@ Use the public skills snapshot before improvising Urbit operations or userspace 
 - Comet onboarding for agents: `/.agents/skills/running-urbit-os/references/comet-onboarding-for-agents.md`
 - Userspace apps: `/.agents/skills/using-urbit-apps/SKILL.md`
 - Userspace apps bundle: `/.agents/skills/bundles/userspace-apps.yaml`
-- Obelisk references: `/.agents/skills/using-urbit-apps/references/obelisk/README.md`
 
 ## Safety profile
 
@@ -187,7 +186,7 @@ Use the public skills snapshot before improvising Urbit operations or userspace 
 - Verify that the article-provided July pill URL is publicly retrievable before booting. If it is unavailable, surface the exact error and stop rather than substituting another pill.
 - `%cliff` can edit Clay files and change publication settings. Confirm the target desk, path, and intended visibility before editing or publishing anything.
 - `%docs`, `%caderno`, and Tlon Notebooks can publish content. Keep private or sensitive material out of test documents and confirm visibility before publishing.
-- The article describes `%obelisk` as a dependency of the network-distributed `%graph-viz`, while the linked source repository currently describes a self-contained desk. Verify the release-specific requirements before installing either desk, and surface the discrepancy rather than guessing.
+- `%graph-viz` is self-contained and does not require `%obelisk`. Do not install `%obelisk` as part of the `%graph-viz` flow; only discuss or install it if the user separately requests it.
 - This article covers Hawk 499. Do not apply instructions written specifically for Hawk 500 unless the source confirms they are compatible.
 - If a boot, update, or install command fails, surface the exact error and stop. Do not silently switch to an unreviewed pill, publisher, or install path.
 
@@ -240,8 +239,7 @@ The article describes a two-phase rollout. The 408k release makes Directed Messa
 | `%cliff` | Clay file explorer with editing and publication controls | `|install ~magbel %cliff` | Can edit files and alter whitelists or blacklists. Prefer a disposable ship and test paths. |
 | Mondrian | Noun visualization project from `~lagrev-nocfep` | <https://github.com/sigilante/mondrian> | Repository/reference project; do not invent a network install command. |
 | `%caderno` | Hoon notebook app for publishing, browsing, sharing, and forking notebooks | `|install ~magbel %caderno` | Use test notebooks first and confirm intended visibility before publishing. |
-| `%graph-viz` | Gall app that renders Graphviz DOT diagrams as SVG on-ship | `|install ~dister-nomryg-nilref %graph-viz`; <https://github.com/jackfoxy/graph-viz> | The article says the network release requires `%obelisk`, while the linked source repository describes a self-contained desk. Verify the release-specific requirement before installing dependencies. |
-| `%obelisk` | Database described in the article as a dependency for the network-distributed `%graph-viz` | `|install ~dister-nomryg-nilref %obelisk` | Install only after confirming the release-specific dependency; use `/.agents/skills/using-urbit-apps/references/obelisk/README.md` for general Obelisk guidance, not as proof of this OTA install path. |
+| `%graph-viz` | Self-contained Gall app that renders Graphviz DOT diagrams as SVG on-ship | `|install ~dister-nomryg-nilref %graph-viz`; <https://github.com/jackfoxy/graph-viz> | Does not depend on `%obelisk`; install only `%graph-viz` for this article's graph visualization flow. |
 | `%hawk` at Kelvin 499 | Composable interface tooling for interacting with agents on a ship | `|install ~dister-migrev-dolseg %hawk`; <https://willhanlen.com/hawk499/crash-course#module-0> | Confirm instructions are for Hawk 499; public references for other Kelvin versions may not be compatible. |
 | Tlon Notebooks and Context Lens | Markdown notebook channels and detailed Tlonbot run inspection | <https://tlon.io>; <https://x.com/tloncorporation/status/2075224895013736784?s=20> | Informational features. Do not automate account access or inspect private notebooks and run logs without permission. |
 
@@ -250,7 +248,7 @@ The article describes a two-phase rollout. The 408k release makes Directed Messa
 1. Ask whether the user wants to boot the July test ship, inspect or enable Directed Messaging, install a featured Gall app, explore a linked repository, or review the Tlon features.
 2. For the full set of Gall apps, verify the article-provided July TMIU pill is publicly retrievable, then prefer it on a disposable moon or comet.
 3. For an existing ship, confirm the exact target, publisher, desk, and expected state or publication change before each command.
-4. The article says to install `%obelisk` before `%graph-viz`, but the linked source repository describes a self-contained desk. Verify the requirements of the network-distributed release before either state-changing install.
+4. Install `%graph-viz` by itself; do not install `%obelisk` as a dependency.
 5. For `%cliff`, begin with read-only exploration and ask separately before editing files or changing publication controls.
 6. For `%docs` and `%caderno`, use non-sensitive test content and confirm clearweb or peer visibility before publishing.
 7. For `%hawk`, use the linked Hawk 499 crash course and version-matched documentation before improvising interface endpoints.

--- a/app/content/blog/this-month-in-urbit-july-2026.md
+++ b/app/content/blog/this-month-in-urbit-july-2026.md
@@ -15,7 +15,6 @@ search_terms = [
     "mondrian",
     "%caderno",
     "%graph-viz",
-    "%obelisk",
     "hawk 499",
     "tlon notebooks",
     "context lens"
@@ -118,23 +117,19 @@ On the Gall side, he released `%caderno`, which you can download by running:
 
 Portuguese for "notebook," `%caderno` is a Hoon notebook. Similar to a Jupyter notebook in spirit, it allows users to publish and share notebooks, with built-in functionality for browsing and forking the notebooks of your peers.
 
-## Obelisk, also visualized
+## Graphs, also visualized
 
-As a follow-on to his `%obelisk` project, `~nomryg-nilref` built an example of how to use its database capabilities in an effectively stateless Gall agent. `%graph-viz` lets users write the DOT "graph description language" to create flow charts, dependency graphs, state machines, and more. You can pick it up from the `~dister` moon:
+As a follow-on to his `%obelisk` project, `~nomryg-nilref` built `%graph-viz` to let users write the DOT "graph description language" to create flow charts, dependency graphs, state machines, and more. You can pick it up from the `~dister` moon:
 
 ```
 |install ~dister-nomryg-nilref %graph-viz
 ```
 
-Note here that `%obelisk` is a dependency for `%graph-viz`, so make sure you have it installed as well:
-
-```
-|install ~dister-nomryg-nilref %obelisk
-```
-
-With both desks installed, end users are able to render [Graphviz](https://graphviz.org/) DOT diagrams as SVG entirely on-ship, without a dependency on external services and without any sloppy glue code.
+End users are able to render [Graphviz](https://graphviz.org/) DOT diagrams as SVG entirely on-ship, without a dependency on external services and without any sloppy glue code.
 
 For full documentation and related agent skills, check out the [repo on GitHub](https://github.com/jackfoxy/graph-viz).
+
+> *Correction August 5, 2026: An earlier version of this post noted `%obelisk` as a dependency for `%graph-viz`. That was incorrect.
 
 ## Hawk, revisited
 

--- a/public/.agents/blog/this-month-in-urbit-july-2026.md
+++ b/public/.agents/blog/this-month-in-urbit-july-2026.md
@@ -14,7 +14,7 @@ Human-oriented content: /blog/this-month-in-urbit-july-2026.md
 
 # Agent companion: This Month in Urbit, July 2026
 
-This companion is for AI agents helping a user reproduce or explore the July 2026 _This Month in Urbit_ items. The human-facing article is intentionally narrative; use this section as the operational checklist and source map. This article includes the July TMIU pill, the 408k Directed Messaging rollout, `%docs`, `%cliff`, Mondrian, `%caderno`, `%graph-viz`, `%obelisk`, Hawk 499, and new Tlon Messenger features.
+This companion is for AI agents helping a user reproduce or explore the July 2026 _This Month in Urbit_ items. The human-facing article is intentionally narrative; use this section as the operational checklist and source map. This article includes the July TMIU pill, the 408k Directed Messaging rollout, `%docs`, `%cliff`, Mondrian, `%caderno`, the self-contained `%graph-viz` app, Hawk 499, and new Tlon Messenger features.
 
 ## Start with the public Urbit skills
 
@@ -25,7 +25,6 @@ Use the public skills snapshot before improvising Urbit operations or userspace 
 - Comet onboarding for agents: `/.agents/skills/running-urbit-os/references/comet-onboarding-for-agents.md`
 - Userspace apps: `/.agents/skills/using-urbit-apps/SKILL.md`
 - Userspace apps bundle: `/.agents/skills/bundles/userspace-apps.yaml`
-- Obelisk references: `/.agents/skills/using-urbit-apps/references/obelisk/README.md`
 
 ## Safety profile
 
@@ -38,7 +37,7 @@ Use the public skills snapshot before improvising Urbit operations or userspace 
 - Verify that the article-provided July pill URL is publicly retrievable before booting. If it is unavailable, surface the exact error and stop rather than substituting another pill.
 - `%cliff` can edit Clay files and change publication settings. Confirm the target desk, path, and intended visibility before editing or publishing anything.
 - `%docs`, `%caderno`, and Tlon Notebooks can publish content. Keep private or sensitive material out of test documents and confirm visibility before publishing.
-- The article describes `%obelisk` as a dependency of the network-distributed `%graph-viz`, while the linked source repository currently describes a self-contained desk. Verify the release-specific requirements before installing either desk, and surface the discrepancy rather than guessing.
+- `%graph-viz` is self-contained and does not require `%obelisk`. Do not install `%obelisk` as part of the `%graph-viz` flow; only discuss or install it if the user separately requests it.
 - This article covers Hawk 499. Do not apply instructions written specifically for Hawk 500 unless the source confirms they are compatible.
 - If a boot, update, or install command fails, surface the exact error and stop. Do not silently switch to an unreviewed pill, publisher, or install path.
 
@@ -91,8 +90,7 @@ The article describes a two-phase rollout. The 408k release makes Directed Messa
 | `%cliff` | Clay file explorer with editing and publication controls | `|install ~magbel %cliff` | Can edit files and alter whitelists or blacklists. Prefer a disposable ship and test paths. |
 | Mondrian | Noun visualization project from `~lagrev-nocfep` | <https://github.com/sigilante/mondrian> | Repository/reference project; do not invent a network install command. |
 | `%caderno` | Hoon notebook app for publishing, browsing, sharing, and forking notebooks | `|install ~magbel %caderno` | Use test notebooks first and confirm intended visibility before publishing. |
-| `%graph-viz` | Gall app that renders Graphviz DOT diagrams as SVG on-ship | `|install ~dister-nomryg-nilref %graph-viz`; <https://github.com/jackfoxy/graph-viz> | The article says the network release requires `%obelisk`, while the linked source repository describes a self-contained desk. Verify the release-specific requirement before installing dependencies. |
-| `%obelisk` | Database described in the article as a dependency for the network-distributed `%graph-viz` | `|install ~dister-nomryg-nilref %obelisk` | Install only after confirming the release-specific dependency; use `/.agents/skills/using-urbit-apps/references/obelisk/README.md` for general Obelisk guidance, not as proof of this OTA install path. |
+| `%graph-viz` | Self-contained Gall app that renders Graphviz DOT diagrams as SVG on-ship | `|install ~dister-nomryg-nilref %graph-viz`; <https://github.com/jackfoxy/graph-viz> | Does not depend on `%obelisk`; install only `%graph-viz` for this article's graph visualization flow. |
 | `%hawk` at Kelvin 499 | Composable interface tooling for interacting with agents on a ship | `|install ~dister-migrev-dolseg %hawk`; <https://willhanlen.com/hawk499/crash-course#module-0> | Confirm instructions are for Hawk 499; public references for other Kelvin versions may not be compatible. |
 | Tlon Notebooks and Context Lens | Markdown notebook channels and detailed Tlonbot run inspection | <https://tlon.io>; <https://x.com/tloncorporation/status/2075224895013736784?s=20> | Informational features. Do not automate account access or inspect private notebooks and run logs without permission. |
 
@@ -101,7 +99,7 @@ The article describes a two-phase rollout. The 408k release makes Directed Messa
 1. Ask whether the user wants to boot the July test ship, inspect or enable Directed Messaging, install a featured Gall app, explore a linked repository, or review the Tlon features.
 2. For the full set of Gall apps, verify the article-provided July TMIU pill is publicly retrievable, then prefer it on a disposable moon or comet.
 3. For an existing ship, confirm the exact target, publisher, desk, and expected state or publication change before each command.
-4. The article says to install `%obelisk` before `%graph-viz`, but the linked source repository describes a self-contained desk. Verify the requirements of the network-distributed release before either state-changing install.
+4. Install `%graph-viz` by itself; do not install `%obelisk` as a dependency.
 5. For `%cliff`, begin with read-only exploration and ask separately before editing files or changing publication controls.
 6. For `%docs` and `%caderno`, use non-sensitive test content and confirm clearweb or peer visibility before publishing.
 7. For `%hawk`, use the linked Hawk 499 crash course and version-matched documentation before improvising interface endpoints.

--- a/public/blog/this-month-in-urbit-july-2026.md
+++ b/public/blog/this-month-in-urbit-july-2026.md
@@ -94,23 +94,19 @@ On the Gall side, he released `%caderno`, which you can download by running:
 
 Portuguese for "notebook," `%caderno` is a Hoon notebook. Similar to a Jupyter notebook in spirit, it allows users to publish and share notebooks, with built-in functionality for browsing and forking the notebooks of your peers.
 
-## Obelisk, also visualized
+## Graphs, also visualized
 
-As a follow-on to his `%obelisk` project, `~nomryg-nilref` built an example of how to use its database capabilities in an effectively stateless Gall agent. `%graph-viz` lets users write the DOT "graph description language" to create flow charts, dependency graphs, state machines, and more. You can pick it up from the `~dister` moon:
+As a follow-on to his `%obelisk` project, `~nomryg-nilref` built `%graph-viz` to let users write the DOT "graph description language" to create flow charts, dependency graphs, state machines, and more. You can pick it up from the `~dister` moon:
 
 ```
 |install ~dister-nomryg-nilref %graph-viz
 ```
 
-Note here that `%obelisk` is a dependency for `%graph-viz`, so make sure you have it installed as well:
-
-```
-|install ~dister-nomryg-nilref %obelisk
-```
-
-With both desks installed, end users are able to render [Graphviz](https://graphviz.org/) DOT diagrams as SVG entirely on-ship, without a dependency on external services and without any sloppy glue code.
+End users are able to render [Graphviz](https://graphviz.org/) DOT diagrams as SVG entirely on-ship, without a dependency on external services and without any sloppy glue code.
 
 For full documentation and related agent skills, check out the [repo on GitHub](https://github.com/jackfoxy/graph-viz).
+
+> *Correction August 5, 2026: An earlier version of this post noted `%obelisk` as a dependency for `%graph-viz`. That was incorrect.*
 
 ## Hawk, revisited
 

--- a/public/content-index.json
+++ b/public/content-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-31T21:22:40.013Z",
+  "generatedAt": "2026-08-05T16:41:14.510Z",
   "total": 358,
   "entries": [
     {
@@ -3154,7 +3154,6 @@
         "mondrian",
         "%caderno",
         "%graph-viz",
-        "%obelisk",
         "hawk 499",
         "tlon notebooks",
         "context lens"

--- a/public/search-index.json
+++ b/public/search-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-31T21:22:39.799Z",
+  "generatedAt": "2026-08-05T16:41:14.277Z",
   "total": 195,
   "entries": [
     {
@@ -4401,7 +4401,6 @@
         "mondrian",
         "%caderno",
         "%graph-viz",
-        "%obelisk",
         "hawk 499",
         "tlon notebooks",
         "context lens"
@@ -4414,7 +4413,7 @@
       "path": "/blog/this-month-in-urbit-july-2026",
       "section": "blog",
       "sectionLabel": "Blog",
-      "searchText": "this month in urbit: july 2026 july 2026 brings directed messaging, refreshed gall apps, hoon notebooks, noun and graph visualization, hawk 499, and new tlon messenger features. this-month-in-urbit ecosystem applications directed-messaging agents tlon this month in urbit july 2026 urbit directed messaging named data networking 408k %docs %cliff mondrian %caderno %graph-viz %obelisk hawk 499 tlon notebooks context lens ~sarlev-sarsen /blog/this-month-in-urbit-july-2026 blog 2026-07-31 this month in urbit for july 2026 covers directed messaging in 408k, updated %docs and %cliff apps, mondrian, %caderno, %graph-viz, hawk 499, and tlon messenger's new notebooks and context lens. this month in urbit july 2026 urbit directed messaging named data networking 408k %docs %cliff mondrian %caderno %graph-viz %obelisk hawk 499 tlon notebooks context lens https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog_tmiu+july/blog_tmiu+july_social.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog_tmiu+july/blog_tmiu+july_social16_9.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog_tmiu+july/blog_tmiu+july_banner.jpg this-month-in-urbit ecosystem applications directed-messaging agents tlon"
+      "searchText": "this month in urbit: july 2026 july 2026 brings directed messaging, refreshed gall apps, hoon notebooks, noun and graph visualization, hawk 499, and new tlon messenger features. this-month-in-urbit ecosystem applications directed-messaging agents tlon this month in urbit july 2026 urbit directed messaging named data networking 408k %docs %cliff mondrian %caderno %graph-viz hawk 499 tlon notebooks context lens ~sarlev-sarsen /blog/this-month-in-urbit-july-2026 blog 2026-07-31 this month in urbit for july 2026 covers directed messaging in 408k, updated %docs and %cliff apps, mondrian, %caderno, %graph-viz, hawk 499, and tlon messenger's new notebooks and context lens. this month in urbit july 2026 urbit directed messaging named data networking 408k %docs %cliff mondrian %caderno %graph-viz hawk 499 tlon notebooks context lens https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog_tmiu+july/blog_tmiu+july_social.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog_tmiu+july/blog_tmiu+july_social16_9.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog_tmiu+july/blog_tmiu+july_banner.jpg this-month-in-urbit ecosystem applications directed-messaging agents tlon"
     },
     {
       "id": "blog/this-month-in-urbit-june-2026.md",


### PR DESCRIPTION
## Summary

- Apply the post-publication correction that %graph-viz does not depend on %obelisk.
- Remove the obsolete %obelisk install command and dependency search term from the July article.
- Update the dedicated agent companion to describe %graph-viz as self-contained and prevent agents from installing %obelisk as part of this flow.
- Regenerate the human mirror, agent companion, content index, and search index.
- Close the correction note's Markdown emphasis marker.

## Validation

- npm run build
- npm run test:agent-snapshot
- git diff --check