### PR TITLE
Update spotlight publication date

### DIFF
--- a/app/content/blog/contributor-spotlight-navsul-pagrec.md
+++ b/app/content/blog/contributor-spotlight-navsul-pagrec.md
@@ -1,7 +1,7 @@
 +++
 
 title = "Contributor Spotlight: ~navsul-pagrec"
-date = "2026-08-18"
+date = "2026-08-25"
 description = "A conversation with ~navsul-pagrec on Nockchain developer experience, verifiable compute, LLM-assisted engineering, and Honk"
 summary = "~navsul-pagrec discusses finding a contribution path through Nockchain, improving its Hoon development workflows, using LLMs with strong verification loops, and building Honk for Nockchain's Hoon-138 environment."
 # aliases = []

--- a/public/.agents/blog/contributor-spotlight-navsul-pagrec.md
+++ b/public/.agents/blog/contributor-spotlight-navsul-pagrec.md
@@ -16,7 +16,7 @@ Human-oriented content: /blog/contributor-spotlight-navsul-pagrec.md
 
 A conversation with ~navsul-pagrec on Nockchain developer experience, verifiable compute, LLM-assisted engineering, and Honk
 
-- Date: 2026-08-18
+- Date: 2026-08-25
 - Author: ~sarlev-sarsen
 
 ![~navsul-pagrec Contributor Spotlight Art](https://s3.us-east-1.amazonaws.com/urbit.orgcontent/Blog/Blog+QA+navsul-pagrec/Blog_QA+navsul-pagrec_Hero.jpg)

--- a/public/blog/contributor-spotlight-navsul-pagrec.md
+++ b/public/blog/contributor-spotlight-navsul-pagrec.md
@@ -2,7 +2,7 @@
 
 A conversation with ~navsul-pagrec on Nockchain developer experience, verifiable compute, LLM-assisted engineering, and Honk
 
-- Date: 2026-08-18
+- Date: 2026-08-25
 - Author: ~sarlev-sarsen
 
 ![~navsul-pagrec Contributor Spotlight Art](https://s3.us-east-1.amazonaws.com/urbit.orgcontent/Blog/Blog+QA+navsul-pagrec/Blog_QA+navsul-pagrec_Hero.jpg)

--- a/public/content-index.json
+++ b/public/content-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-25T21:06:26.774Z",
+  "generatedAt": "2026-08-25T21:14:57.921Z",
   "total": 359,
   "entries": [
     {

--- a/public/search-index.json
+++ b/public/search-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-25T21:06:26.542Z",
+  "generatedAt": "2026-08-25T21:14:57.716Z",
   "total": 196,
   "entries": [
     {
@@ -2298,12 +2298,12 @@
       "authors": [
         "~sarlev-sarsen"
       ],
-      "publishedTimestamp": 1787011200000,
+      "publishedTimestamp": 1787616000000,
       "source": "blog",
       "path": "/blog/contributor-spotlight-navsul-pagrec",
       "section": "blog",
       "sectionLabel": "Blog",
-      "searchText": "contributor spotlight: ~navsul-pagrec a conversation with ~navsul-pagrec on nockchain developer experience, verifiable compute, llm-assisted engineering, and honk spotlight nockchain zero-knowledge llms hoon contributor spotlight ~navsul-pagrec nockchain zorp honk hoonc hoon compiler nock nockasm zkvm zero knowledge proofs compute markets llm coding developer experience ~sarlev-sarsen /blog/contributor-spotlight-navsul-pagrec blog 2026-08-18 ~navsul-pagrec discusses finding a contribution path through nockchain, improving its hoon development workflows, using llms with strong verification loops, and building honk for nockchain's hoon-138 environment. contributor spotlight ~navsul-pagrec nockchain zorp honk hoonc hoon compiler nock nockasm zkvm zero knowledge proofs compute markets llm coding developer experience https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+qa+navsul-pagrec/blog_qa+navsul-pagrec_social.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+qa+navsul-pagrec/blog_qa+navsul-pagrec_social16_9.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+qa+navsul-pagrec/blog_qa+navsul-pagrec_banner.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+qa+navsul-pagrec/blog_qa+navsul-pagrec_mail.jpg spotlight nockchain zero-knowledge llms hoon"
+      "searchText": "contributor spotlight: ~navsul-pagrec a conversation with ~navsul-pagrec on nockchain developer experience, verifiable compute, llm-assisted engineering, and honk spotlight nockchain zero-knowledge llms hoon contributor spotlight ~navsul-pagrec nockchain zorp honk hoonc hoon compiler nock nockasm zkvm zero knowledge proofs compute markets llm coding developer experience ~sarlev-sarsen /blog/contributor-spotlight-navsul-pagrec blog 2026-08-25 ~navsul-pagrec discusses finding a contribution path through nockchain, improving its hoon development workflows, using llms with strong verification loops, and building honk for nockchain's hoon-138 environment. contributor spotlight ~navsul-pagrec nockchain zorp honk hoonc hoon compiler nock nockasm zkvm zero knowledge proofs compute markets llm coding developer experience https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+qa+navsul-pagrec/blog_qa+navsul-pagrec_social.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+qa+navsul-pagrec/blog_qa+navsul-pagrec_social16_9.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+qa+navsul-pagrec/blog_qa+navsul-pagrec_banner.jpg https://s3.us-east-1.amazonaws.com/urbit.orgcontent/blog/blog+qa+navsul-pagrec/blog_qa+navsul-pagrec_mail.jpg spotlight nockchain zero-knowledge llms hoon"
     },
     {
       "id": "blog/contributor-spotlight-nomryg-nilref.md",


### PR DESCRIPTION
## Summary
- update the `~navsul-pagrec` contributor spotlight publication date from August 18 to August 25, 2026
- regenerate the human, agent, search, and content-index artifacts
- consolidate the cleanup requested alongside #2460

## White Marble title
The #2460 title shortening is already present on `master` through commit `bdb57f88a`: the source article and all generated artifacts use `Building White Marble`. This PR verifies and preserves that state without adding a redundant diff.

## Validation
- `npm run build`
- `npm run lint` (passes with three pre-existing warnings)
- validated the generated spotlight timestamp and White Marble title in both JSON indexes
- `git diff --check`